### PR TITLE
Fix call stack alignment and variadic AL for AMD64 System V

### DIFF
--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -49,7 +49,7 @@ std::string ATandTInstructionSet::pop(const Register& reg) const {
 }
 
 std::string ATandTInstructionSet::add(const Register& reg, int constant) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::add(const Register& reg, int constant)" };
+    return "addq " + constantReference(constant) + ", " + registerAccess(reg);
 }
 
 std::string ATandTInstructionSet::sub(const Register& reg, int constant) const {
@@ -155,7 +155,7 @@ std::string ATandTInstructionSet::ret() const {
 }
 
 std::string ATandTInstructionSet::xor_(const Register& operand, const Register& result) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::xor_(const Register& operand, const Register& result) " };
+    return "xorq " + registerAccess(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::xor_(const Register& operandBase, int operandOffset, const Register& result) const {

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -238,14 +238,22 @@ void StackMachine::callProcedure(std::string procedureName) {
     storeRegisterValue(registers->getRetrievalRegister());
     spillCallerSavedRegisters();
     int argumentOffset{0};
+    // System V AMD64: RSP must be 16-byte aligned before call. Without stack args we are
+    // aligned; each stack arg is 8 bytes, so an odd count needs 8 bytes of padding.
+    if (stackArguments.size() % 2 == 1) {
+        assembly << instructionSet->sub(registers->getStackPointer(), MACHINE_WORD_SIZE);
+        argumentOffset += MACHINE_WORD_SIZE;
+    }
     for (auto argument : stackArguments) {
         pushProcedureArgument(*argument, argumentOffset);
         argumentOffset += MACHINE_WORD_SIZE;
     }
     integerArguments.clear();
     stackArguments.clear();
-    //auto& retrievalRegister = registers->getRetrievalRegister();
-    //assembly << instructionSet->xor_(retrievalRegister, retrievalRegister);
+    // AL must hold the number of vector registers used for variadic calls (System V AMD64).
+    // This compiler only passes integer args, so set AL to 0 via xor rax, rax.
+    auto& retrievalRegister = registers->getRetrievalRegister();
+    assembly << instructionSet->xor_(retrievalRegister, retrievalRegister);
     assembly << instructionSet->call(procedureName);
     if (argumentOffset) {
         assembly << instructionSet->add(registers->getStackPointer(), argumentOffset);

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -58,7 +58,8 @@ TEST_F(StackMachineTest, procedureCall_doesNotPushUnusedCallerSavedRegisters) {
 
     stackMachine.callProcedure("procedure");
 
-    expectCode("\tcall procedure\n");
+    expectCode("\txorq %rax, %rax\n"
+            "\tcall procedure\n");
 }
 
 TEST_F(StackMachineTest, procedureCall_storesAllDirtyCallerSavedRegisters) {
@@ -79,7 +80,23 @@ TEST_F(StackMachineTest, procedureCall_storesAllDirtyCallerSavedRegisters) {
             "\tmovq %r9, (%rsp)\n"
             "\tmovq %r10, (%rsp)\n"
             "\tmovq %r11, (%rsp)\n"
+            "\txorq %rax, %rax\n"
             "\tcall procedure\n");
+}
+
+// Variadic ABI: AL must be 0 when no vector args are passed (e.g. printf with integers only)
+TEST_F(StackMachineTest, procedureCall_clearsRaxForVariadicAlRequirement) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<ATandTInstructionSet>(), std::make_unique<Amd64Registers>() };
+    Value value = intValue("value");
+    stackMachine.startProcedure("proc", { value }, { });
+    assemblyCode.str("");
+
+    stackMachine.procedureArgument(value.getName());
+    stackMachine.callProcedure("printf");
+
+    expectCode("\tmovq -40(%rsp), %rdi\n"
+            "\txorq %rax, %rax\n"
+            "\tcall printf\n");
 }
 
 TEST_F(StackMachineTest, procedureStart_storesCalleeSavedRegisters) {
@@ -133,7 +150,37 @@ TEST_F(StackMachineTest, procedureArgumentPassing_firstIntegerArgumentIsPassedIn
     stackMachine.callProcedure("procedure");
 
     expectCode("\tmovq -40(%rsp), %rdi\n"
+            "\txorq %rax, %rax\n"
             "\tcall procedure\n");
+}
+
+// Odd number of stack args needs 8-byte padding so RSP is 16-byte aligned before call
+TEST_F(StackMachineTest, procedureCall_padsStackForOddNumberOfStackArguments) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<ATandTInstructionSet>(), std::make_unique<Amd64Registers>() };
+    std::vector<Value> locals;
+    for (int i = 0; i < 7; ++i) {
+        locals.push_back({ "a" + std::to_string(i), i, Type::INTEGRAL, 8 });
+    }
+    stackMachine.startProcedure("proc", locals, { });
+    assemblyCode.str("");
+
+    for (const auto& local : locals) {
+        stackMachine.procedureArgument(local.getName());
+    }
+    stackMachine.callProcedure("procedure");
+
+    expectCode("\tmovq -40(%rsp), %rdi\n"
+            "\tmovq -48(%rsp), %rsi\n"
+            "\tmovq -56(%rsp), %rdx\n"
+            "\tmovq -64(%rsp), %rcx\n"
+            "\tmovq -72(%rsp), %r8\n"
+            "\tmovq -80(%rsp), %r9\n"
+            "\tsubq $8, %rsp\n"
+            "\tmovq -96(%rsp), %rax\n"
+            "\tpushq %rax\n"
+            "\txorq %rax, %rax\n"
+            "\tcall procedure\n"
+            "\taddq $16, %rsp\n");
 }
 
 TEST_F(StackMachineTest, sub_reg_reg) {

--- a/test/src/functionalTest/FunctionCallTest.cpp
+++ b/test/src/functionalTest/FunctionCallTest.cpp
@@ -21,6 +21,34 @@ TEST(Compiler, canPassAndOutputArguments) {
     program.runAndExpect("1\n2", "1 2");
 }
 
+// 7 total args: 6 in registers, 1 on the stack (odd stack-arg count must keep RSP 16-byte aligned)
+TEST(Compiler, callWithSevenArguments) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d %d %d %d %d %d\n", 1, 2, 3, 4, 5, 6);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("1 2 3 4 5 6\n");
+}
+
+// 8 total args: 2 on the stack (even stack-arg count stays aligned without padding)
+TEST(Compiler, callWithEightArguments) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d %d %d %d %d %d %d\n", 1, 2, 3, 4, 5, 6, 7);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("1 2 3 4 5 6 7\n");
+}
+
 // FIXME: segfaults when more outputs are replaced with printfs
 TEST(Compiler, canPassAndOutputManyArguments) {
     SourceProgram program{R"prg(


### PR DESCRIPTION
Odd stack-arg counts misaligned RSP before call (printf segfault with 7+ args). Pad when needed and xor rax,rax so AL is 0 for variadics.