### PR TITLE
Fix unary codegen double-evaluating operands

### DIFF
--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -132,22 +132,17 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
     switch (expression.getOperator()->getLexeme().front()) {
     case '&':
         instructions.push_back(std::make_unique<AddressOf>(expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
-        expression.visitOperand(*this);
         break;
     case '*':
         instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName(),
                                                              expression.getResultSymbol()->getName()));
-        expression.visitOperand(*this);
         break;
     case '+':
-        expression.visitOperand(*this);
         break;
     case '-':
-        expression.visitOperand(*this);
         instructions.push_back(std::make_unique<UnaryMinus>(expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
         break;
     case '!':
-        expression.visitOperand(*this);
         instructions.push_back(std::make_unique<ZeroCompare>(expression.operandSymbol()->getName()));
         instructions.push_back(std::make_unique<Jump>(expression.getTruthyLabel()->getName(), JumpCondition::IF_EQUAL));
         instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol()->getName()));

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -110,6 +110,7 @@ add_executable(functionalTest gtest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp
         functionalTest/LogicalOperatorsTest.cpp
+        functionalTest/UnaryOperatorsTest.cpp
         functionalTest/ShiftOperatorsTest.cpp
         functionalTest/AssignmentOperatorsTest.cpp
         functionalTest/SemanticErrorsTest.cpp

--- a/test/src/functionalTest/ConditionalTest.cpp
+++ b/test/src/functionalTest/ConditionalTest.cpp
@@ -54,8 +54,7 @@ TEST(Compiler, notEquals) {
     program.runAndExpect("-42 42", "1");
 }
 
-// FIXME: fails to compile - something gets messed up with labels in generated assembly
-/*TEST(Compiler, equalsNegated) {
+TEST(Compiler, equalsNegated) {
     SourceProgram program{R"prg(
         int main() {
             int a, b;
@@ -79,7 +78,97 @@ TEST(Compiler, notEquals) {
     program.runAndExpect("-1 0", "1");
     program.runAndExpect("42 -42", "1");
     program.runAndExpect("-42 42", "1");
-}*/
+}
+
+TEST(Compiler, notEqualsNegated) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a, b;
+            scanf("%ld %ld", &a, &b);
+            printf("%d", !(a != b));
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0 0", "1");
+    program.runAndExpect("1 1", "1");
+    program.runAndExpect("0 1", "0");
+    program.runAndExpect("1 0", "0");
+}
+
+TEST(Compiler, lessThanNegated) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a, b;
+            scanf("%ld %ld", &a, &b);
+            printf("%d", !(a < b));
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0 1", "0");
+    program.runAndExpect("1 0", "1");
+    program.runAndExpect("1 1", "1");
+    program.runAndExpect("-1 0", "0");
+}
+
+TEST(Compiler, logicalAndNegated) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a, b;
+            scanf("%ld %ld", &a, &b);
+            printf("%d", !(a && b));
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0 0", "1");
+    program.runAndExpect("1 0", "1");
+    program.runAndExpect("0 1", "1");
+    program.runAndExpect("1 1", "0");
+}
+
+TEST(Compiler, logicalOrNegated) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a, b;
+            scanf("%ld %ld", &a, &b);
+            printf("%d", !(a || b));
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0 0", "1");
+    program.runAndExpect("1 0", "0");
+    program.runAndExpect("0 1", "0");
+    program.runAndExpect("1 1", "0");
+}
+
+TEST(Compiler, doubleLogicalNot) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            scanf("%ld", &a);
+            printf("%d", !!a);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0", "0");
+    program.runAndExpect("1", "1");
+    program.runAndExpect("2", "1");
+    program.runAndExpect("-1", "1");
+}
 
 TEST(Compiler, lessThanOrEqualsConst) {
     SourceProgram program{R"prg(

--- a/test/src/functionalTest/FunctionCallTest.cpp
+++ b/test/src/functionalTest/FunctionCallTest.cpp
@@ -49,7 +49,6 @@ TEST(Compiler, callWithEightArguments) {
     program.runAndExpect("1 2 3 4 5 6 7\n");
 }
 
-// FIXME: segfaults when more outputs are replaced with printfs
 TEST(Compiler, canPassAndOutputManyArguments) {
     SourceProgram program{R"prg(
         void function(int a, int b, int c, int d, int e, int f, int g,

--- a/test/src/functionalTest/UnaryOperatorsTest.cpp
+++ b/test/src/functionalTest/UnaryOperatorsTest.cpp
@@ -1,0 +1,60 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, unaryMinusOnVariable) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            scanf("%ld", &a);
+            printf("%d %d", -a, -(-a));
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0", "0 0");
+    program.runAndExpect("1", "-1 1");
+    program.runAndExpect("-2", "2 -2");
+}
+
+TEST(Compiler, addressOfAndDereference) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            int* p;
+            scanf("%ld", &a);
+            p = &a;
+            printf("%d %d", *p, a);
+            *p = 7;
+            printf(" %d %d", *p, a);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("3", "3 3 7 7");
+    program.runAndExpect("0", "0 0 7 7");
+}
+
+TEST(Compiler, logicalNotOnVariable) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            scanf("%ld", &a);
+            printf("%d", !a);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+
+    program.runAndExpect("0", "1");
+    program.runAndExpect("1", "0");
+    program.runAndExpect("2", "0");
+    program.runAndExpect("-1", "0");
+}
+
+} // namespace


### PR DESCRIPTION
- Evaluate unary operands exactly once in `CodeGeneratingVisitor` so nested comparisons/logical ops under `!` no longer emit duplicate assembly labels (e.g. `!(a == b)`).
- Add regression tests for negated comparisons/logical ops and `!!a`, plus focused unary smoke tests; remove a stale FunctionCall FIXME.
