### PR TITLE
Support optional for-loop init, condition, and increment

### DIFF
--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -460,20 +460,6 @@ void ifElseStatement(AbstractSyntaxTreeBuilderContext& context) {
     context.pushStatement(std::make_unique<IfElseStatement>(context.popExpression(), std::move(truthyStatement), std::move(falsyStatement)));
 }
 
-void forLoopStatement(AbstractSyntaxTreeBuilderContext& context) {
-    context.popTerminal();
-    context.popTerminal();
-    context.popTerminal();
-    context.popTerminal();
-    context.popTerminal();
-    auto increment = context.popExpression();
-    auto clause = context.popExpression();
-    auto initialization = context.popExpression();
-    auto loopHeader = std::make_unique<ForLoopHeader>(std::move(initialization), std::move(clause), std::move(increment));
-    auto body = context.popStatement();
-    context.pushStatement(std::make_unique<LoopStatement>(std::move(loopHeader), std::move(body)));
-}
-
 void whileLoopStatement(AbstractSyntaxTreeBuilderContext& context) {
     context.popTerminal();
     context.popTerminal();
@@ -848,8 +834,34 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     int s_for = grammar.symbolId("for");
     nodeCreatorRegistry[s_iteration_stat_matched][{ s_while, s_open_paren, s_exp, s_close_paren, s_matched }] = whileLoopStatement;
     nodeCreatorRegistry[s_iteration_stat_unmatched][{ s_while, s_open_paren, s_exp, s_close_paren, s_unmatched }] = whileLoopStatement;
-    nodeCreatorRegistry[s_iteration_stat_matched][{ s_for, s_open_paren, s_exp, s_semicolon, s_exp, s_semicolon, s_exp, s_close_paren, s_matched }] = forLoopStatement;
-    nodeCreatorRegistry[s_iteration_stat_unmatched][{ s_for, s_open_paren, s_exp, s_semicolon, s_exp, s_semicolon, s_exp, s_close_paren, s_unmatched }] = forLoopStatement;
+
+    auto forLoop = [](bool hasInit, bool hasClause, bool hasIncrement) {
+        return [=](AbstractSyntaxTreeBuilderContext& context) {
+            for (int i = 0; i < 5; ++i) {
+                context.popTerminal();  // for ( ; ; ) punctuation
+            }
+            auto increment = hasIncrement ? context.popExpression() : nullptr;
+            auto clause = hasClause ? context.popExpression() : nullptr;
+            auto initialization = hasInit ? context.popExpression() : nullptr;
+            auto loopHeader = std::make_unique<ForLoopHeader>(std::move(initialization), std::move(clause), std::move(increment));
+            auto body = context.popStatement();
+            context.pushStatement(std::make_unique<LoopStatement>(std::move(loopHeader), std::move(body)));
+        };
+    };
+    auto registerFor = [&](const std::vector<int>& prod, std::function<void(AbstractSyntaxTreeBuilderContext&)> creator) {
+        nodeCreatorRegistry[s_iteration_stat_matched][prod] = creator;
+        auto unmatchedProd = prod;
+        unmatchedProd.back() = s_unmatched;
+        nodeCreatorRegistry[s_iteration_stat_unmatched][unmatchedProd] = creator;
+    };
+    registerFor({ s_for, s_open_paren, s_exp, s_semicolon, s_exp, s_semicolon, s_exp, s_close_paren, s_matched }, forLoop(true,  true,  true));
+    registerFor({ s_for, s_open_paren, s_exp, s_semicolon, s_exp, s_semicolon, s_close_paren, s_matched }, forLoop(true,  true,  false));
+    registerFor({ s_for, s_open_paren, s_exp, s_semicolon, s_semicolon, s_exp, s_close_paren, s_matched }, forLoop(true,  false, true));
+    registerFor({ s_for, s_open_paren, s_exp, s_semicolon, s_semicolon, s_close_paren, s_matched }, forLoop(true,  false, false));
+    registerFor({ s_for, s_open_paren, s_semicolon, s_exp, s_semicolon, s_exp, s_close_paren, s_matched }, forLoop(false, true,  true));
+    registerFor({ s_for, s_open_paren, s_semicolon, s_exp, s_semicolon, s_close_paren, s_matched }, forLoop(false, true,  false));
+    registerFor({ s_for, s_open_paren, s_semicolon, s_semicolon, s_exp, s_close_paren, s_matched }, forLoop(false, false, true));
+    registerFor({ s_for, s_open_paren, s_semicolon, s_semicolon, s_close_paren, s_matched }, forLoop(false, false, false));
 }
 
 ContextualSyntaxNodeBuilder::~ContextualSyntaxNodeBuilder() = default;

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -453,12 +453,16 @@ void CodeGeneratingVisitor::visit(ast::LoopStatement& loop) {
 }
 
 void CodeGeneratingVisitor::visit(ast::ForLoopHeader& loopHeader) {
-    loopHeader.initialization->accept(*this);
+    if (loopHeader.initialization) {
+        loopHeader.initialization->accept(*this);
+    }
 
     instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry()->getName()));
