### PR TITLE
Fix ++/-- and compound assign through pointers

### DIFF
--- a/src/ast/SingleOperandExpression.cpp
+++ b/src/ast/SingleOperandExpression.cpp
@@ -23,6 +23,10 @@ semantic_analyzer::ValueEntry* SingleOperandExpression::operandSymbol() const {
     return _operand->getResultSymbol();
 }
 
+semantic_analyzer::ValueEntry* SingleOperandExpression::operandLvalueSymbol() const {
+    return _operand->getLvalueSymbol();
+}
+
 translation_unit::Context SingleOperandExpression::getContext() const {
     return _operand->getContext();
 }

--- a/src/ast/SingleOperandExpression.h
+++ b/src/ast/SingleOperandExpression.h
@@ -16,6 +16,7 @@ public:
     void visitOperand(AbstractSyntaxTreeVisitor& visitor);
     type::Type operandType() const;
     semantic_analyzer::ValueEntry* operandSymbol() const;
+    semantic_analyzer::ValueEntry* operandLvalueSymbol() const;
 
     bool isLval() const override;
 

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -113,16 +113,26 @@ void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
         instructions.push_back(std::make_unique<Dec>(resultSymbolName));
     }
 
+    // Dereference (and similar) lvalues: value lives in a temp; store new value through the pointer.
+    if (auto* lvalue = expression.operandLvalueSymbol()) {
+        instructions.push_back(std::make_unique<LvalueAssign>(resultSymbolName, lvalue->getName()));
+    }
+
     expression.setResultSymbol(*expression.getPreOperationSymbol());
 }
 
 void CodeGeneratingVisitor::visit(ast::PrefixExpression& expression) {
     expression.visitOperand(*this);
 
+    auto resultSymbolName = expression.getResultSymbol()->getName();
     if (expression.getOperator()->getLexeme() == "++") {
-        instructions.push_back(std::make_unique<Inc>(expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Inc>(resultSymbolName));
     } else if (expression.getOperator()->getLexeme() == "--") {
-        instructions.push_back(std::make_unique<Dec>(expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Dec>(resultSymbolName));
+    }
+
+    if (auto* lvalue = expression.operandLvalueSymbol()) {
+        instructions.push_back(std::make_unique<LvalueAssign>(resultSymbolName, lvalue->getName()));
     }
 }
 
@@ -302,65 +312,66 @@ void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
     expression.visitRightOperand(*this);
 
     auto assignmentOperator = expression.getOperator();
+    auto resultName = expression.getResultSymbol()->getName();
     if (assignmentOperator->getLexeme() == "+=")
         instructions.push_back(std::make_unique<Add>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "-=")
         instructions.push_back(std::make_unique<Sub>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "*=")
         instructions.push_back(std::make_unique<Mul>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "/=")
         instructions.push_back(std::make_unique<Div>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "%=")
         instructions.push_back(std::make_unique<Mod>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "&=")
         instructions.push_back(std::make_unique<And>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "^=")
         instructions.push_back(std::make_unique<Xor>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "|=")
         instructions.push_back(std::make_unique<Or>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     else if (assignmentOperator->getLexeme() == "<<=") {
         instructions.push_back(std::make_unique<Shl>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     } else if (assignmentOperator->getLexeme() == ">>=") {
         instructions.push_back(std::make_unique<Shr>(
-                    expression.getResultSymbol()->getName(),
+                    resultName,
                     expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()
+                    resultName
         ));
     } else if (assignmentOperator->getLexeme() == "=") {
         if (expression.leftOperandLvalueSymbol()) {
@@ -371,11 +382,17 @@ void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
         } else {
             instructions.push_back(std::make_unique<Assign>(
                         expression.rightOperandSymbol()->getName(),
-                        expression.getResultSymbol()->getName()
+                        resultName
             ));
         }
+        return;
     } else {
         throw std::runtime_error { "unidentified assignment operator: " + assignmentOperator->getLexeme() };
+    }
+
+    // Compound assign updated the value temp; write back through pointer lvalues (e.g. *p += 1).
+    if (auto* lvalue = expression.leftOperandLvalueSymbol()) {
+        instructions.push_back(std::make_unique<LvalueAssign>(resultName, lvalue->getName()));
     }
 }
 

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -406,6 +406,8 @@ void StackMachine::mul(std::string leftOperandName, std::string rightOperandName
 
     Register& multiplicationRegister = registers->getMultiplicationRegister();
     assignRegisterToSymbol(multiplicationRegister, leftOperand);
+    // imul writes RDX:RAX; spill RDX if it holds a live value (e.g. pointer for *p *= ...)
+    storeRegisterValue(registers->getRemainderRegister());
     if (rightOperand.isStored()) {
         assembly << instructionSet->imul(memoryBaseRegister(rightOperand), memoryOffset(rightOperand));
     } else {

--- a/test/src/functionalTest/AssignmentOperatorsTest.cpp
+++ b/test/src/functionalTest/AssignmentOperatorsTest.cpp
@@ -238,5 +238,73 @@ TEST(Compiler, shiftRightAssign) {
     program.runAndExpect("16", "8 4 2");
 }
 
-} // namespace
+TEST(Compiler, addAssignThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            *p += 3;
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("8");
+}
+
+TEST(Compiler, subAssignThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            *p -= 2;
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, mulAssignThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            *p *= 2;
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("10");
+}
+
+TEST(Compiler, divAssignThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 10;
+            p = &n;
+            *p /= 2;
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("5");
+}
+
+}
 

--- a/test/src/functionalTest/IncrementsDecrementsTest.cpp
+++ b/test/src/functionalTest/IncrementsDecrementsTest.cpp
@@ -100,8 +100,6 @@ TEST(Compiler, decrementsFunctions) {
     program.runAndExpect("-1", "-2 -1 -1");
 }
 
-// FIXME
-/*
 TEST(Compiler, incrementsFunctionsPointers) {
     SourceProgram program{R"prg(
         void pre(int* i) {
@@ -132,6 +130,110 @@ TEST(Compiler, incrementsFunctionsPointers) {
     program.runAndExpect("-1", "0\n1\n");
     program.runAndExpect("-3", "-2\n-1\n");
 }
-*/
+
+TEST(Compiler, prefixIncrementThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            ++(*p);
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("6");
+}
+
+TEST(Compiler, postfixIncrementThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            (*p)++;
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("6");
+}
+
+TEST(Compiler, prefixDecrementThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            --(*p);
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("4");
+}
+
+TEST(Compiler, postfixDecrementThroughPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            n = 5;
+            p = &n;
+            (*p)--;
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("4");
+}
+
+TEST(Compiler, postfixIncrementThroughPointerExpressionValue) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            int old;
+            n = 5;
+            p = &n;
+            old = (*p)++;
+            printf("%d %d", old, n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("5 6");
+}
+
+TEST(Compiler, prefixIncrementThroughPointerExpressionValue) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int* p;
+            int neu;
+            n = 5;
+            p = &n;
+            neu = ++(*p);
+            printf("%d %d", neu, n);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    program.runAndExpect("6 6");
+}
+
 }
 


### PR DESCRIPTION
Fix ++/-- and compound assign through pointers

Emit LvalueAssign after mutating dereference temps; spill RDX before
imul. Tests for pointer increments and *p op= forms.