### PR TITLE
Implement C-like block scopes and shadowing

### DIFF
--- a/src/ast/FunctionDefinition.cpp
+++ b/src/ast/FunctionDefinition.cpp
@@ -1,8 +1,10 @@
 #include "FunctionDefinition.h"
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "AbstractSyntaxTreeVisitor.h"
+#include "Block.h"
 
 namespace ast {
 
@@ -30,6 +32,14 @@ void FunctionDefinition::visitDeclarator(AbstractSyntaxTreeVisitor& visitor) {
 }
 
 void FunctionDefinition::visitBody(AbstractSyntaxTreeVisitor& visitor) {
+    body->accept(visitor);
+}
+
+void FunctionDefinition::visitBodyChildren(AbstractSyntaxTreeVisitor& visitor) {
+    if (auto* block = dynamic_cast<Block*>(body.get())) {
+        block->visitChildren(visitor);
+        return;
+    }
     body->accept(visitor);
 }
 

--- a/src/ast/FunctionDefinition.h
+++ b/src/ast/FunctionDefinition.h
@@ -22,6 +22,8 @@ public:
     void visitReturnType(AbstractSyntaxTreeVisitor& visitor);
     void visitDeclarator(AbstractSyntaxTreeVisitor& visitor);
     void visitBody(AbstractSyntaxTreeVisitor& visitor);
+    // Visit body block contents without Block::accept (no extra scope enter).
+    void visitBodyChildren(AbstractSyntaxTreeVisitor& visitor);
 
     void setSymbol(semantic_analyzer::FunctionEntry symbol);
     void setLocalVariables(std::map<std::string, semantic_analyzer::ValueEntry> localVariables);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -400,14 +400,17 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
 
     function.setSymbol(symbolTable.findFunction(function.getName()));
     symbolTable.startFunction(function.getName(), argumentNames);
-    function.visitBody(*this);
+    // Parameters and outermost body declarations share one scope (C); do not enterBlockScope.
+    function.visitBodyChildren(*this);
     function.setArguments(symbolTable.getCurrentScopeArguments());
     function.setLocalVariables(symbolTable.getCurrentScopeSymbols());
     symbolTable.endFunction();
 }
 
 void SemanticAnalysisVisitor::visit(ast::Block& block) {
+    symbolTable.enterBlockScope();
     block.visitChildren(*this);
+    symbolTable.exitBlockScope();
 }
 
 void SemanticAnalysisVisitor::typeCheck(const type::Type& typeFrom, const type::Type& typeTo,

--- a/src/semantic_analyzer/SymbolTable.cpp
+++ b/src/semantic_analyzer/SymbolTable.cpp
@@ -27,7 +27,7 @@ namespace semantic_analyzer {
 const std::string SymbolTable::SCOPE_PREFIX = "$s";
 
 bool SymbolTable::insertSymbol(std::string name, const type::Type& type, translation_unit::Context context) {
-    return functionScopes.back().insertSymbol(scopePrefix(currentScopeIndex) + name, type, context);
+    return functionScopes.back().insertSymbol(scopePrefix(currentScopeId()) + name, type, context);
 }
 
 std::string SymbolTable::newConstant(const std::string& value) {
@@ -37,7 +37,7 @@ std::string SymbolTable::newConstant(const std::string& value) {
 }
 
 void SymbolTable::insertFunctionArgument(std::string name, type::Type type, translation_unit::Context context) {
-    functionScopes.back().insertFunctionArgument(scopePrefix(currentScopeIndex + 1) + name, type, context);
+    functionScopes.back().insertFunctionArgument(scopePrefix(currentScopeId()) + name, type, context);
 }
 
 FunctionEntry SymbolTable::insertFunction(std::string name, type::Function functionType, translation_unit::Context context) {
@@ -51,15 +51,24 @@ FunctionEntry SymbolTable::findFunction(std::string name) const {
 }
 
 bool SymbolTable::hasSymbol(std::string symbolName) const {
-    return functionScopes.back().isSymbolDefined(scopePrefix(currentScopeIndex) + symbolName) || globalScope.isSymbolDefined(symbolName);
+    try {
+        lookup(symbolName);
+        return true;
+    } catch (std::out_of_range&) {
+        return false;
+    }
 }
 
 ValueEntry SymbolTable::lookup(std::string name) const {
-    try {
-        return functionScopes.back().lookup(scopePrefix(currentScopeIndex) + name);
-    } catch (std::out_of_range&) {
-        return globalScope.lookup(name);
+    if (!functionScopes.empty()) {
+        for (auto it = scopeIdStack.rbegin(); it != scopeIdStack.rend(); ++it) {
+            try {
+                return functionScopes.back().lookup(scopePrefix(*it) + name);
+            } catch (std::out_of_range&) {
+            }
+        }
     }
+    return globalScope.lookup(name);
 }
 
 ValueEntry SymbolTable::createTemporarySymbol(type::Type type) {
@@ -75,6 +84,8 @@ LabelEntry SymbolTable::newLabel() {
 
 void SymbolTable::startFunction(std::string name, std::vector<std::string> formalArguments) {
     functionScopes.push_back(ValueScope { });
+    scopeIdStack.clear();
+    scopeIdStack.push_back(++nextScopeId);
     auto function = findFunction(name);
     size_t i { 0 };
     for (auto& argument : function.arguments()) {
@@ -83,11 +94,22 @@ void SymbolTable::startFunction(std::string name, std::vector<std::string> forma
         }
         ++i;
     }
-    ++currentScopeIndex;
 }
 
 void SymbolTable::endFunction() {
-    --currentScopeIndex;
+    scopeIdStack.clear();
+}
+
+void SymbolTable::enterBlockScope() {
+    scopeIdStack.push_back(++nextScopeId);
+}
+
+void SymbolTable::exitBlockScope() {
+    scopeIdStack.pop_back();
+}
+
+unsigned SymbolTable::currentScopeId() const {
+    return scopeIdStack.back();
 }
 
 std::map<std::string, ValueEntry> SymbolTable::getCurrentScopeSymbols() const {
@@ -126,8 +148,8 @@ void SymbolTable::printTable() const {
     }
 }
 
-std::string SymbolTable::scopePrefix(unsigned scopeIndex) const {
-    return SCOPE_PREFIX + std::to_string(scopeIndex);
+std::string SymbolTable::scopePrefix(unsigned scopeId) const {
+    return SCOPE_PREFIX + std::to_string(scopeId);
 }
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/SymbolTable.h
+++ b/src/semantic_analyzer/SymbolTable.h
@@ -26,6 +26,8 @@ public:
     LabelEntry newLabel();
     void startFunction(std::string name, std::vector<std::string> formalArguments);
     void endFunction();
+    void enterBlockScope();
+    void exitBlockScope();
 
     std::map<std::string, ValueEntry> getCurrentScopeSymbols() const;
     std::vector<ValueEntry> getCurrentScopeArguments() const;
@@ -43,8 +45,12 @@ private:
     std::vector<ValueScope> functionScopes;
     ValueScope globalScope;
 
-    unsigned currentScopeIndex { 0 };
-    std::string scopePrefix(unsigned scopeIndex) const;
+    // Stack of monotonic scope ids (siblings never reuse an id).
+    unsigned nextScopeId { 0 };
+    std::vector<unsigned> scopeIdStack;
+
+    std::string scopePrefix(unsigned scopeId) const;
+    unsigned currentScopeId() const;
 
     static const std::string SCOPE_PREFIX;
 };

--- a/src/semantic_analyzer/ValueScope.cpp
+++ b/src/semantic_analyzer/ValueScope.cpp
@@ -37,6 +37,11 @@ bool ValueScope::insertSymbol(std::string name, const type::Type& type, translat
     if (localSymbols.find(name) != localSymbols.end()) {
         return false;
     }
+    // Parameters live in `arguments` but share block scope with the function body (C).
+    auto existingArgument = std::find_if(arguments.begin(), arguments.end(), EntryWithSameNameExists { name });
+    if (existingArgument != arguments.end()) {
+        return false;
+    }
     ValueEntry entry { name, type, false, context, static_cast<int>(localSymbols.size()) };
     localSymbols.insert(std::make_pair(name, entry));
     return true;

--- a/test/src/functionalTest/ScopeTest.cpp
+++ b/test/src/functionalTest/ScopeTest.cpp
@@ -30,12 +30,6 @@ TEST(Compiler, initializedLocals) {
     program.runAndExpect("4 5");
 }
 
-// TODO(gap): block-scope shadowing - inner `int a` reports "declaration conflicts"
-// with outer `a`. Symbol table treats nested scopes as a flat conflict instead of
-// allowing a new binding (README mentions prefixing inner locals; not applied to
-// same name in an inner block). Need proper nested scopes in SemanticAnalysisVisitor
-// / SymbolTable so outer `a` remains visible after the block.
-/*
 TEST(Compiler, innerBlockShadowsOuter) {
     SourceProgram program{R"prg(
         int main() {
@@ -53,7 +47,6 @@ TEST(Compiler, innerBlockShadowsOuter) {
     program.compile();
     program.runAndExpect("2 1");
 }
-*/
 
 TEST(Compiler, innerBlockSeparateVariable) {
     SourceProgram program{R"prg(
@@ -71,6 +64,87 @@ TEST(Compiler, innerBlockSeparateVariable) {
     )prg"};
     program.compile();
     program.runAndExpect("2 1");
+}
+
+// Sibling blocks each introduce their own `a`; must not clash with each other or outer `a`.
+TEST(Compiler, siblingBlocksShadowIndependently) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1;
+            {
+                int a;
+                a = 2;
+                printf("%d", a);
+            }
+            {
+                int a;
+                a = 3;
+                printf(" %d", a);
+            }
+            printf(" %d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2 3 1");
+}
+
+// C: parameters and the function's outermost block share one scope - cannot redeclare a parameter.
+TEST(Compiler, parameterRedeclaredInOutermostBlockRejected) {
+    SourceProgram program{R"prg(
+        int f(int a) {
+            int a;
+            a = 2;
+            return a;
+        }
+
+        int main() {
+            printf("%d", f(1));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("declaration conflicts");
+}
+
+// Nested block may shadow a parameter (distinct inner scope).
+TEST(Compiler, parameterShadowedInNestedBlock) {
+    SourceProgram program{R"prg(
+        int f(int a) {
+            {
+                int a;
+                a = 2;
+                printf("%d", a);
+            }
+            printf(" %d", a);
+            return 0;
+        }
+
+        int main() {
+            f(1);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2 1");
+}
+
+// Using a parameter in the outermost body (same scope as the parameter) must work.
+TEST(Compiler, parameterUsedInOutermostBlock) {
+    SourceProgram program{R"prg(
+        int f(int a) {
+            printf("%d", a);
+            return a;
+        }
+
+        int main() {
+            printf(" %d", f(7));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7 7");
 }
 
 TEST(Compiler, charPromotedInArithmetic) {


### PR DESCRIPTION
Use a monotonic scope-id stack for nested and sibling blocks. Share one
scope between parameters and the function body (visit body children
without entering a new scope). Reject redeclaring parameters as locals.
Add tests for nested/sibling shadowing and parameter scope rules.