-    loopHeader.clause->accept(*this);
-    instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
-    instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
+    if (loopHeader.clause) {
+        loopHeader.clause->accept(*this);
+        instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
+    }
 }
 
 void CodeGeneratingVisitor::visit(ast::WhileLoopHeader& loopHeader) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -331,9 +331,15 @@ void SemanticAnalysisVisitor::visit(ast::LoopStatement& loop) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::ForLoopHeader& loopHeader) {
-    loopHeader.initialization->accept(*this);
-    loopHeader.clause->accept(*this);
-    loopHeader.increment->accept(*this);
+    if (loopHeader.initialization) {
+        loopHeader.initialization->accept(*this);
+    }
+    if (loopHeader.clause) {
+        loopHeader.clause->accept(*this);
+    }
+    if (loopHeader.increment) {
+        loopHeader.increment->accept(*this);
+    }
 
     loopHeader.setLoopEntry(symbolTable.newLabel());
     loopHeader.setLoopExit(symbolTable.newLabel());

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -280,9 +280,15 @@ void SemanticXmlOutputVisitor::visit(ast::LoopStatement& statement) {
 void SemanticXmlOutputVisitor::visit(ast::ForLoopHeader& loopHeader) {
     const std::string nodeId { "forLoopHeader" };
     openXmlNode(nodeId);
-    loopHeader.initialization->accept(*this);
-    loopHeader.clause->accept(*this);
-    loopHeader.increment->accept(*this);
+    if (loopHeader.initialization) {
+        loopHeader.initialization->accept(*this);
+    }
+    if (loopHeader.clause) {
+        loopHeader.clause->accept(*this);
+    }
+    if (loopHeader.increment) {
+        loopHeader.increment->accept(*this);
+    }
     closeXmlNode(nodeId);
 }
 

--- a/test/src/functionalTest/ControlFlowTest.cpp
+++ b/test/src/functionalTest/ControlFlowTest.cpp
@@ -154,10 +154,21 @@ TEST(Compiler, forEmptyBody) {
     program.runAndExpect("3");
 }
 
-// TODO(gap): empty for-init `for (; cond; incr)` - no AST creator for
-// `<iteration_stat_matched> ::= for ( ; <exp> ; <exp> ) <matched>`. Need grammar
-// action / ContextualSyntaxNodeBuilder support for omitted for-init (valid C).
-/*
+TEST(Compiler, forEmptyInit) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            i = 0;
+            for (; i < 3; i = i + 1) {
+            }
+            printf("%d", i);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
 TEST(Compiler, forWithPointerInUpdate) {
     SourceProgram program{R"prg(
         int main() {
@@ -174,7 +185,109 @@ TEST(Compiler, forWithPointerInUpdate) {
     program.compile();
     program.runAndExpect("3");
 }
-*/
+
+TEST(Compiler, forNoIncrement) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            for (i = 0; i < 3; ) {
+                i = i + 1;
+            }
+            printf("%d", i);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, forNoInitNoIncrement) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            i = 0;
+            for (; i < 3; ) {
+                i = i + 1;
+            }
+            printf("%d", i);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, forNoClause) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            for (i = 0; ; i = i + 1) {
+                if (i == 3) {
+                    printf("%d", i);
+                    return 0;
+                }
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, forNoClauseNoIncrement) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            for (i = 0; ; ) {
+                if (i == 3) {
+                    printf("%d", i);
+                    return 0;
+                }
+                i = i + 1;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, forNoInitNoClause) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            i = 0;
+            for (; ; i = i + 1) {
+                if (i == 3) {
+                    printf("%d", i);
+                    return 0;
+                }
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, forEmpty) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            i = 0;
+            for (; ; ) {
+                if (i == 3) {
+                    printf("%d", i);
+                    return 0;
+                }
+                i = i + 1;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
 
 TEST(Compiler, earlyReturnSkipsCode) {
     SourceProgram program{R"prg(


### PR DESCRIPTION
Register AST builders for all for grammar variants and allow null
parts in semantic analysis and codegen. Enable forEmptyInit and
forWithPointerInUpdate tests.