### PR TITLE
Use integer vectors within parser generator

### DIFF
--- a/src/parser/CanonicalCollection.cpp
+++ b/src/parser/CanonicalCollection.cpp
@@ -20,7 +20,7 @@ CanonicalCollection::CanonicalCollection(const FirstTable& firstTable, const Gra
         grammarSymbols.push_back(terminal);
     }
 
-    LR1Item initialItem { grammar.getRuleByIndex(grammar.ruleCount() - 1), { grammar.getEndSymbol() } };
+    LR1Item initialItem { grammar.getRuleByIndex(grammar.ruleCount() - 1), { grammar.getEndSymbol().getId() } };
     std::vector<LR1Item> initialSet { initialItem };
     Closure closure { firstTable, &grammar };
     closure(initialSet);

--- a/src/parser/Closure.cpp
+++ b/src/parser/Closure.cpp
@@ -19,7 +19,7 @@ void Closure::operator()(std::vector<LR1Item>& items) const {
             if (item.hasUnvisitedSymbols() && item.nextUnvisitedSymbol().isNonterminal()) { // [ A -> u.Bv, a ] (expected[0] == B)
                 const auto& nextExpectedNonterminal = item.nextUnvisitedSymbol();
                 const auto& expectedSymbols = item.getExpectedSymbols();
-                std::vector<GrammarSymbol> firstForNextSymbol {
+                std::vector<int> firstForNextSymbol {
                         (expectedSymbols.size() > 1) ? first(expectedSymbols.at(1).getId()) : item.getLookaheads() };
                 for (const auto& ruleIndex : nextExpectedNonterminal.getRuleIndexes()) {
                     LR1Item newItem { grammar->getRuleByIndex(ruleIndex), firstForNextSymbol };

--- a/src/parser/FirstTable.cpp
+++ b/src/parser/FirstTable.cpp
@@ -16,19 +16,19 @@ FirstTable::FirstTable(const Grammar& grammar) {
             for (auto& production : grammar.getProductionsOfSymbol(symbol)) {
                 const auto& firstProductionSymbol = *production.begin();
                 for (const auto& firstSymbol : firstTable.at(firstProductionSymbol.getId())) {
-                    moreToAdd |= addFirstSymbol(symbol, firstSymbol);
+                    moreToAdd |= addFirstSymbol(symbol.getId(), firstSymbol);
                 }
             }
         }
     }
 }
 
-const std::vector<GrammarSymbol> FirstTable::operator()(int symbolId) const {
+const std::vector<int> FirstTable::operator()(int symbolId) const {
     return firstTable.at(symbolId);
 }
 
-bool FirstTable::addFirstSymbol(const GrammarSymbol& firstFor, const GrammarSymbol& firstSymbol) {
-    auto& firstSetForSymbol = firstTable.at(firstFor.getId());
+bool FirstTable::addFirstSymbol(int firstFor, int firstSymbol) {
+    auto& firstSetForSymbol = firstTable.at(firstFor);
     if (std::find(firstSetForSymbol.begin(), firstSetForSymbol.end(), firstSymbol) == firstSetForSymbol.end()) {
         firstSetForSymbol.push_back(firstSymbol);
         return true;
@@ -38,16 +38,12 @@ bool FirstTable::addFirstSymbol(const GrammarSymbol& firstFor, const GrammarSymb
 
 void FirstTable::initializeTable(const std::vector<GrammarSymbol>& symbols, const Grammar& grammar) {
     for (const auto& symbol : symbols) {
-        if (firstTable.find(symbol.getId()) == firstTable.end()) {
-            firstTable[symbol.getId()] = std::vector<GrammarSymbol> { };
-        }
+        firstTable.insert({symbol.getId(), {}});
         for (auto production : grammar.getProductionsOfSymbol(symbol)) {
             for (const auto& productionSymbol : production) {
-                if (firstTable.find(productionSymbol.getId()) == firstTable.end()) {
-                    firstTable[productionSymbol.getId()] = std::vector<GrammarSymbol> { };
-                }
+                firstTable.insert({productionSymbol.getId(), {}});
                 if (productionSymbol.isTerminal()) {
-                    addFirstSymbol(productionSymbol, productionSymbol);
+                    addFirstSymbol(productionSymbol.getId(), productionSymbol.getId());
                 }
             }
         }

--- a/src/parser/FirstTable.h
+++ b/src/parser/FirstTable.h
@@ -13,14 +13,14 @@ class FirstTable {
 public:
     FirstTable(const Grammar& grammar);
 
-    const std::vector<GrammarSymbol> operator()(int symbolId) const;
+    const std::vector<int> operator()(int symbolId) const;
     std::string str(const Grammar& grammar) const;
 
 private:
     void initializeTable(const std::vector<GrammarSymbol>& symbols, const Grammar& grammar);
-    bool addFirstSymbol(const GrammarSymbol& firstFor, const GrammarSymbol& firstSymbol);
+    bool addFirstSymbol(int firstFor, int firstSymbol);
 
-    std::map<int, std::vector<GrammarSymbol>> firstTable { };
+    std::map<int, std::vector<int>> firstTable { };
 };
 
 } // namespace parser

--- a/src/parser/GeneratedParsingTable.cpp
+++ b/src/parser/GeneratedParsingTable.cpp
@@ -46,7 +46,7 @@ void GeneratedParsingTable::computeActionTable(const CanonicalCollection& canoni
                 for (const auto& lookahead : item.getLookaheads()) {
                     lookaheadActionTable.addAction(
                             currentState,
-                            lookahead.getId(),
+                            lookahead,
                             std::make_unique<ReduceAction>(item.getProduction(), this));
                 }
             }
@@ -82,7 +82,7 @@ void GeneratedParsingTable::computeErrorActions(size_t stateCount) {
                 if (potentialAction is shift) {
                     expected = terminal;
                 } else if (potentialAction is reduce) {
-                	forge_token = terminal.getId();
+                    forge_token = terminal.getId();
                 }
             } catch (std::out_of_range&) {
             }

--- a/src/parser/LR1Item.cpp
+++ b/src/parser/LR1Item.cpp
@@ -5,7 +5,7 @@
 
 namespace parser {
 
-LR1Item::LR1Item(const Production& production, const std::vector<GrammarSymbol>& lookaheads) :
+LR1Item::LR1Item(const Production& production, const std::vector<int>& lookaheads) :
         production { production },
         lookaheads { lookaheads }
 {
@@ -29,7 +29,7 @@ bool LR1Item::coresAreEqual(const LR1Item& that) const {
     return this->production.getId() == that.production.getId() && this->visitedOffset == that.visitedOffset;
 }
 
-bool LR1Item::mergeLookaheads(const std::vector<GrammarSymbol>& lookaheadsToMerge) {
+bool LR1Item::mergeLookaheads(const std::vector<int>& lookaheadsToMerge) {
     bool lookaheadsAdded { false };
     for (const auto& lookahead : lookaheadsToMerge) {
         if (std::find(lookaheads.begin(), lookaheads.end(), lookahead) == lookaheads.end()) {
@@ -63,7 +63,7 @@ std::vector<GrammarSymbol> LR1Item::getExpectedSymbols() const {
     return {production.begin() + visitedOffset, production.end()};
 }
 
-std::vector<GrammarSymbol> LR1Item::getLookaheads() const {
+std::vector<int> LR1Item::getLookaheads() const {
     return lookaheads;
 }
 

--- a/src/parser/LR1Item.h
+++ b/src/parser/LR1Item.h
@@ -13,17 +13,17 @@ namespace parser {
 
 class LR1Item {
 public:
-    LR1Item(const Production& production, const std::vector<GrammarSymbol>& lookaheads);
+    LR1Item(const Production& production, const std::vector<int>& lookaheads);
 
     LR1Item advance() const;
-    bool mergeLookaheads(const std::vector<GrammarSymbol>& lookaheadsToMerge);
+    bool mergeLookaheads(const std::vector<int>& lookaheadsToMerge);
 
     const GrammarSymbol getDefiningSymbol() const;
     std::vector<GrammarSymbol> getVisited() const;
     bool hasUnvisitedSymbols() const;
     const GrammarSymbol& nextUnvisitedSymbol() const;
     std::vector<GrammarSymbol> getExpectedSymbols() const;
-    std::vector<GrammarSymbol> getLookaheads() const;
+    std::vector<int> getLookaheads() const;
 
     Production getProduction() const;
 
@@ -34,7 +34,7 @@ public:
 private:
     const Production production;
     size_t visitedOffset { 0 };
-    std::vector<GrammarSymbol> lookaheads;
+    std::vector<int> lookaheads;
 };
 
 } // namespace parser

--- a/test/src/parserTest/ClosureTest.cpp
+++ b/test/src/parserTest/ClosureTest.cpp
@@ -17,7 +17,7 @@ TEST(Closure, computesClosure) {
     FirstTable firstTable { grammar };
     Closure closure { firstTable, &grammar };
 
-    std::vector<LR1Item> items { LR1Item { grammar.getRuleByIndex(grammar.ruleCount() - 1), { grammar.getEndSymbol() } } };
+    std::vector<LR1Item> items { LR1Item { grammar.getRuleByIndex(grammar.ruleCount() - 1), { grammar.getEndSymbol().getId() } } };
     closure(items);
 
     EXPECT_THAT(items, SizeIs(6));

--- a/test/src/parserTest/LR1ItemTest.cpp
+++ b/test/src/parserTest/LR1ItemTest.cpp
@@ -18,7 +18,7 @@ TEST(LR1Item, constructsItemFromGrammarRuleAndLookahead) {
     GrammarSymbol terminal2 { 4 };
     Production production { nonterm, { terminal1, nonterm1, terminal2 }, 0 };
     GrammarSymbol lookahead { 5 };
-    LR1Item item { production, { lookahead } };
+    LR1Item item { production, { lookahead.getId() } };
 
     EXPECT_THAT(item.getDefiningSymbol(), Eq(nonterm));
     EXPECT_THAT(item.getVisited(), SizeIs(0));
@@ -33,7 +33,7 @@ TEST(LR1Item, advancesTheVisitedSymbols) {
     GrammarSymbol terminal2 { 4 };
     Production production {nonterm, { terminal1, nonterm1, terminal2 }, 0 };
     GrammarSymbol lookahead { 5 };
-    LR1Item item { production, { lookahead } };
+    LR1Item item { production, { lookahead.getId() } };
 
     LR1Item advanced1Item = item.advance();
     EXPECT_THAT(advanced1Item.getVisited(), SizeIs(1));
@@ -53,7 +53,7 @@ TEST(LR1Item, throwsAnExceptionIfAdvancedPastProductionBounds) {
     GrammarSymbol terminal1 { 2 };
     Production production {nonterm, { terminal1 }, 0 };
     GrammarSymbol lookahead { 3 };
-    LR1Item item { production, { lookahead } };
+    LR1Item item { production, { lookahead.getId() } };
 
     EXPECT_THAT(item.advance().getVisited(), SizeIs(1));
     EXPECT_THAT(item.advance().getExpectedSymbols(), SizeIs(0));


### PR DESCRIPTION
Before
```
(master)$ ./regenerate-parsing-table.sh
Generating parsing table
Parsing table generation took 6427219[µs]

(master with -O3)$ ./regenerate-parsing-table.sh
Generating parsing table
Parsing table generation took 563922[µs]
```

After
```
(optimize-parser-v1)$ ./regenerate-parsing-table.sh
Generating parsing table
Parsing table generation took 2766216[µs]

(optimize-parser-v1 with -O3)$ ./regenerate-parsing-table.sh
Generating parsing table
Parsing table generation took 416640[µs]
```