### PR TITLE
Add file-scope global variables

### DIFF
--- a/src/ast/ConstantExpression.cpp
+++ b/src/ast/ConstantExpression.cpp
@@ -4,6 +4,40 @@
 
 namespace ast {
 
+namespace {
+
+// Decode an integer literal or a single-character constant ('a', '\n') to its value.
+bool parseConstantToken(const std::string& token, long& value) {
+    if (token.size() >= 3 && token.front() == '\'' && token.back() == '\'') {
+        const std::string inner = token.substr(1, token.size() - 2);
+        if (inner.size() == 1) {
+            value = static_cast<unsigned char>(inner[0]);
+            return true;
+        }
+        if (inner.size() == 2 && inner[0] == '\\') {
+            switch (inner[1]) {
+                case 'n': value = '\n'; return true;
+                case 't': value = '\t'; return true;
+                case 'r': value = '\r'; return true;
+                case '0': value = '\0'; return true;
+                case '\\': value = '\\'; return true;
+                case '\'': value = '\''; return true;
+                case '"': value = '"'; return true;
+            }
+        }
+        return false;
+    }
+    try {
+        // base 0: honor C's 0-prefix octal and 0x hex, else decimal.
+        value = std::stol(token, nullptr, 0);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace
+
 ConstantExpression::ConstantExpression(Constant constant) :
         constant { constant }
 {
@@ -23,6 +57,10 @@ translation_unit::Context ConstantExpression::getContext() const {
 
 std::string ConstantExpression::getValue() const {
     return constant.getValue();
+}
+
+bool ConstantExpression::evaluateConstant(long& value) const {
+    return parseConstantToken(constant.getValue(), value);
 }
 
 } // namespace ast

--- a/src/ast/ConstantExpression.h
+++ b/src/ast/ConstantExpression.h
@@ -18,6 +18,8 @@ public:
     translation_unit::Context getContext() const override;
     std::string getValue() const;
 
+    bool evaluateConstant(long& value) const override;
+
 private:
     Constant constant;
 };

--- a/src/ast/DoubleOperandExpression.cpp
+++ b/src/ast/DoubleOperandExpression.cpp
@@ -23,6 +23,37 @@ Operator* DoubleOperandExpression::getOperator() const {
     return _operator.get();
 }
 
+bool DoubleOperandExpression::evaluateConstant(long& value) const {
+    if (!_operator) {
+        return false;
+    }
+    long left = 0;
+    long right = 0;
+    if (!leftOperand->evaluateConstant(left) || !rightOperand->evaluateConstant(right)) {
+        return false;
+    }
+    const std::string op = _operator->getLexeme();
+    if (op == "+") { value = left + right; return true; }
+    if (op == "-") { value = left - right; return true; }
+    if (op == "*") { value = left * right; return true; }
+    if (op == "/") { if (right == 0) return false; value = left / right; return true; }
+    if (op == "%") { if (right == 0) return false; value = left % right; return true; }
+    if (op == "<<") { if (right < 0 || right >= 64) return false; value = left << right; return true; }
+    if (op == ">>") { if (right < 0 || right >= 64) return false; value = left >> right; return true; }
+    if (op == "&") { value = left & right; return true; }
+    if (op == "|") { value = left | right; return true; }
+    if (op == "^") { value = left ^ right; return true; }
+    if (op == "<") { value = left < right; return true; }
+    if (op == ">") { value = left > right; return true; }
+    if (op == "<=") { value = left <= right; return true; }
+    if (op == ">=") { value = left >= right; return true; }
+    if (op == "==") { value = left == right; return true; }
+    if (op == "!=") { value = left != right; return true; }
+    if (op == "&&") { value = left && right; return true; }
+    if (op == "||") { value = left || right; return true; }
+    return false;
+}
+
 void DoubleOperandExpression::visitLeftOperand(AbstractSyntaxTreeVisitor& visitor) {
     leftOperand->accept(visitor);
 }

--- a/src/ast/DoubleOperandExpression.h
+++ b/src/ast/DoubleOperandExpression.h
@@ -26,6 +26,8 @@ public:
 
     Operator* getOperator() const;
 
+    bool evaluateConstant(long& value) const override;
+
 protected:
     const std::unique_ptr<Expression> leftOperand;
     const std::unique_ptr<Expression> rightOperand;

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -21,6 +21,9 @@ public:
     virtual bool isLval() const;
     virtual semantic_analyzer::ValueEntry* getLvalueSymbol() const;
 
+    // Fold an integer constant expression; returns false if not a constant expression.
+    virtual bool evaluateConstant(long& value) const { return false; }
+
     void setResultSymbol(semantic_analyzer::ValueEntry resultSymbol);
     semantic_analyzer::ValueEntry* getResultSymbol() const;
 

--- a/src/ast/InitializedDeclarator.cpp
+++ b/src/ast/InitializedDeclarator.cpp
@@ -29,6 +29,10 @@ bool InitializedDeclarator::hasInitializer() const {
     return !!initializer;
 }
 
+Expression* InitializedDeclarator::getInitializer() const {
+    return initializer.get();
+}
+
 semantic_analyzer::ValueEntry* InitializedDeclarator::getInitializerHolder() const {
     return initializer->getResultSymbol();
 }

--- a/src/ast/InitializedDeclarator.h
+++ b/src/ast/InitializedDeclarator.h
@@ -20,6 +20,7 @@ public:
     type::Type getFundamentalType(const type::Type& baseType);
 
     bool hasInitializer() const;
+    Expression* getInitializer() const;
     semantic_analyzer::ValueEntry* getInitializerHolder() const;
 
     translation_unit::Context getContext() const;

--- a/src/ast/UnaryExpression.cpp
+++ b/src/ast/UnaryExpression.cpp
@@ -18,6 +18,18 @@ bool UnaryExpression::isLval() const {
     return getOperator()->getLexeme() == "*";
 }
 
+bool UnaryExpression::evaluateConstant(long& value) const {
+    long operand = 0;
+    if (!_operand->evaluateConstant(operand)) {
+        return false;
+    }
+    const std::string op = getOperator()->getLexeme();
+    if (op == "-") { value = -operand; return true; }
+    if (op == "+") { value = operand; return true; }
+    if (op == "!") { value = !operand; return true; }
+    return false;
+}
+
 void UnaryExpression::setTruthyLabel(semantic_analyzer::LabelEntry truthyLabel) {
     this->truthyLabel = std::unique_ptr<semantic_analyzer::LabelEntry> {
             new semantic_analyzer::LabelEntry { truthyLabel } };

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -15,6 +15,7 @@ public:
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
     bool isLval() const override;
+    bool evaluateConstant(long& value) const override;
 
     void setTruthyLabel(semantic_analyzer::LabelEntry truthyLabel);
     semantic_analyzer::LabelEntry* getTruthyLabel() const;

--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -1,6 +1,7 @@
 #include "ATandTInstructionSet.h"
 
 #include "Register.h"
+#include "MemoryOperand.h"
 
 #include <stdexcept>
 
@@ -10,6 +11,13 @@ using codegen::Register;
 
 std::string memoryOffsetMnemonic(const Register& memoryBase, int memoryOffset) {
     return (memoryOffset ? "-" + std::to_string(memoryOffset) : "") + "(%" + memoryBase.getName() + ")";
+}
+
+std::string memoryReference(const codegen::MemoryOperand& operand) {
+    if (operand.isGlobal()) {
+        throw std::runtime_error { "not implemented ATandTInstructionSet: global variable operand" };
+    }
+    return memoryOffsetMnemonic(operand.baseRegister(), operand.offset());
 }
 
 std::string registerAccess(const Register& reg) {
@@ -26,7 +34,10 @@ namespace codegen {
 
 ATandTInstructionSet::~ATandTInstructionSet() = default;
 
-std::string ATandTInstructionSet::preamble(std::map<std::string, std::string> constants) const {
+std::string ATandTInstructionSet::preamble(const std::map<std::string, std::string>& constants,
+        const std::vector<GlobalVariable>& globalVariables) const {
+    (void)constants;
+    (void)globalVariables;
     return ".extern scanf\n"
             ".extern printf\n\n"
             ".data\n"
@@ -56,16 +67,16 @@ std::string ATandTInstructionSet::sub(const Register& reg, int constant) const {
     return "subq " + constantReference(constant) + ", " + registerAccess(reg);
 }
 
-std::string ATandTInstructionSet::lea(const Register& base, int offset, const Register& target) const {
-    throw std::runtime_error { "not implemented ATandTinstructionSet::lea(const Register& base, int offset, const Register& target)"};
+std::string ATandTInstructionSet::lea(const MemoryOperand& source, const Register& target) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::lea" };
 }
 
 std::string ATandTInstructionSet::not_(const Register& reg) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::not_(const Register& reg)" };
 }
 
-std::string ATandTInstructionSet::mov(const Register& source, const Register& memoryBase, int memoryOffset) const {
-    return "movq " + registerAccess(source) + ", " + memoryOffsetMnemonic(memoryBase, memoryOffset);
+std::string ATandTInstructionSet::mov(const Register& source, const MemoryOperand& destination) const {
+    return "movq " + registerAccess(source) + ", " + memoryReference(destination);
 }
 
 std::string ATandTInstructionSet::mov(const Register& source, const Register& destination) const {
@@ -75,39 +86,36 @@ std::string ATandTInstructionSet::mov(const Register& source, const Register& de
     return "movq " + registerAccess(source) + ", " + registerAccess(destination);
 }
 
-std::string ATandTInstructionSet::mov(const Register& memoryBase, int memoryOffset, const Register& destination) const {
-    return "movq " + memoryOffsetMnemonic(memoryBase, memoryOffset) + ", " + registerAccess(destination);
+std::string ATandTInstructionSet::mov(const MemoryOperand& source, const Register& destination) const {
+    return "movq " + memoryReference(source) + ", " + registerAccess(destination);
 }
 
-std::string ATandTInstructionSet::mov(std::string constant, const Register& memoryBase, int memoryOffset) const {
-    throw std::runtime_error {
-            "not implemented ATandTInstructionSet::mov(std::string constant, const Register& memoryBase, int memoryOffset)" };
+std::string ATandTInstructionSet::mov(std::string constant, const MemoryOperand& destination) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::mov(std::string constant, MemoryOperand)" };
 }
 
 std::string ATandTInstructionSet::mov(std::string constant, const Register& destination) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::mov(std::string constant, const Register& destination)" };
 }
 
-std::string ATandTInstructionSet::cmp(const Register& leftArgument, const Register& memoryBase, int memoryOffset) const {
-    throw std::runtime_error {
-            "not implemented ATandTInstructionSet::cmp(const Register& leftArgument, const Register& memoryBase, int memoryOffset)" };
+std::string ATandTInstructionSet::cmp(const Register& leftArgument, const MemoryOperand& rightArgument) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(Register, MemoryOperand)" };
 }
 
 std::string ATandTInstructionSet::cmp(const Register& leftArgument, const Register& rightArgument) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(const Register& leftArgument, const Register& rightArgument)" };
 }
 
-std::string ATandTInstructionSet::cmp(const Register& memoryBase, int memoryOffset, const Register& rightArgument) const {
-    throw std::runtime_error {
-            "not implemented ATandTInstructionSet::cmp(const Register& memoryBase, int memoryOffset, const Register& rightArgument)" };
+std::string ATandTInstructionSet::cmp(const MemoryOperand& leftArgument, const Register& rightArgument) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(MemoryOperand, Register)" };
 }
 
 std::string ATandTInstructionSet::cmp(const Register& argument, int constant) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(const Register& argument, int constant)" };
 }
 
-std::string ATandTInstructionSet::cmp(const Register& memoryBase, int memoryOffset, int constant) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(const Register& memoryBase, int memoryOffset, int constant)" };
+std::string ATandTInstructionSet::cmp(const MemoryOperand& leftArgument, int constant) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(MemoryOperand, int constant)" };
 }
 
 std::string ATandTInstructionSet::label(std::string name) const {
@@ -158,27 +166,24 @@ std::string ATandTInstructionSet::xor_(const Register& operand, const Register& 
     return "xorq " + registerAccess(operand) + ", " + registerAccess(result);
 }
 
-std::string ATandTInstructionSet::xor_(const Register& operandBase, int operandOffset, const Register& result) const {
-    throw std::runtime_error {
-            "not implemented ATandTInstructionSet::xor_(const Register& operandBase, int operandOffset, const Register& result)" };
+std::string ATandTInstructionSet::xor_(const MemoryOperand& operand, const Register& result) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::xor_(MemoryOperand, Register)" };
 }
 
 std::string ATandTInstructionSet::or_(const Register& operand, const Register& result) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::or_(const Register& operand, const Register& result)" };
 }
 
-std::string ATandTInstructionSet::or_(const Register& operandBase, int operandOffset, const Register& result) const {
-    throw std::runtime_error {
-            "not implemented ATandTInstructionSet::or_(const Register& operandBase, int operandOffset, const Register& result)" };
+std::string ATandTInstructionSet::or_(const MemoryOperand& operand, const Register& result) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::or_(MemoryOperand, Register)" };
 }
 
 std::string ATandTInstructionSet::and_(const Register& operand, const Register& result) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::and_(const Register& operand, const Register& result)" };
 }
 
-std::string ATandTInstructionSet::and_(const Register& operandBase, int operandOffset, const Register& result) const {
-    throw std::runtime_error {
-            "not implemented ATandTInstructionSet::and_(const Register& operandBase, int operandOffset, const Register& result)" };
+std::string ATandTInstructionSet::and_(const MemoryOperand& operand, const Register& result) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::and_(MemoryOperand, Register)" };
 }
 
 std::string ATandTInstructionSet::shl(const Register& result) const {
@@ -203,48 +208,48 @@ std::string ATandTInstructionSet::add(const Register& operand, const Register& r
     return "addq " + registerAccess(operand) + ", " + registerAccess(result); // result = result + operand
 }
 
-std::string ATandTInstructionSet::add(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "addq " + memoryOffsetMnemonic(operandBase, operandOffset) + ", " + registerAccess(result);
+std::string ATandTInstructionSet::add(const MemoryOperand& operand, const Register& result) const {
+    return "addq " + memoryReference(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::sub(const Register& operand, const Register& result) const {
     return "subq " + registerAccess(operand) + ", " + registerAccess(result); // result = result - operand
 }
 
-std::string ATandTInstructionSet::sub(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "subq " + memoryOffsetMnemonic(operandBase, operandOffset) + ", " + registerAccess(result);
+std::string ATandTInstructionSet::sub(const MemoryOperand& operand, const Register& result) const {
+    return "subq " + memoryReference(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::imul(const Register& operand) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::imul(const Register& operand)" };
 }
 
-std::string ATandTInstructionSet::imul(const Register& operandBase, int operandOffset) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::imul(const Register& operandBase, int operandOffset)" };
+std::string ATandTInstructionSet::imul(const MemoryOperand& operand) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::imul(MemoryOperand)" };
 }
 
 std::string ATandTInstructionSet::idiv(const Register& operand) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::idiv(const Register& operand)" };
 }
 
-std::string ATandTInstructionSet::idiv(const Register& operandBase, int operandOffset) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::idiv(const Register& operandBase, int operandOffset)" };
+std::string ATandTInstructionSet::idiv(const MemoryOperand& operand) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::idiv(MemoryOperand)" };
 }
 
 std::string ATandTInstructionSet::inc(const Register& operand) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::inc(const Register& operand)" };
 }
 
-std::string ATandTInstructionSet::inc(const Register& operandBase, int operandOffset) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::inc(const Register& operandBase, int operandOffset)" };
+std::string ATandTInstructionSet::inc(const MemoryOperand& operand) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::inc(MemoryOperand)" };
 }
 
 std::string ATandTInstructionSet::dec(const Register& operand) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::dec(const Register& operand)" };
 }
 
-std::string ATandTInstructionSet::dec(const Register& operandBase, int operandOffset) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::dec(const Register& operandBase, int operandOffset)" };
+std::string ATandTInstructionSet::dec(const MemoryOperand& operand) const {
+    throw std::runtime_error { "not implemented ATandTInstructionSet::dec(MemoryOperand)" };
 }
 
 std::string ATandTInstructionSet::neg(const Register& operand) const {

--- a/src/codegen/ATandTInstructionSet.h
+++ b/src/codegen/ATandTInstructionSet.h
@@ -9,7 +9,8 @@ class ATandTInstructionSet: public InstructionSet {
 public:
     virtual ~ATandTInstructionSet();
 
-    std::string preamble(std::map<std::string, std::string> constants) const override;
+    std::string preamble(const std::map<std::string, std::string>& constants,
+            const std::vector<GlobalVariable>& globalVariables = {}) const override;
 
     std::string call(std::string procedureName) const override;
 
@@ -19,21 +20,21 @@ public:
     std::string add(const Register& reg, int constant) const override;
     std::string sub(const Register& reg, int constant) const override;
 
-    std::string lea(const Register& base, int offset, const Register& target) const override;
+    std::string lea(const MemoryOperand& source, const Register& target) const override;
 
     std::string not_(const Register& reg) const override;
 
-    std::string mov(const Register& source, const Register& memoryBase, int memoryOffset) const override;
+    std::string mov(const Register& source, const MemoryOperand& destination) const override;
     std::string mov(const Register& source, const Register& destination) const override;
-    std::string mov(const Register& memoryBase, int memoryOffset, const Register& destination) const override;
-    std::string mov(std::string constant, const Register& memoryBase, int memoryOffset) const override;
+    std::string mov(const MemoryOperand& source, const Register& destination) const override;
+    std::string mov(std::string constant, const MemoryOperand& destination) const override;
     std::string mov(std::string constant, const Register& destination) const override;
 
-    std::string cmp(const Register& leftArgument, const Register& memoryBase, int memoryOffset) const override;
+    std::string cmp(const Register& leftArgument, const MemoryOperand& rightArgument) const override;
     std::string cmp(const Register& leftArgument, const Register& rightArgument) const override;
-    std::string cmp(const Register& memoryBase, int memoryOffset, const Register& rightArgument) const override;
+    std::string cmp(const MemoryOperand& leftArgument, const Register& rightArgument) const override;
     std::string cmp(const Register& argument, int constant) const override;
-    std::string cmp(const Register& memoryBase, int memoryOffset, int constant) const override;
+    std::string cmp(const MemoryOperand& leftArgument, int constant) const override;
 
     std::string label(std::string name) const override;
     std::string jmp(std::string label) const override;
@@ -49,13 +50,13 @@ public:
     std::string ret() const override;
 
     std::string xor_(const Register& operand, const Register& result) const override;
-    std::string xor_(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string xor_(const MemoryOperand& operand, const Register& result) const override;
 
     std::string or_(const Register& operand, const Register& result) const override;
-    std::string or_(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string or_(const MemoryOperand& operand, const Register& result) const override;
 
     std::string and_(const Register& operand, const Register& result) const override;
-    std::string and_(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string and_(const MemoryOperand& operand, const Register& result) const override;
 
     std::string shl(const Register& result) const override;
     //std::string shl(std::string constant, const Register& result) const override;
@@ -63,22 +64,22 @@ public:
     //std::string shr(std::string constant, const Register& result) const override;
 
     std::string add(const Register& operand, const Register& result) const override;
-    std::string add(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string add(const MemoryOperand& operand, const Register& result) const override;
 
     std::string sub(const Register& operand, const Register& result) const override;
-    std::string sub(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string sub(const MemoryOperand& operand, const Register& result) const override;
 
     std::string imul(const Register& operand) const override;
-    std::string imul(const Register& operandBase, int operandOffset) const override;
+    std::string imul(const MemoryOperand& operand) const override;
 
     std::string idiv(const Register& operand) const override;
-    std::string idiv(const Register& operandBase, int operandOffset) const override;
+    std::string idiv(const MemoryOperand& operand) const override;
 
     std::string inc(const Register& operand) const override;
-    std::string inc(const Register& operandBase, int operandOffset) const override;
+    std::string inc(const MemoryOperand& operand) const override;
 
     std::string dec(const Register& operand) const override;
-    std::string dec(const Register& operandBase, int operandOffset) const override;
+    std::string dec(const MemoryOperand& operand) const override;
 
     std::string neg(const Register& operand) const override;
 };

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -11,9 +11,10 @@ AssemblyGenerator::AssemblyGenerator(std::unique_ptr<StackMachine> stackMachine)
 
 void AssemblyGenerator::generateAssemblyCode(
         std::vector<std::unique_ptr<Quadruple> > quadruples,
-        std::map<std::string, std::string> constants)
+        const std::map<std::string, std::string>& constants,
+        const std::vector<GlobalVariable>& globalVariables)
 {
-    stackMachine->generatePreamble(constants);
+    stackMachine->generatePreamble(constants, globalVariables);
     for (const auto& quadruple : quadruples) {
         quadruple->generateCode(*this);
     }

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -41,7 +41,9 @@ class AssemblyGenerator {
 public:
     AssemblyGenerator(std::unique_ptr<StackMachine> stackMachine);
 
-    void generateAssemblyCode(std::vector<std::unique_ptr<Quadruple>> quadruples, std::map<std::string, std::string> constants);
+    void generateAssemblyCode(std::vector<std::unique_ptr<Quadruple>> quadruples,
+            const std::map<std::string, std::string>& constants,
+            const std::vector<GlobalVariable>& globalVariables);
 
     void generateCodeFor(const StartProcedure& startProcedure);
     void generateCodeFor(const EndProcedure& endProcedure);

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(codegen
         ATandTInstructionSet.h
         CodeGeneratingVisitor.h
         InstructionSet.h
+        GlobalVariable.h
         IntelInstructionSet.h
         QuadrupleGenerator.h
         Register.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -1,6 +1,5 @@
 #include "CodeGeneratingVisitor.h"
 
-#include <iostream>
 #include <stdexcept>
 
 #include "semantic_analyzer/ValueEntry.h"
@@ -56,10 +55,14 @@ void CodeGeneratingVisitor::visit(ast::Declarator& declarator) {
 }
 
 void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
+    // File-scope variables are initialized in .data; skip children (would emit assigns with no procedure).
+    if (declarator.hasInitializer() && declarator.getHolder()->isGlobal()) {
+        return;
+    }
     declarator.visitChildren(*this);
-
     if (declarator.hasInitializer()) {
-        instructions.push_back(std::make_unique<Assign>(declarator.getInitializerHolder()->getName(), declarator.getHolder()->getName()));
+        instructions.push_back(std::make_unique<Assign>(
+                declarator.getInitializerHolder()->getName(), declarator.getHolder()->getName()));
     }
 }
 
@@ -501,8 +504,7 @@ void CodeGeneratingVisitor::visit(ast::FunctionDefinition& function) {
                 valueSymbol.second.getIndex(),
                 // FIXME:
                 Type::INTEGRAL,
-                valueSymbol.second.getType().getSize(),
-                false
+                valueSymbol.second.getType().getSize()
         });
     }
     std::vector<Value> arguments;

--- a/src/codegen/GlobalVariable.h
+++ b/src/codegen/GlobalVariable.h
@@ -1,0 +1,24 @@
+#ifndef GLOBALVARIABLE_H_
+#define GLOBALVARIABLE_H_
+
+#include <string>
+
+#include "Value.h"
+
+namespace codegen {
+
+// File-scope variable for preamble emission and StackMachine::globals registration.
+struct GlobalVariable {
+    std::string name;
+    int sizeInBytes;
+    std::string initializerLiteral;
+
+    // Stack machine currently models only integral/pointer-sized words as INTEGRAL.
+    Value toValue() const {
+        return Value { name, 0, Type::INTEGRAL, sizeInBytes, false, true };
+    }
+};
+
+} // namespace codegen
+
+#endif // GLOBALVARIABLE_H_

--- a/src/codegen/InstructionSet.h
+++ b/src/codegen/InstructionSet.h
@@ -3,6 +3,10 @@
 
 #include <string>
 #include <map>
+#include <vector>
+
+#include "GlobalVariable.h"
+#include "MemoryOperand.h"
 
 namespace codegen {
 
@@ -12,31 +16,32 @@ class InstructionSet {
 public:
     virtual ~InstructionSet() = default;
 
-    virtual std::string preamble(std::map<std::string, std::string> constants) const = 0;
+    virtual std::string preamble(const std::map<std::string, std::string>& constants,
+            const std::vector<GlobalVariable>& globalVariables = {}) const = 0;
 
     virtual std::string call(std::string procedureName) const = 0;
 
     virtual std::string push(const Register& reg) const = 0;
     virtual std::string pop(const Register& reg) const = 0;
 
-    virtual std::string lea(const Register& base, int offset, const Register& target) const = 0;
+    virtual std::string lea(const MemoryOperand& source, const Register& target) const = 0;
 
     virtual std::string add(const Register& reg, int constant) const = 0;
     virtual std::string sub(const Register& reg, int constant) const = 0;
 
     virtual std::string not_(const Register& reg) const = 0;
 
-    virtual std::string mov(const Register& from, const Register& memoryBase, int memoryOffset) const = 0;
+    virtual std::string mov(const Register& from, const MemoryOperand& destination) const = 0;
     virtual std::string mov(const Register& from, const Register& to) const = 0;
-    virtual std::string mov(const Register& memoryBase, int memoryOffset, const Register& to) const = 0;
-    virtual std::string mov(std::string constant, const Register& memoryBase, int memoryOffset) const = 0;
+    virtual std::string mov(const MemoryOperand& source, const Register& to) const = 0;
+    virtual std::string mov(std::string constant, const MemoryOperand& destination) const = 0;
     virtual std::string mov(std::string constant, const Register& to) const = 0;
 
-    virtual std::string cmp(const Register& leftArgument, const Register& memoryBase, int memoryOffset) const = 0;
+    virtual std::string cmp(const Register& leftArgument, const MemoryOperand& rightArgument) const = 0;
     virtual std::string cmp(const Register& leftArgument, const Register& rightArgument) const = 0;
-    virtual std::string cmp(const Register& memoryBase, int memoryOffset, const Register& rightArgument) const = 0;
+    virtual std::string cmp(const MemoryOperand& leftArgument, const Register& rightArgument) const = 0;
     virtual std::string cmp(const Register& argument, int constant) const = 0;
-    virtual std::string cmp(const Register& memoryBase, int memoryOffset, int constant) const = 0;
+    virtual std::string cmp(const MemoryOperand& leftArgument, int constant) const = 0;
 
     virtual std::string label(std::string name) const = 0;
     virtual std::string jmp(std::string label) const = 0;
@@ -52,13 +57,13 @@ public:
     virtual std::string ret() const = 0;
 
     virtual std::string xor_(const Register& operand, const Register& result) const = 0;
-    virtual std::string xor_(const Register& operandBase, int operandOffset, const Register& result) const = 0;
+    virtual std::string xor_(const MemoryOperand& operand, const Register& result) const = 0;
 
     virtual std::string or_(const Register& operand, const Register& result) const = 0;
-    virtual std::string or_(const Register& operandBase, int operandOffset, const Register& result) const = 0;
+    virtual std::string or_(const MemoryOperand& operand, const Register& result) const = 0;
 
     virtual std::string and_(const Register& operand, const Register& result) const = 0;
-    virtual std::string and_(const Register& operandBase, int operandOffset, const Register& result) const = 0;
+    virtual std::string and_(const MemoryOperand& operand, const Register& result) const = 0;
 
     virtual std::string shl(const Register& result) const = 0;
     //virtual std::string shl(std::string constant, const Register& result) const = 0;
@@ -66,22 +71,22 @@ public:
     //virtual std::string shr(std::string constant, const Register& result) const = 0;
 
     virtual std::string add(const Register& operand, const Register& result) const = 0;
-    virtual std::string add(const Register& operandBase, int operandOffset, const Register& result) const = 0;
+    virtual std::string add(const MemoryOperand& operand, const Register& result) const = 0;
 
     virtual std::string sub(const Register& operand, const Register& result) const = 0;
-    virtual std::string sub(const Register& operandBase, int operandOffset, const Register& result) const = 0;
+    virtual std::string sub(const MemoryOperand& operand, const Register& result) const = 0;
 
     virtual std::string imul(const Register& operand) const = 0;
-    virtual std::string imul(const Register& operandBase, int operandOffset) const = 0;
+    virtual std::string imul(const MemoryOperand& operand) const = 0;
 
     virtual std::string idiv(const Register& operand) const = 0;
-    virtual std::string idiv(const Register& operandBase, int operandOffset) const = 0;
+    virtual std::string idiv(const MemoryOperand& operand) const = 0;
 
     virtual std::string inc(const Register& operand) const = 0;
-    virtual std::string inc(const Register& operandBase, int operandOffset) const = 0;
+    virtual std::string inc(const MemoryOperand& operand) const = 0;
 
     virtual std::string dec(const Register& operand) const = 0;
-    virtual std::string dec(const Register& operandBase, int operandOffset) const = 0;
+    virtual std::string dec(const MemoryOperand& operand) const = 0;
 
     virtual std::string neg(const Register& operand) const = 0;
 };

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -11,6 +11,13 @@ std::string memoryOffsetMnemonic(const codegen::Register& memoryBase, int memory
     return "[" + memoryBase.getName() + (memoryOffset ? " + " + std::to_string(memoryOffset) : "") + "]";
 }
 
+std::string memoryReference(const codegen::MemoryOperand& operand) {
+    if (operand.isGlobal()) {
+        return "[rel " + operand.label() + "]";
+    }
+    return memoryOffsetMnemonic(operand.baseRegister(), operand.offset());
+}
+
 } // namespace
 
 namespace codegen {
@@ -37,13 +44,19 @@ std::string toConstantDeclaration(std::string escapedConstant) {
     return declaration.str();
 }
 
-std::string IntelInstructionSet::preamble(std::map<std::string, std::string> constants) const {
+std::string IntelInstructionSet::preamble(const std::map<std::string, std::string>& constants,
+        const std::vector<GlobalVariable>& globalVariables) const {
     std::stringstream preamble;
-    preamble << "extern scanf\n"
+    preamble << "default rel\n"
+            "extern scanf\n"
             "extern printf\n\n"
             "section .data\n";
-    for (auto constant : constants) {
+    for (const auto& constant : constants) {
         preamble << "\t" << constant.first << " " << toConstantDeclaration(constant.second) << "\n";
+    }
+    // One qword per global for now (sizeInBytes is tracked for StackMachine homes only).
+    for (const auto& global : globalVariables) {
+        preamble << "\t" << global.name << " dq " << global.initializerLiteral << "\n";
     }
     preamble << "\n"
             "section .text\n"
@@ -71,16 +84,16 @@ std::string IntelInstructionSet::sub(const Register& reg, int constant) const {
     return "sub " + reg.getName() + ", " + std::to_string(constant);
 }
 
-std::string IntelInstructionSet::lea(const Register& base, int offset, const Register& target) const {
-    return "lea " + target.getName() + ", " + memoryOffsetMnemonic(base, offset);
+std::string IntelInstructionSet::lea(const MemoryOperand& source, const Register& target) const {
+    return "lea " + target.getName() + ", " + memoryReference(source);
 }
 
 std::string IntelInstructionSet::not_(const Register& reg) const {
     return "not " + reg.getName();
 }
 
-std::string IntelInstructionSet::mov(const Register& from, const Register& memoryBase, int memoryOffset) const {
-    return "mov " + memoryOffsetMnemonic(memoryBase, memoryOffset) + ", " + from.getName();
+std::string IntelInstructionSet::mov(const Register& from, const MemoryOperand& destination) const {
+    return "mov " + memoryReference(destination) + ", " + from.getName();
 }
 
 std::string IntelInstructionSet::mov(const Register& from, const Register& to) const {
@@ -90,36 +103,36 @@ std::string IntelInstructionSet::mov(const Register& from, const Register& to) c
     return "mov " + to.getName() + ", " + from.getName();
 }
 
-std::string IntelInstructionSet::mov(const Register& memoryBase, int memoryOffset, const Register& to) const {
-    return "mov " + to.getName() + ", " + memoryOffsetMnemonic(memoryBase, memoryOffset);
+std::string IntelInstructionSet::mov(const MemoryOperand& source, const Register& to) const {
+    return "mov " + to.getName() + ", " + memoryReference(source);
 }
 
-std::string IntelInstructionSet::mov(std::string constant, const Register& memoryBase, int memoryOffset) const {
-    return "mov qword " + memoryOffsetMnemonic(memoryBase, memoryOffset) + ", " + constant;
+std::string IntelInstructionSet::mov(std::string constant, const MemoryOperand& destination) const {
+    return "mov qword " + memoryReference(destination) + ", " + constant;
 }
 
 std::string IntelInstructionSet::mov(std::string constant, const Register& to) const {
     return "mov " + to.getName() + ", " + constant;
 }
 
-std::string IntelInstructionSet::cmp(const Register& leftArgument, const Register& memoryBase, int memoryOffset) const {
-    return "cmp " + leftArgument.getName() + ", " + "qword " + memoryOffsetMnemonic(memoryBase, memoryOffset);
+std::string IntelInstructionSet::cmp(const Register& leftArgument, const MemoryOperand& rightArgument) const {
+    return "cmp " + leftArgument.getName() + ", " + "qword " + memoryReference(rightArgument);
 }
 
 std::string IntelInstructionSet::cmp(const Register& leftArgument, const Register& rightArgument) const {
     return "cmp " + leftArgument.getName() + ", " + rightArgument.getName();
 }
 
-std::string IntelInstructionSet::cmp(const Register& memoryBase, int memoryOffset, const Register& rightArgument) const {
-    return "cmp qword " + memoryOffsetMnemonic(memoryBase, memoryOffset) + ", " + rightArgument.getName();
+std::string IntelInstructionSet::cmp(const MemoryOperand& leftArgument, const Register& rightArgument) const {
+    return "cmp qword " + memoryReference(leftArgument) + ", " + rightArgument.getName();
 }
 
 std::string IntelInstructionSet::cmp(const Register& argument, int constant) const {
     return "cmp " + argument.getName() + ", " + std::to_string(constant);
 }
 
-std::string IntelInstructionSet::cmp(const Register& memoryBase, int memoryOffset, int constant) const {
-    return "cmp qword " + memoryOffsetMnemonic(memoryBase, memoryOffset) + ", " + std::to_string(constant);
+std::string IntelInstructionSet::cmp(const MemoryOperand& leftArgument, int constant) const {
+    return "cmp qword " + memoryReference(leftArgument) + ", " + std::to_string(constant);
 }
 
 std::string IntelInstructionSet::call(std::string procedureName) const {
@@ -170,24 +183,24 @@ std::string IntelInstructionSet::xor_(const Register& operand, const Register& r
     return "xor " + result.getName() + ", " + operand.getName();
 }
 
-std::string IntelInstructionSet::xor_(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "xor " + result.getName() + ", " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::xor_(const MemoryOperand& operand, const Register& result) const {
+    return "xor " + result.getName() + ", " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::or_(const Register& operand, const Register& result) const {
     return "or " + result.getName() + ", " + operand.getName();
 }
 
-std::string IntelInstructionSet::or_(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "or " + result.getName() + ", " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::or_(const MemoryOperand& operand, const Register& result) const {
+    return "or " + result.getName() + ", " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::and_(const Register& operand, const Register& result) const {
     return "and " + result.getName() + ", " + operand.getName();
 }
 
-std::string IntelInstructionSet::and_(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "and " + result.getName() + ", " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::and_(const MemoryOperand& operand, const Register& result) const {
+    return "and " + result.getName() + ", " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::shl(const Register& result) const {
@@ -208,48 +221,48 @@ std::string IntelInstructionSet::add(const Register& operand, const Register& re
     return "add " + result.getName() + ", " + operand.getName();
 }
 
-std::string IntelInstructionSet::add(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "add " + result.getName() + ", " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::add(const MemoryOperand& operand, const Register& result) const {
+    return "add " + result.getName() + ", " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::sub(const Register& operand, const Register& result) const {
     return "sub " + result.getName() + ", " + operand.getName();
 }
 
-std::string IntelInstructionSet::sub(const Register& operandBase, int operandOffset, const Register& result) const {
-    return "sub " + result.getName() + ", " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::sub(const MemoryOperand& operand, const Register& result) const {
+    return "sub " + result.getName() + ", " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::imul(const Register& operand) const {
     return "imul " + operand.getName();
 }
 
-std::string IntelInstructionSet::imul(const Register& operandBase, int operandOffset) const {
-    return "imul qword " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::imul(const MemoryOperand& operand) const {
+    return "imul qword " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::idiv(const Register& operand) const {
     return "idiv " + operand.getName();
 }
 
-std::string IntelInstructionSet::idiv(const Register& operandBase, int operandOffset) const {
-    return "idiv qword " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::idiv(const MemoryOperand& operand) const {
+    return "idiv qword " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::inc(const Register& operand) const {
     return "inc " + operand.getName();
 }
 
-std::string IntelInstructionSet::inc(const Register& operandBase, int operandOffset) const {
-    return "inc qword " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::inc(const MemoryOperand& operand) const {
+    return "inc qword " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::dec(const Register& operand) const {
     return "dec " + operand.getName();
 }
 
-std::string IntelInstructionSet::dec(const Register& operandBase, int operandOffset) const {
-    return "dec qword " + memoryOffsetMnemonic(operandBase, operandOffset);
+std::string IntelInstructionSet::dec(const MemoryOperand& operand) const {
+    return "dec qword " + memoryReference(operand);
 }
 
 std::string IntelInstructionSet::neg(const Register& operand) const {

--- a/src/codegen/IntelInstructionSet.h
+++ b/src/codegen/IntelInstructionSet.h
@@ -11,7 +11,8 @@ class IntelInstructionSet: public InstructionSet {
 public:
     virtual ~IntelInstructionSet();
 
-    std::string preamble(std::map<std::string, std::string> constants) const override;
+    std::string preamble(const std::map<std::string, std::string>& constants,
+            const std::vector<GlobalVariable>& globalVariables = {}) const override;
 
     std::string call(std::string procedureName) const override;
 
@@ -21,21 +22,21 @@ public:
     std::string add(const Register& reg, int constant) const override;
     std::string sub(const Register& reg, int constant) const override;
 
-    std::string lea(const Register& base, int offset, const Register& target) const override;
+    std::string lea(const MemoryOperand& source, const Register& target) const override;
 
     std::string not_(const Register& reg) const override;
 
-    std::string mov(const Register& from, const Register& memoryBase, int memoryOffset) const override;
+    std::string mov(const Register& from, const MemoryOperand& destination) const override;
     std::string mov(const Register& from, const Register& to) const override;
-    std::string mov(const Register& memoryBase, int memoryOffset, const Register& to) const override;
-    std::string mov(std::string constant, const Register& memoryBase, int memoryOffset) const override;
+    std::string mov(const MemoryOperand& source, const Register& to) const override;
+    std::string mov(std::string constant, const MemoryOperand& destination) const override;
     std::string mov(std::string constant, const Register& to) const override;
 
-    std::string cmp(const Register& leftArgument, const Register& memoryBase, int memoryOffset) const override;
+    std::string cmp(const Register& leftArgument, const MemoryOperand& rightArgument) const override;
     std::string cmp(const Register& leftArgument, const Register& rightArgument) const override;
-    std::string cmp(const Register& memoryBase, int memoryOffset, const Register& rightArgument) const override;
+    std::string cmp(const MemoryOperand& leftArgument, const Register& rightArgument) const override;
     std::string cmp(const Register& argument, int constant) const override;
-    std::string cmp(const Register& memoryBase, int memoryOffset, int constant) const override;
+    std::string cmp(const MemoryOperand& leftArgument, int constant) const override;
 
     std::string label(std::string name) const override;
     std::string jmp(std::string label) const override;
@@ -51,13 +52,13 @@ public:
     std::string ret() const override;
 
     std::string xor_(const Register& operand, const Register& result) const override;
-    std::string xor_(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string xor_(const MemoryOperand& operand, const Register& result) const override;
 
     std::string or_(const Register& operand, const Register& result) const override;
-    std::string or_(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string or_(const MemoryOperand& operand, const Register& result) const override;
 
     std::string and_(const Register& operand, const Register& result) const override;
-    std::string and_(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string and_(const MemoryOperand& operand, const Register& result) const override;
 
     std::string shl(const Register& result) const override;
     //std::string shl(std::string constant, const Register& result) const override;
@@ -65,22 +66,22 @@ public:
     //std::string shr(std::string constant, const Register& result) const override;
 
     std::string add(const Register& operand, const Register& result) const override;
-    std::string add(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string add(const MemoryOperand& operand, const Register& result) const override;
 
     std::string sub(const Register& operand, const Register& result) const override;
-    std::string sub(const Register& operandBase, int operandOffset, const Register& result) const override;
+    std::string sub(const MemoryOperand& operand, const Register& result) const override;
 
     std::string imul(const Register& operand) const override;
-    std::string imul(const Register& operandBase, int operandOffset) const override;
+    std::string imul(const MemoryOperand& operand) const override;
 
     std::string idiv(const Register& operand) const override;
-    std::string idiv(const Register& operandBase, int operandOffset) const override;
+    std::string idiv(const MemoryOperand& operand) const override;
 
     std::string inc(const Register& operand) const override;
-    std::string inc(const Register& operandBase, int operandOffset) const override;
+    std::string inc(const MemoryOperand& operand) const override;
 
     std::string dec(const Register& operand) const override;
-    std::string dec(const Register& operandBase, int operandOffset) const override;
+    std::string dec(const MemoryOperand& operand) const override;
 
     std::string neg(const Register& operand) const override;
 };

--- a/src/codegen/MemoryOperand.h
+++ b/src/codegen/MemoryOperand.h
@@ -1,0 +1,40 @@
+#ifndef MEMORYOPERAND_H_
+#define MEMORYOPERAND_H_
+
+#include <string>
+#include <utility>
+
+namespace codegen {
+
+class Register;
+
+// A memory location operand: either base-register-plus-offset (`[base + offset]`,
+// used for stack slots and pointer dereferences) or a global variable (a named label).
+// The instruction set renders it in its own syntax, so the global/stack distinction
+// lives in one place instead of at every call site.
+class MemoryOperand {
+public:
+    static MemoryOperand at(const Register& base, int offset) {
+        return MemoryOperand { &base, offset, {} };
+    }
+    static MemoryOperand global(std::string label) {
+        return MemoryOperand { nullptr, 0, std::move(label) };
+    }
+
+    bool isGlobal() const { return base_ == nullptr; }
+    const Register& baseRegister() const { return *base_; }
+    int offset() const { return offset_; }
+    const std::string& label() const { return label_; }
+
+private:
+    MemoryOperand(const Register* base, int offset, std::string label) :
+            base_ { base }, offset_ { offset }, label_ { std::move(label) } {}
+
+    const Register* base_;
+    int offset_;
+    std::string label_;
+};
+
+} // namespace codegen
+
+#endif // MEMORYOPERAND_H_

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -16,8 +16,13 @@ StackMachine::StackMachine(std::ostream *ostream, std::unique_ptr<InstructionSet
         instructionSet{std::move(instructionSet)},
         registers{std::move(registers)} {}
 
-void StackMachine::generatePreamble(std::map<std::string, std::string> constants) {
-    assembly.raw(instructionSet->preamble(constants));
+void StackMachine::generatePreamble(const std::map<std::string, std::string>& constants,
+        const std::vector<GlobalVariable>& globalVariables) {
+    assembly.raw(instructionSet->preamble(constants, globalVariables));
+    // Register every global once with real size/type; resolve() falls back here for non-frame names.
+    for (const auto& global : globalVariables) {
+        globals.emplace(global.name, global.toValue());
+    }
 }
 
 void StackMachine::startProcedure(std::string procedureName, std::vector<Value> values, std::vector<Value> arguments) {
@@ -37,7 +42,7 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
         if (argument.getType() == Type::INTEGRAL && integerArgumentRegisterIndex < registers->getIntegerArgumentRegisters().size()) {
             Value registerArgument{argument.getName(), static_cast<int>(localIndex), argument.getType(), argument.getSizeInBytes()};
             scopeValues.insert({argument.getName(), registerArgument});
-            registers->getIntegerArgumentRegisters()[integerArgumentRegisterIndex]->assign(&scopeValues.at(argument.getName()));
+            registers->getIntegerArgumentRegisters()[integerArgumentRegisterIndex]->assign(&resolve(argument.getName()));
             ++integerArgumentRegisterIndex;
             ++localIndex;
         } else {
@@ -46,7 +51,6 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
             ++argumentIndex;
         }
     }
-    localVariableStackSize = 0;
     int savedRegistersStack = registers->getCalleeSavedRegisters().size() * MACHINE_WORD_SIZE;
     localVariableStackSize = (scopeValues.size() - argumentIndex) * MACHINE_WORD_SIZE;
     int stackSize = savedRegistersStack + localVariableStackSize;
@@ -109,10 +113,28 @@ void StackMachine::spillCallerSavedRegisters() {
     }
 }
 
+void StackMachine::emitLoad(Value& symbol, Register& dest) {
+    assembly << instructionSet->mov(memoryOperand(symbol), dest);
+}
+
+void StackMachine::emitStore(Register& source, Value& symbol) {
+    assembly << instructionSet->mov(source, memoryOperand(symbol));
+}
+
+// Bind a freshly computed result to its destination symbol. A global is never register-resident,
+// so write it straight to [rel name]; a local/temp stays register-resident for lazy write-back.
+void StackMachine::bindResult(Register& reg, Value& result) {
+    if (result.isGlobal()) {
+        emitStore(reg, result);
+    } else {
+        reg.assign(&result);
+    }
+}
+
 void StackMachine::assignRegisterToSymbol(Register& reg, Value& symbol) {
     if (symbol.isStored()) {
         storeRegisterValue(reg);
-        assembly << instructionSet->mov(memoryBaseRegister(symbol), memoryOffset(symbol), reg);
+        emitLoad(symbol, reg);
     } else if (&reg != &symbol.getAssignedRegister()) {
         storeRegisterValue(reg);
         Register& valueRegister = symbol.getAssignedRegister();
@@ -122,108 +144,105 @@ void StackMachine::assignRegisterToSymbol(Register& reg, Value& symbol) {
 }
 
 void StackMachine::compare(std::string leftSymbolName, std::string rightSymbolName) {
-    auto& leftSymbol = scopeValues.at(leftSymbolName);
-    auto& rightSymbol = scopeValues.at(rightSymbolName);
+    auto& leftSymbol = resolve(leftSymbolName);
+    auto& rightSymbol = resolve(rightSymbolName);
 
     if (leftSymbol.isStored() && rightSymbol.isStored()) {
         Register& rightSymbolRegister = assignRegisterTo(rightSymbol);
-        assembly << instructionSet->cmp(memoryBaseRegister(leftSymbol), memoryOffset(leftSymbol), rightSymbolRegister);
+        assembly << instructionSet->cmp(memoryOperand(leftSymbol), rightSymbolRegister);
     } else if (leftSymbol.isStored()) {
-        assembly << instructionSet->cmp(memoryBaseRegister(leftSymbol), memoryOffset(leftSymbol), rightSymbol.getAssignedRegister());
+        assembly << instructionSet->cmp(memoryOperand(leftSymbol), rightSymbol.getAssignedRegister());
     } else if (rightSymbol.isStored()) {
-        assembly << instructionSet->cmp(leftSymbol.getAssignedRegister(), memoryBaseRegister(rightSymbol), memoryOffset(rightSymbol));
+        assembly << instructionSet->cmp(leftSymbol.getAssignedRegister(), memoryOperand(rightSymbol));
     } else {
         assembly << instructionSet->cmp(leftSymbol.getAssignedRegister(), rightSymbol.getAssignedRegister());
     }
 }
 
 void StackMachine::zeroCompare(std::string symbolName) {
-    auto& symbol = scopeValues.at(symbolName);
+    auto& symbol = resolve(symbolName);
     if (symbol.isStored()) {
-        assembly << instructionSet->cmp(memoryBaseRegister(symbol), memoryOffset(symbol), 0);
+        assembly << instructionSet->cmp(memoryOperand(symbol), 0);
     } else {
         assembly << instructionSet->cmp(symbol.getAssignedRegister(), 0);
     }
 }
 
 void StackMachine::addressOf(std::string operandName, std::string resultName) {
-    auto& operand = scopeValues.at(operandName);
+    auto& operand = resolve(operandName);
     storeInMemory(operand);
     Register& resultRegister = get64BitRegister();
-    assembly << instructionSet->mov(memoryBaseRegister(operand), resultRegister);
-    int offset = memoryOffset(operand);
-    if (offset) {
-        assembly << instructionSet->add(resultRegister, offset);
-    }
-    resultRegister.assign(&scopeValues.at(resultName));
+    assembly << instructionSet->lea(memoryOperand(operand), resultRegister);
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::dereference(std::string operandName, std::string lvalueName, std::string resultName) {
-    auto& operand = scopeValues.at(operandName);
+    auto& operand = resolve(operandName);
     if (operand.isStored()) {
         assignRegisterTo(operand);
     }
     Register& resultRegister = get64BitRegisterExcluding(operand.getAssignedRegister());
-    assembly << instructionSet->mov(operand.getAssignedRegister(), 0, resultRegister);
-    resultRegister.assign(&scopeValues.at(resultName));
+    assembly << instructionSet->mov(MemoryOperand::at(operand.getAssignedRegister(), 0), resultRegister);
+    bindResult(resultRegister, resolve(resultName));
 
     Register& lvalueRegister = get64BitRegisterExcluding(operand.getAssignedRegister());
     assembly << instructionSet->mov(operand.getAssignedRegister(), lvalueRegister);
-    lvalueRegister.assign(&scopeValues.at(lvalueName));
+    lvalueRegister.assign(&resolve(lvalueName));
 }
 
 void StackMachine::unaryMinus(std::string operandName, std::string resultName) {
-    auto& operand = scopeValues.at(operandName);
+    auto& operand = resolve(operandName);
     if (operand.isStored()) {
         Register& resultRegister = get64BitRegister();
-        assembly << instructionSet->mov(memoryBaseRegister(operand), memoryOffset(operand), resultRegister);
+        emitLoad(operand, resultRegister);
         assembly << instructionSet->neg(resultRegister);
-        resultRegister.assign(&scopeValues.at(resultName));
+        bindResult(resultRegister, resolve(resultName));
     } else {
         Register& operandRegister = operand.getAssignedRegister();
         Register& resultRegister = get64BitRegisterExcluding(operand.getAssignedRegister());
         assembly << instructionSet->mov(operandRegister, resultRegister);
         assembly << instructionSet->neg(resultRegister);
-        resultRegister.assign(&scopeValues.at(resultName));
+        bindResult(resultRegister, resolve(resultName));
     }
 }
 
 void StackMachine::assign(std::string operandName, std::string resultName) {
-    auto& operand = scopeValues.at(operandName);
-    auto& result = scopeValues.at(resultName);
+    auto& operand = resolve(operandName);
+    auto& result = resolve(resultName);
 
     if (operand.isStored() && result.isStored()) {
-        Register& resultRegister = assignRegisterTo(result);
-        assembly << instructionSet->mov(memoryBaseRegister(operand), memoryOffset(operand), resultRegister);
+        Register& reg = get64BitRegister();
+        emitLoad(operand, reg);
+        emitStore(reg, result);
     } else if (operand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(operand), memoryOffset(operand), result.getAssignedRegister());
+        emitLoad(operand, result.getAssignedRegister());
     } else if (result.isStored()) {
-        assembly << instructionSet->mov(operand.getAssignedRegister(), memoryBaseRegister(result), memoryOffset(result));
+        emitStore(operand.getAssignedRegister(), result);
     } else {
         assembly << instructionSet->mov(operand.getAssignedRegister(), result.getAssignedRegister());
     }
 }
 
 void StackMachine::assignConstant(std::string constant, std::string resultName) {
-    auto& result = scopeValues.at(resultName);
+    auto& result = resolve(resultName);
     if (result.isStored()) {
-        assembly << instructionSet->mov(constant, memoryBaseRegister(result), memoryOffset(result)); // mov dword?
+        assembly << instructionSet->mov(constant, memoryOperand(result));
     } else {
-        assembly << instructionSet->mov(constant, result.getAssignedRegister()); // mov dword?
+        assembly << instructionSet->mov(constant, result.getAssignedRegister());
     }
 }
 
 void StackMachine::lvalueAssign(std::string operandName, std::string resultName) {
-    auto& operand = scopeValues.at(operandName);
-    auto& result = scopeValues.at(resultName);
+    auto& operand = resolve(operandName);
+    auto& result = resolve(resultName);
 
     Register& operandRegister = operand.isStored() ? assignRegisterTo(operand) : operand.getAssignedRegister();
     Register& resultRegister = result.isStored() ? assignRegisterExcluding(result, operandRegister) : result.getAssignedRegister();
-    assembly << instructionSet->mov(operandRegister, resultRegister, 0);
+    assembly << instructionSet->mov(operandRegister, MemoryOperand::at(resultRegister, 0));
 }
 
 void StackMachine::procedureArgument(std::string argumentName) {
-    auto argument = &scopeValues.at(argumentName);
+    auto argument = &resolve(argumentName);
     if (integerArguments.size() < registers->getIntegerArgumentRegisters().size()) {
         integerArguments.push_back(argument);
     } else {
@@ -263,8 +282,9 @@ void StackMachine::callProcedure(std::string procedureName) {
 void StackMachine::pushProcedureArgument(Value& symbolToPush, int argumentOffset) {
     if (symbolToPush.isStored()) {
         Register& reg = get64BitRegister();
-        assembly << instructionSet->mov(memoryBaseRegister(symbolToPush),
-                                        symbolToPush.isFunctionArgument() ? memoryOffset(symbolToPush) : memoryOffset(symbolToPush) + argumentOffset, reg);
+        // rsp moves as stack args are pushed, so a non-argument stack operand needs the running offset.
+        int extraOffset = symbolToPush.isFunctionArgument() ? 0 : argumentOffset;
+        assembly << instructionSet->mov(memoryOperand(symbolToPush, extraOffset), reg);
         assembly << instructionSet->push(reg);
     } else {
         assembly << instructionSet->push(symbolToPush.getAssignedRegister());
@@ -273,9 +293,9 @@ void StackMachine::pushProcedureArgument(Value& symbolToPush, int argumentOffset
 
 void StackMachine::returnFromProcedure(std::string returnSymbolName) {
     if (!returnSymbolName.empty()) {
-        Value& returnSymbol = scopeValues.at(returnSymbolName);
+        Value& returnSymbol = resolve(returnSymbolName);
         if (returnSymbol.isStored()) {
-            assembly << instructionSet->mov(memoryBaseRegister(returnSymbol), memoryOffset(returnSymbol), registers->getRetrievalRegister());
+            emitLoad(returnSymbol, registers->getRetrievalRegister());
         } else if (&registers->getRetrievalRegister() != &returnSymbol.getAssignedRegister()) {
             assembly << instructionSet->mov(returnSymbol.getAssignedRegister(), registers->getRetrievalRegister());
         }
@@ -286,119 +306,104 @@ void StackMachine::returnFromProcedure(std::string returnSymbolName) {
 }
 
 void StackMachine::retrieveProcedureReturnValue(std::string returnSymbolName) {
-    Value& returnSymbol = scopeValues.at(returnSymbolName);
-    assembly << instructionSet->mov(registers->getRetrievalRegister(), memoryBaseRegister(returnSymbol), memoryOffset(returnSymbol));
+    Value& returnSymbol = resolve(returnSymbolName);
+    emitStore(registers->getRetrievalRegister(), returnSymbol);
 }
 
 void StackMachine::xorCommand(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored() && rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->xor_(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-    } else if (leftOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->xor_(rightOperand.getAssignedRegister(), resultRegister);
-    } else if (rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-        assembly << instructionSet->xor_(leftOperand.getAssignedRegister(), resultRegister);
+    if (leftOperand.isStored()) {
+        emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
+    }
+    if (rightOperand.isStored()) {
+        assembly << instructionSet->xor_(memoryOperand(rightOperand), resultRegister);
+    } else {
         assembly << instructionSet->xor_(rightOperand.getAssignedRegister(), resultRegister);
     }
-    resultRegister.assign(&scopeValues.at(resultName));
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::orCommand(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored() && rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->or_(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-    } else if (leftOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->or_(rightOperand.getAssignedRegister(), resultRegister);
-    } else if (rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-        assembly << instructionSet->or_(leftOperand.getAssignedRegister(), resultRegister);
+    if (leftOperand.isStored()) {
+        emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
+    }
+    if (rightOperand.isStored()) {
+        assembly << instructionSet->or_(memoryOperand(rightOperand), resultRegister);
+    } else {
         assembly << instructionSet->or_(rightOperand.getAssignedRegister(), resultRegister);
     }
-    resultRegister.assign(&scopeValues.at(resultName));
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::andCommand(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored() && rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->and_(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-    } else if (leftOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->and_(rightOperand.getAssignedRegister(), resultRegister);
-    } else if (rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-        assembly << instructionSet->and_(leftOperand.getAssignedRegister(), resultRegister);
+    if (leftOperand.isStored()) {
+        emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
+    }
+    if (rightOperand.isStored()) {
+        assembly << instructionSet->and_(memoryOperand(rightOperand), resultRegister);
+    } else {
         assembly << instructionSet->and_(rightOperand.getAssignedRegister(), resultRegister);
     }
-    resultRegister.assign(&scopeValues.at(resultName));
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::add(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored() && rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->add(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-    } else if (leftOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->add(rightOperand.getAssignedRegister(), resultRegister);
-    } else if (rightOperand.isStored()) {
-        assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
-        assembly << instructionSet->add(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
+    if (leftOperand.isStored()) {
+        emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
+    }
+    if (rightOperand.isStored()) {
+        assembly << instructionSet->add(memoryOperand(rightOperand), resultRegister);
+    } else {
         assembly << instructionSet->add(rightOperand.getAssignedRegister(), resultRegister);
     }
-    resultRegister.assign(&scopeValues.at(resultName));
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::sub(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored() && rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->sub(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
-    } else if (leftOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(leftOperand), memoryOffset(leftOperand), resultRegister);
-        assembly << instructionSet->sub(rightOperand.getAssignedRegister(), resultRegister);
-    } else if (rightOperand.isStored()) {
-        assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
-        assembly << instructionSet->sub(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), resultRegister);
+    if (leftOperand.isStored()) {
+        emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
+    }
+    if (rightOperand.isStored()) {
+        assembly << instructionSet->sub(memoryOperand(rightOperand), resultRegister);
+    } else {
         assembly << instructionSet->sub(rightOperand.getAssignedRegister(), resultRegister);
     }
-    resultRegister.assign(&scopeValues.at(resultName));
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::mul(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
-    Value& result = scopeValues.at(resultName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
+    Value& result = resolve(resultName);
 
     if (result.getType() != Type::INTEGRAL) {
         throw std::runtime_error{"multiplication of non integers is not implemented"};
@@ -409,17 +414,17 @@ void StackMachine::mul(std::string leftOperandName, std::string rightOperandName
     // imul writes RDX:RAX; spill RDX if it holds a live value (e.g. pointer for *p *= ...)
     storeRegisterValue(registers->getRemainderRegister());
     if (rightOperand.isStored()) {
-        assembly << instructionSet->imul(memoryBaseRegister(rightOperand), memoryOffset(rightOperand));
+        assembly << instructionSet->imul(memoryOperand(rightOperand));
     } else {
         assembly << instructionSet->imul(rightOperand.getAssignedRegister());
     }
-    multiplicationRegister.assign(&result);
+    bindResult(multiplicationRegister, result);
 }
 
 void StackMachine::div(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
-    Value& result = scopeValues.at(resultName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
+    Value& result = resolve(resultName);
 
     if (result.getType() != Type::INTEGRAL) {
         throw std::runtime_error{"division of non integer types is not implemented"};
@@ -430,17 +435,17 @@ void StackMachine::div(std::string leftOperandName, std::string rightOperandName
     storeRegisterValue(registers->getRemainderRegister());
     assembly << instructionSet->xor_(registers->getRemainderRegister(), registers->getRemainderRegister());
     if (rightOperand.isStored()) {
-        assembly << instructionSet->idiv(memoryBaseRegister(rightOperand), memoryOffset(rightOperand));
+        assembly << instructionSet->idiv(memoryOperand(rightOperand));
     } else {
         assembly << instructionSet->idiv(rightOperand.getAssignedRegister());
     }
-    multiplicationRegister.assign(&result);
+    bindResult(multiplicationRegister, result);
 }
 
 void StackMachine::mod(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
-    Value& leftOperand = scopeValues.at(leftOperandName);
-    Value& rightOperand = scopeValues.at(rightOperandName);
-    Value& result = scopeValues.at(resultName);
+    Value& leftOperand = resolve(leftOperandName);
+    Value& rightOperand = resolve(rightOperandName);
+    Value& result = resolve(resultName);
 
     if (result.getType() != Type::INTEGRAL) {
         throw std::runtime_error{"modular division of non integer types is not implemented"};
@@ -451,26 +456,26 @@ void StackMachine::mod(std::string leftOperandName, std::string rightOperandName
     storeRegisterValue(registers->getRemainderRegister());
     assembly << instructionSet->xor_(registers->getRemainderRegister(), registers->getRemainderRegister());
     if (rightOperand.isStored()) {
-        assembly << instructionSet->idiv(memoryBaseRegister(rightOperand), memoryOffset(rightOperand));
+        assembly << instructionSet->idiv(memoryOperand(rightOperand));
     } else {
         assembly << instructionSet->idiv(rightOperand.getAssignedRegister());
     }
-    registers->getRemainderRegister().assign(&result);
+    bindResult(registers->getRemainderRegister(), result);
 }
 
 void StackMachine::inc(std::string operandName) {
-    Value& operand = scopeValues.at(operandName);
+    Value& operand = resolve(operandName);
     if (operand.isStored()) {
-        assembly << instructionSet->inc(memoryBaseRegister(operand), memoryOffset(operand));
+        assembly << instructionSet->inc(memoryOperand(operand));
     } else {
         assembly << instructionSet->inc(operand.getAssignedRegister());
     }
 }
 
 void StackMachine::dec(std::string operandName) {
-    Value& operand = scopeValues.at(operandName);
+    Value& operand = resolve(operandName);
     if (operand.isStored()) {
-        assembly << instructionSet->dec(memoryBaseRegister(operand), memoryOffset(operand));
+        assembly << instructionSet->dec(memoryOperand(operand));
     } else {
         assembly << instructionSet->dec(operand.getAssignedRegister());
     }
@@ -480,21 +485,21 @@ void StackMachine::shiftBy(std::string leftOperandName, std::string rightOperand
         std::string (InstructionSet::*emitShift)(const Register&) const) {
     // Count must live in %cl (RCX) and be tracked so the value is not placed in RCX.
     Register& counterRegister = getCounterRegister();
-    Value& rightOperand = scopeValues.at(rightOperandName);
+    Value& rightOperand = resolve(rightOperandName);
     if (rightOperand.isStored()) {
-        assembly << instructionSet->mov(memoryBaseRegister(rightOperand), memoryOffset(rightOperand), counterRegister);
+        emitLoad(rightOperand, counterRegister);
     } else if (&counterRegister != &rightOperand.getAssignedRegister()) {
         assembly << instructionSet->mov(rightOperand.getAssignedRegister(), counterRegister);
         storeRegisterValue(rightOperand.getAssignedRegister());
     }
     counterRegister.assign(&rightOperand);
 
-    Value& leftOperand = scopeValues.at(leftOperandName);
+    Value& leftOperand = resolve(leftOperandName);
     Register& resultRegister = get64BitRegisterExcluding(counterRegister);
     assignRegisterToSymbol(resultRegister, leftOperand);
     assembly << (instructionSet.get()->*emitShift)(resultRegister);
-    Value& result = scopeValues.at(resultName);
-    resultRegister.assign(&result);
+    Value& result = resolve(resultName);
+    bindResult(resultRegister, result);
 }
 
 void StackMachine::shl(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
@@ -507,7 +512,7 @@ void StackMachine::shr(std::string leftOperandName, std::string rightOperandName
 
 void StackMachine::storeRegisterValue(Register& reg) {
     if (reg.containsUnstoredValue()) {
-        assembly << instructionSet->mov(reg, memoryBaseRegister(*reg.getValue()), memoryOffset(*reg.getValue()));
+        emitStore(reg, *reg.getValue());
         reg.free();
     }
 }
@@ -552,11 +557,13 @@ int StackMachine::memoryOffset(const Value& symbol) const {
     return symbol.getIndex() * MACHINE_WORD_SIZE + calleeSavedRegisters.size() * MACHINE_WORD_SIZE;
 }
 
-const Register& StackMachine::memoryBaseRegister(const Value& symbol) const {
-    if (symbol.isFunctionArgument()) {
-        return registers->getBasePointer();
+MemoryOperand StackMachine::memoryOperand(const Value& symbol, int extraOffset) const {
+    if (symbol.isGlobal()) {
+        return MemoryOperand::global(symbol.getName());
     }
-    return registers->getStackPointer();
+    // Arguments are addressed off rbp, locals off rsp.
+    const Register& base = symbol.isFunctionArgument() ? registers->getBasePointer() : registers->getStackPointer();
+    return MemoryOperand::at(base, memoryOffset(symbol) + extraOffset);
 }
 
 Register& StackMachine::get64BitRegister() {
@@ -572,7 +579,7 @@ Register& StackMachine::get64BitRegister() {
 
 Register& StackMachine::get64BitRegisterExcluding(Register& registerToExclude) {
     for (auto& reg : registers->getGeneralPurposeRegisters()) {
-        if (!reg->containsUnstoredValue()) {
+        if (reg != &registerToExclude && !reg->containsUnstoredValue()) {
             return *reg;
         }
     }
@@ -593,14 +600,14 @@ Register& StackMachine::getCounterRegister() {
 
 Register& StackMachine::assignRegisterTo(Value& symbol) {
     Register& reg = get64BitRegister();
-    assembly << instructionSet->mov(memoryBaseRegister(symbol), memoryOffset(symbol), reg);
+    emitLoad(symbol, reg);
     reg.assign(&symbol);
     return reg;
 }
 
 Register& StackMachine::assignRegisterExcluding(Value& symbol, Register& registerToExclude) {
     Register& reg = get64BitRegisterExcluding(registerToExclude);
-    assembly << instructionSet->mov(memoryBaseRegister(symbol), memoryOffset(symbol), reg);
+    emitLoad(symbol, reg);
     reg.assign(&symbol);
     return reg;
 }
@@ -609,6 +616,14 @@ void StackMachine::setScope(std::vector<Value> variables) {
     for (auto& var : variables) {
         scopeValues.insert({var.getName(), var});
     }
+}
+
+Value& StackMachine::resolve(const std::string& name) {
+    auto local = scopeValues.find(name);
+    if (local != scopeValues.end()) {
+        return local->second;
+    }
+    return globals.at(name);
 }
 
 } // namespace codegen

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -6,10 +6,10 @@
 #include <ostream>
 #include <string>
 #include <vector>
-#include <stack>
 
 #include "InstructionSet.h"
 #include "Amd64Registers.h"
+#include "GlobalVariable.h"
 #include "quadruples/Jump.h"
 #include "Value.h"
 #include "Assembly.h"
@@ -26,7 +26,8 @@ public:
     StackMachine& operator=(const StackMachine&) = delete;
     StackMachine& operator=(StackMachine&&) = default;
 
-    void generatePreamble(std::map<std::string, std::string> constants);
+    void generatePreamble(const std::map<std::string, std::string>& constants,
+            const std::vector<GlobalVariable>& globalVariables);
 
     void startProcedure(std::string procedureName, std::vector<Value> values, std::vector<Value> arguments);
     void endProcedure();
@@ -90,8 +91,14 @@ private:
 
     void storeInMemory(Value& symbol);
 
+    // Resolve a symbol name to its Value: a per-frame local/argument, or a program-scoped global.
+    Value& resolve(const std::string& name);
+
     int memoryOffset(const Value& symbol) const;
-    const Register& memoryBaseRegister(const Value& symbol) const;
+    MemoryOperand memoryOperand(const Value& symbol, int extraOffset = 0) const;
+    void emitLoad(Value& symbol, Register& dest);
+    void emitStore(Register& source, Value& symbol);
+    void bindResult(Register& reg, Value& result);
 
     Register& get64BitRegister();
     Register& get64BitRegisterExcluding(Register& registerToExclude);
@@ -107,6 +114,7 @@ private:
     std::vector<Register*> calleeSavedRegisters;
 
     std::map<std::string, Value> scopeValues;
+    std::map<std::string, Value> globals;
     std::vector<Value*> integerArguments;
     std::vector<Value*> stackArguments;
 

--- a/src/codegen/Value.cpp
+++ b/src/codegen/Value.cpp
@@ -4,12 +4,13 @@
 
 namespace codegen {
 
-Value::Value(std::string name, int index, Type type, int sizeInBytes, bool functionArgument) :
+Value::Value(std::string name, int index, Type type, int sizeInBytes, bool functionArgument, bool global) :
         name { name },
         index { index },
         type { type },
         sizeInBytes { sizeInBytes },
-        functionArgument { functionArgument }
+        functionArgument { functionArgument },
+        global { global }
 {
 }
 
@@ -22,7 +23,8 @@ void Value::assignRegister(Register* reg) {
 }
 
 bool Value::isStored() const {
-    return !assignedRegister;
+    // A global's home is [rel name]; it is never register-resident, so it is always "stored".
+    return global || !assignedRegister;
 }
 
 void Value::removeRegister(Register* reg) {
@@ -38,6 +40,10 @@ Register& Value::getAssignedRegister() const {
 
 bool Value::isFunctionArgument() const {
     return functionArgument;
+}
+
+bool Value::isGlobal() const {
+    return global;
 }
 
 int Value::getIndex() const {

--- a/src/codegen/Value.h
+++ b/src/codegen/Value.h
@@ -12,13 +12,8 @@ enum class Type {
 
 class Value {
 public:
-    Value(std::string name, int index, Type type, int sizeInBytes, bool functionArgument = false);
+    Value(std::string name, int index, Type type, int sizeInBytes, bool functionArgument = false, bool global = false);
     ~Value() = default;
-    //Value(const Value&) = delete;
-    //Value(Value&&) = delete;
-
-    //Value& operator=(const Value&) = delete;
-    //Value& operator=(Value&&) = delete;
 
     std::string getName() const;
 
@@ -28,6 +23,7 @@ public:
     bool isStored() const;
 
     bool isFunctionArgument() const;
+    bool isGlobal() const;
     int getIndex() const;
     Type getType() const;
     int getSizeInBytes() const;
@@ -38,6 +34,7 @@ private:
     Type type;
     int sizeInBytes;
     bool functionArgument;
+    bool global;
 
     Register* assignedRegister { nullptr };
 };

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -4,6 +4,7 @@
 
 #include "CompilerComponentsFactory.h"
 #include "codegen/AssemblyGenerator.h"
+#include "codegen/GlobalVariable.h"
 #include "codegen/QuadrupleGenerator.h"
 #include "parser/SyntaxTreeBuilder.h"
 #include "scanner/Scanner.h"
@@ -44,6 +45,15 @@ void Compiler::compile(std::string sourceFileName) const {
     semantic_analyzer::SemanticAnalyzer semanticAnalyzer;
     semanticAnalyzer.analyze(*syntaxTree);
 
+    std::vector<codegen::GlobalVariable> globalVariables;
+    for (const auto& global : semanticAnalyzer.getGlobalVariables()) {
+        globalVariables.push_back({
+                global.getName(),
+                global.getType().getSize(),
+                std::to_string(global.getConstantInitializer().value_or(0))
+        });
+    }
+
     codegen::QuadrupleGenerator quadrupleGenerator;
     // TODO: encapsulate quadruples behind intermediate form object
     std::vector<std::unique_ptr<codegen::Quadruple>> quadruples = quadrupleGenerator.generateQuadruplesFrom(*syntaxTree);
@@ -62,7 +72,7 @@ void Compiler::compile(std::string sourceFileName) const {
     std::string assemblyFileName { sourceFileName + ".S" };
     std::ofstream assemblyFile { assemblyFileName };
     std::unique_ptr<codegen::AssemblyGenerator> assemblyGenerator = compilerComponentsFactory.makeAssemblyGenerator(&assemblyFile);
-    assemblyGenerator->generateAssemblyCode(std::move(quadruples), semanticAnalyzer.getConstants());
+    assemblyGenerator->generateAssemblyCode(std::move(quadruples), semanticAnalyzer.getConstants(), globalVariables);
     assemblyFile.close();
 
     if (assemble(assemblyFileName) == 0 && link(sourceFileName) == 0) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -46,9 +46,20 @@ void SemanticAnalysisVisitor::visit(ast::Declaration& declaration) {
         auto type = declarator->getFundamentalType(baseType);
         if (type.isVoid()) {
             semanticError("variable `" + declarator->getName() + "` declared void", declarator->getContext());
+        } else if (symbolTable.isAtFileScope() && symbolTable.hasFunction(declarator->getName())) {
+            semanticError("symbol `" + declarator->getName() + "` declaration conflicts with function of the same name",
+                    declarator->getContext());
         } else if (symbolTable.insertSymbol(declarator->getName(), type, declarator->getContext())) {
             declarator->setHolder(symbolTable.lookup(declarator->getName()));
             // TODO: type check initializers
+            if (declarator->hasInitializer() && symbolTable.isAtFileScope()) {
+                long initValue = 0;
+                if (declarator->getInitializer()->evaluateConstant(initValue)) {
+                    symbolTable.setGlobalInitializer(declarator->getName(), initValue);
+                } else {
+                    semanticError("global initializer is not a constant expression", declarator->getContext());
+                }
+            }
         } else {
             semanticError(
                     "symbol `" + declarator->getName() +
@@ -375,6 +386,11 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDeclarator& declarator) {
 
     // FIXME: return type is not known at this point!
     type::Type functionType = type::function(type::signedInteger(), arguments);
+    if (symbolTable.hasGlobalVariable(declarator.getName())) {
+        semanticError("function `" + declarator.getName() + "` conflicts with global variable of the same name",
+                declarator.getContext());
+        return;
+    }
     FunctionEntry functionEntry = symbolTable.insertFunction(
             declarator.getName(),
             functionType.getFunction(),
@@ -398,6 +414,9 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
     function.visitReturnType(*this);
     function.visitDeclarator(*this);
 
+    if (!symbolTable.hasFunction(function.getName())) {
+        return;
+    }
     function.setSymbol(symbolTable.findFunction(function.getName()));
     symbolTable.startFunction(function.getName(), argumentNames);
     // Parameters and outermost body declarations share one scope (C); do not enterBlockScope.
@@ -432,6 +451,10 @@ bool SemanticAnalysisVisitor::successfulSemanticAnalysis() const {
 
 std::map<std::string, std::string> SemanticAnalysisVisitor::getConstants() const {
     return symbolTable.getConstants();
+}
+
+std::vector<ValueEntry> SemanticAnalysisVisitor::getGlobalVariables() const {
+    return symbolTable.getGlobalVariables();
 }
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -63,6 +63,7 @@ public:
 
     bool successfulSemanticAnalysis() const;
     std::map<std::string, std::string> getConstants() const;
+    std::vector<ValueEntry> getGlobalVariables() const;
 
     void printSymbolTable() const;
 

--- a/src/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/src/semantic_analyzer/SemanticAnalyzer.cpp
@@ -19,6 +19,10 @@ std::map<std::string, std::string> SemanticAnalyzer::getConstants() const {
     return analyzerVisitor.getConstants();
 }
 
+std::vector<ValueEntry> SemanticAnalyzer::getGlobalVariables() const {
+    return analyzerVisitor.getGlobalVariables();
+}
+
 void SemanticAnalyzer::visit(ast::AbstractSyntaxTree& tree) {
     for (const auto& treeNode : tree) {
         treeNode->accept(analyzerVisitor);

--- a/src/semantic_analyzer/SemanticAnalyzer.h
+++ b/src/semantic_analyzer/SemanticAnalyzer.h
@@ -2,10 +2,12 @@
 #define SYNTAXTREEBUILDERDECORATOR_H_
 
 #include <iostream>
+#include <vector>
 
 #include "parser/SyntaxTree.h"
 #include "parser/SyntaxTreeVisitor.h"
 #include "semantic_analyzer/SemanticAnalysisVisitor.h"
+#include "semantic_analyzer/ValueEntry.h"
 
 namespace semantic_analyzer {
 
@@ -16,6 +18,7 @@ public:
 
     void analyze(parser::SyntaxTree& syntaxTree);
     std::map<std::string, std::string> getConstants() const;
+    std::vector<ValueEntry> getGlobalVariables() const;
 
     void printSymbolTable() const;
 

--- a/src/semantic_analyzer/SymbolTable.cpp
+++ b/src/semantic_analyzer/SymbolTable.cpp
@@ -27,6 +27,9 @@ namespace semantic_analyzer {
 const std::string SymbolTable::SCOPE_PREFIX = "$s";
 
 bool SymbolTable::insertSymbol(std::string name, const type::Type& type, translation_unit::Context context) {
+    if (isAtFileScope()) {
+        return globalScope.insertSymbol(name, type, context, true);
+    }
     return functionScopes.back().insertSymbol(scopePrefix(currentScopeId()) + name, type, context);
 }
 
@@ -48,6 +51,26 @@ FunctionEntry SymbolTable::insertFunction(std::string name, type::Function funct
 
 FunctionEntry SymbolTable::findFunction(std::string name) const {
     return functions.at(name);
+}
+
+bool SymbolTable::hasFunction(const std::string& name) const {
+    return functions.find(name) != functions.end();
+}
+
+bool SymbolTable::isAtFileScope() const {
+    return scopeIdStack.empty();
+}
+
+bool SymbolTable::hasGlobalVariable(const std::string& name) const {
+    try {
+        return !globalScope.lookup(name).getType().isFunction();
+    } catch (std::out_of_range&) {
+        return false;
+    }
+}
+
+void SymbolTable::setGlobalInitializer(const std::string& name, long constantValue) {
+    globalScope.setConstantInitializer(name, constantValue);
 }
 
 bool SymbolTable::hasSymbol(std::string symbolName) const {
@@ -72,6 +95,9 @@ ValueEntry SymbolTable::lookup(std::string name) const {
 }
 
 ValueEntry SymbolTable::createTemporarySymbol(type::Type type) {
+    if (functionScopes.empty()) {
+        return globalScope.createTemporarySymbol(type);
+    }
     return functionScopes.back().createTemporarySymbol(type);
 }
 
@@ -122,6 +148,16 @@ std::vector<ValueEntry> SymbolTable::getCurrentScopeArguments() const {
 
 std::map<std::string, std::string> SymbolTable::getConstants() const {
     return constants;
+}
+
+std::vector<ValueEntry> SymbolTable::getGlobalVariables() const {
+    std::vector<ValueEntry> globals;
+    for (const auto& entry : globalScope.getSymbols()) {
+        if (entry.second.isGlobal()) {
+            globals.push_back(entry.second);
+        }
+    }
+    return globals;
 }
 
 void SymbolTable::printTable() const {

--- a/src/semantic_analyzer/SymbolTable.h
+++ b/src/semantic_analyzer/SymbolTable.h
@@ -32,6 +32,12 @@ public:
     std::map<std::string, ValueEntry> getCurrentScopeSymbols() const;
     std::vector<ValueEntry> getCurrentScopeArguments() const;
     std::map<std::string, std::string> getConstants() const;
+    // File-scope variables (isGlobal); constant init is on each ValueEntry when present.
+    std::vector<ValueEntry> getGlobalVariables() const;
+    void setGlobalInitializer(const std::string& name, long constantValue);
+    bool hasFunction(const std::string& name) const;
+    bool hasGlobalVariable(const std::string& name) const;
+    bool isAtFileScope() const;
 
     void printTable() const;
 

--- a/src/semantic_analyzer/ValueEntry.cpp
+++ b/src/semantic_analyzer/ValueEntry.cpp
@@ -5,12 +5,13 @@
 
 namespace semantic_analyzer {
 
-ValueEntry::ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index) :
+ValueEntry::ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index, bool global) :
         name { name },
         type { type },
         context { context },
         index { index },
-        temp { tmp }
+        temp { tmp },
+        global { global }
 {
 }
 
@@ -34,6 +35,18 @@ int ValueEntry::getIndex() const {
 
 std::string ValueEntry::getName() const {
     return name;
+}
+
+bool ValueEntry::isGlobal() const {
+    return global;
+}
+
+void ValueEntry::setConstantInitializer(long value) {
+    constantInitializer = value;
+}
+
+std::optional<long> ValueEntry::getConstantInitializer() const {
+    return constantInitializer;
 }
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/ValueEntry.h
+++ b/src/semantic_analyzer/ValueEntry.h
@@ -2,6 +2,7 @@
 #define VALUEENTRY_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "translation_unit/Context.h"
@@ -11,12 +12,17 @@ namespace semantic_analyzer {
 
 class ValueEntry {
 public:
-    ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index);
+    ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index, bool global = false);
 
     std::string getName() const;
+    bool isGlobal() const;
     type::Type getType() const;
     translation_unit::Context getContext() const;
     int getIndex() const;
+
+    // Folded integer constant initializer for file-scope variables (unset means default 0).
+    void setConstantInitializer(long value);
+    std::optional<long> getConstantInitializer() const;
 
     std::string to_string() const;
 
@@ -27,6 +33,8 @@ private:
     int index;
 
     bool temp;
+    bool global;
+    std::optional<long> constantInitializer;
 };
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/ValueScope.cpp
+++ b/src/semantic_analyzer/ValueScope.cpp
@@ -33,7 +33,7 @@ private:
 
 namespace semantic_analyzer {
 
-bool ValueScope::insertSymbol(std::string name, const type::Type& type, translation_unit::Context context) {
+bool ValueScope::insertSymbol(std::string name, const type::Type& type, translation_unit::Context context, bool global) {
     if (localSymbols.find(name) != localSymbols.end()) {
         return false;
     }
@@ -42,7 +42,7 @@ bool ValueScope::insertSymbol(std::string name, const type::Type& type, translat
     if (existingArgument != arguments.end()) {
         return false;
     }
-    ValueEntry entry { name, type, false, context, static_cast<int>(localSymbols.size()) };
+    ValueEntry entry { name, type, false, context, static_cast<int>(localSymbols.size()), global };
     localSymbols.insert(std::make_pair(name, entry));
     return true;
 }
@@ -73,6 +73,10 @@ ValueEntry ValueScope::lookup(std::string name) const {
         return *existingArgument;
     }
     return localSymbols.at(name);
+}
+
+void ValueScope::setConstantInitializer(const std::string& name, long value) {
+    localSymbols.at(name).setConstantInitializer(value);
 }
 
 ValueEntry ValueScope::createTemporarySymbol(type::Type type) {

--- a/src/semantic_analyzer/ValueScope.h
+++ b/src/semantic_analyzer/ValueScope.h
@@ -13,11 +13,12 @@ namespace semantic_analyzer {
 
 class ValueScope {
 public:
-    bool insertSymbol(std::string name, const type::Type& type, translation_unit::Context context);
+    bool insertSymbol(std::string name, const type::Type& type, translation_unit::Context context, bool global = false);
     void insertFunctionArgument(std::string name, const type::Type& type, translation_unit::Context context);
     ValueEntry createTemporarySymbol(type::Type type);
     bool isSymbolDefined(std::string symbolName) const;
     ValueEntry lookup(std::string name) const;
+    void setConstantInitializer(const std::string& name, long value);
 
     std::map<std::string, ValueEntry> getSymbols() const;
     std::vector<ValueEntry> getArguments() const;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(functionalTest gtest.cpp
         functionalTest/ExpressionTest.cpp
         functionalTest/ScopeTest.cpp
         functionalTest/IntegrationTest.cpp
+        functionalTest/GlobalVariablesTest.cpp
         )
 target_link_libraries(functionalTest gmock driver translation_unit scanner util parser testUtil)
 add_test(functionalTest functionalTest)

--- a/test/src/codegenTest/ATandTInstructionSetTests.cpp
+++ b/test/src/codegenTest/ATandTInstructionSetTests.cpp
@@ -2,6 +2,7 @@
 #include "gmock/gmock.h"
 
 #include "codegen/ATandTInstructionSet.h"
+#include "codegen/MemoryOperand.h"
 #include "codegen/Register.h"
 
 #include <memory>
@@ -26,13 +27,13 @@ TEST(ATandTInstructionSet, emitsPreamble) {
 TEST(ATandTInstructionSet, emitsMovToMemoryWithOffset) {
     Register source { "src" };
     Register memoryBase { "memBase" };
-    EXPECT_THAT(instructions.mov(source, memoryBase, 42), Eq("movq %src, -42(%memBase)"));
+    EXPECT_THAT(instructions.mov(source, MemoryOperand::at(memoryBase, 42)), Eq("movq %src, -42(%memBase)"));
 }
 
 TEST(ATandTInstructionSet, emitsMovToMemoryWithoutOffset) {
     Register source { "src" };
     Register memoryBase { "memBase" };
-    EXPECT_THAT(instructions.mov(source, memoryBase, 0), Eq("movq %src, (%memBase)"));
+    EXPECT_THAT(instructions.mov(source, MemoryOperand::at(memoryBase, 0)), Eq("movq %src, (%memBase)"));
 }
 
 TEST(ATandTInstructionSet, emitsQuadSubtract) {

--- a/test/src/functionalTest/GlobalVariablesTest.cpp
+++ b/test/src/functionalTest/GlobalVariablesTest.cpp
@@ -1,0 +1,518 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, globalAssignedInMain) {
+    SourceProgram program{R"prg(
+        int g;
+
+        int main() {
+            g = 3;
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, globalSharedAcrossFunctions) {
+    SourceProgram program{R"prg(
+        int g;
+
+        void set() {
+            g = 7;
+            return;
+        }
+
+        int main() {
+            set();
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+TEST(Compiler, globalReadBeforeWriteIsZero) {
+    SourceProgram program{R"prg(
+        int g;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("0");
+}
+
+TEST(Compiler, localShadowsGlobal) {
+    SourceProgram program{R"prg(
+        int g;
+
+        int main() {
+            g = 5;
+            {
+                int g;
+                g = 1;
+                printf("%d", g);
+            }
+            printf(" %d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 5");
+}
+
+TEST(Compiler, globalUpdatedFromCalleeVisibleInCaller) {
+    SourceProgram program{R"prg(
+        int counter;
+
+        int inc() {
+            counter = counter + 1;
+            return counter;
+        }
+
+        int main() {
+            printf("%d ", inc());
+            printf("%d", counter);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 1");
+}
+
+TEST(Compiler, globalInitializer) {
+    SourceProgram program{R"prg(
+        int g = 5;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5");
+}
+
+TEST(Compiler, globalInitializerExpression) {
+    SourceProgram program{R"prg(
+        int g = 2 + 3;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5");
+}
+
+TEST(Compiler, globalInitializerNestedExpression) {
+    SourceProgram program{R"prg(
+        int g = (1 + 2) * 4 - 1;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("11");
+}
+
+TEST(Compiler, globalInitializerShift) {
+    SourceProgram program{R"prg(
+        int g = 1 << 4;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("16");
+}
+
+TEST(Compiler, globalInitializerBitwise) {
+    SourceProgram program{R"prg(
+        int g = (5 & 3) | 8;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9");
+}
+
+TEST(Compiler, globalInitializerComparison) {
+    SourceProgram program{R"prg(
+        int g = 2 < 3;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1");
+}
+
+TEST(Compiler, globalInitializerCharConstant) {
+    SourceProgram program{R"prg(
+        int g = 'A';
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("65");
+}
+
+TEST(Compiler, twoGlobalsInOneExpression) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+
+        int main() {
+            a = 2;
+            b = 40;
+            printf("%d", a + b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
+TEST(Compiler, globalVariableNameCollidesWithFunctionRejected) {
+    SourceProgram program{R"prg(
+        int foo;
+
+        int foo() {
+            return 0;
+        }
+
+        int main() {
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("error");
+}
+
+// An initialized local that shadows a global must not overwrite the global's value.
+TEST(Compiler, initializedLocalShadowingGlobalKeepsGlobalValue) {
+    SourceProgram program{R"prg(
+        int g = 1;
+
+        int getGlobal() {
+            return g;
+        }
+
+        int main() {
+            int g = 2;
+            printf("%d %d", g, getGlobal());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2 1");
+}
+
+// A local that shadows a global may have a non-constant initializer (it is not a global initializer).
+TEST(Compiler, localShadowingGlobalAllowsNonConstantInitializer) {
+    SourceProgram program{R"prg(
+        int g = 1;
+
+        int f(int p) {
+            int g = p;
+            return g;
+        }
+
+        int main() {
+            printf("%d", f(7));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+// A global operand must work in every arithmetic/bitwise/shift op, not just + and -,
+// including the two-stored-operands path (two globals).
+TEST(Compiler, twoGlobalsInMultiplication) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+        int main() {
+            a = 6;
+            b = 7;
+            printf("%d", a * b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
+TEST(Compiler, twoGlobalsInDivisionAndModulo) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+        int main() {
+            a = 20;
+            b = 6;
+            printf("%d %d", a / b, a % b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3 2");
+}
+
+TEST(Compiler, twoGlobalsInBitwiseOps) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+        int main() {
+            a = 6;
+            b = 3;
+            printf("%d %d %d", a & b, a | b, a ^ b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2 7 5");
+}
+
+TEST(Compiler, globalOperandInShifts) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+        int main() {
+            a = 8;
+            b = 2;
+            printf("%d %d", a << b, a >> b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("32 2");
+}
+
+// A global read into a register (here as a shift count) must not stay register-resident:
+// a subsequent write to that global has to reach its [rel g] home, so the caller sees it.
+TEST(Compiler, globalWrittenAfterBeingUsedAsShiftCountIsVisibleInCaller) {
+    SourceProgram program{R"prg(
+        int g;
+        int t;
+
+        void use() {
+            t = 1 << g;
+            g = 5;
+            return;
+        }
+
+        int main() {
+            g = 2;
+            use();
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5");
+}
+
+// Signed division/modulo must sign-extend the dividend; a negative global dividend must work.
+// DISABLED: this is a pre-existing signed-division bug (idiv setup uses `xor rdx,rdx` instead of
+// `cqo`), not a globals issue. It fails identically for locals/registers. Enable when that is fixed.
+TEST(Compiler, DISABLED_signedDivisionAndModuloOfNegativeGlobal) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+        int main() {
+            a = -20;
+            b = 6;
+            printf("%d %d", a / b, a % b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("-3 -2");
+}
+
+// Compound assignment makes the global the RESULT of the op (g op= b lowers to Op(g, b, g)).
+// The computed value must reach [rel g], not stay register-resident.
+TEST(Compiler, globalPlusEquals) {
+    SourceProgram program{R"prg(
+        int g;
+        int main() {
+            g = 10;
+            g += 5;
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("15");
+}
+
+TEST(Compiler, globalMinusEquals) {
+    SourceProgram program{R"prg(
+        int g;
+        int main() {
+            g = 10;
+            g -= 3;
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+TEST(Compiler, globalTimesEquals) {
+    SourceProgram program{R"prg(
+        int g;
+        int main() {
+            g = 6;
+            g *= 7;
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
+TEST(Compiler, globalDivideAndModuloEquals) {
+    SourceProgram program{R"prg(
+        int g;
+        int h;
+        int main() {
+            g = 20;
+            g /= 6;
+            h = 20;
+            h %= 6;
+            printf("%d %d", g, h);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3 2");
+}
+
+TEST(Compiler, globalShiftEquals) {
+    SourceProgram program{R"prg(
+        int g;
+        int h;
+        int main() {
+            g = 1;
+            g <<= 4;
+            h = 64;
+            h >>= 2;
+            printf("%d %d", g, h);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("16 16");
+}
+
+TEST(Compiler, globalBitwiseEquals) {
+    SourceProgram program{R"prg(
+        int g;
+        int h;
+        int k;
+        int main() {
+            g = 6;
+            g &= 3;
+            h = 6;
+            h |= 1;
+            k = 6;
+            k ^= 3;
+            printf("%d %d %d", g, h, k);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2 7 5");
+}
+
+// A compound-assign write to a global must be visible across function boundaries.
+TEST(Compiler, globalCompoundAssignVisibleAcrossFunction) {
+    SourceProgram program{R"prg(
+        int counter;
+
+        void bump() {
+            counter += 10;
+            return;
+        }
+
+        int main() {
+            counter = 0;
+            bump();
+            bump();
+            printf("%d", counter);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20");
+}
+
+// A leading-zero literal is octal in C; the global initializer must fold in the right base.
+TEST(Compiler, globalInitializerOctal) {
+    SourceProgram program{R"prg(
+        int g = 010;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8");
+}
+
+// Logical && is a constant expression; a global initializer using it must fold to 0/1.
+TEST(Compiler, globalInitializerLogicalAnd) {
+    SourceProgram program{R"prg(
+        int g = 1 && 0;
+        int h = 2 && 3;
+
+        int main() {
+            printf("%d %d", g, h);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("0 1");
+}
+
+// Logical || is a constant expression; a global initializer using it must fold to 0/1.
+TEST(Compiler, globalInitializerLogicalOr) {
+    SourceProgram program{R"prg(
+        int g = 0 || 0;
+        int h = 0 || 5;
+
+        int main() {
+            printf("%d %d", g, h);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("0 1");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- File-scope variables in `globalScope` with `isGlobal` on `ValueEntry` / codegen `Value`, optional folded integer initializers on the entry.
- AST `evaluateConstant` for static init; reject non-constant global initializers; clash diagnostics for variable vs function names.
- `MemoryOperand` for stack vs `[rel name]` addressing; StackMachine `resolve` / always-store globals via `bindResult`.
- Preamble emits `dq` globals; driver maps `getGlobalVariables()` to header-only `GlobalVariable`.
- `GlobalVariablesTest` plus AT&T tests updated for `MemoryOperand`.

Interim model uses `isGlobal` on `Value`; follow-up work will split Address vs temp Value per design discussion.

## Test plan
- [x] Local `functionalTest` / full suite before push
- [ ] CI `build`
- [ ] Spot-check: `int g = 2+3;`, shadowing, compound assign across functions