### PR TITLE
Codegen Address object homes (phase B)

### DIFF
--- a/src/codegen/Address.h
+++ b/src/codegen/Address.h
@@ -8,11 +8,12 @@ namespace codegen {
 
 // Where a named object lives (not a register-allocation temp).
 //
-// Policy (interim, while Value still carries storage flags):
-// - Locals: FrameBase::Rsp + slot offset; may also be register-cached on a Value.
-// - Stack arguments: FrameBase::Rbp + arg offset; same cache model.
-// - Globals: GlobalLabel; always committed through memory (bindResult stores).
-// Phase 2+ will register Address in an object map and slim Value to temps/caches only.
+// Policy:
+// - Locals / register-arg spill slots: FrameBase::Rsp + offset; Value is a register cache.
+// - Stack arguments: FrameBase::Rbp + offset; same cache model.
+// - Globals: GlobalLabel in StackMachine::globalHomes; bindResult commits stores (isGlobalHome).
+// - Pure temps: no object home; only a Value (spill uses Value flags / index until Phase 3).
+// Homes are registered in globalHomes / frameHomes; addressOf prefers those over Value flags.
 
 enum class FrameBase {
     Rsp,

--- a/src/codegen/Address.h
+++ b/src/codegen/Address.h
@@ -1,0 +1,57 @@
+#ifndef ADDRESS_H_
+#define ADDRESS_H_
+
+#include <string>
+#include <utility>
+
+namespace codegen {
+
+// Where a named object lives (not a register-allocation temp).
+//
+// Policy (interim, while Value still carries storage flags):
+// - Locals: FrameBase::Rsp + slot offset; may also be register-cached on a Value.
+// - Stack arguments: FrameBase::Rbp + arg offset; same cache model.
+// - Globals: GlobalLabel; always committed through memory (bindResult stores).
+// Phase 2+ will register Address in an object map and slim Value to temps/caches only.
+
+enum class FrameBase {
+    Rsp,
+    Rbp
+};
+
+class Address {
+public:
+    static Address frame(FrameBase base, int offsetBytes, int sizeBytes) {
+        return Address { Kind::Frame, base, offsetBytes, sizeBytes, {} };
+    }
+
+    static Address globalLabel(std::string label, int sizeBytes) {
+        return Address { Kind::Global, FrameBase::Rsp, 0, sizeBytes, std::move(label) };
+    }
+
+    bool isGlobal() const { return kind_ == Kind::Global; }
+    FrameBase frameBase() const { return frameBase_; }
+    int offsetBytes() const { return offsetBytes_; }
+    int sizeBytes() const { return sizeBytes_; }
+    const std::string& label() const { return label_; }
+
+private:
+    enum class Kind { Frame, Global };
+
+    Address(Kind kind, FrameBase frameBase, int offsetBytes, int sizeBytes, std::string label) :
+            kind_ { kind },
+            frameBase_ { frameBase },
+            offsetBytes_ { offsetBytes },
+            sizeBytes_ { sizeBytes },
+            label_ { std::move(label) } {}
+
+    Kind kind_;
+    FrameBase frameBase_;
+    int offsetBytes_;
+    int sizeBytes_;
+    std::string label_;
+};
+
+} // namespace codegen
+
+#endif // ADDRESS_H_

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(codegen
         quadruples/ValueCompare.h
         quadruples/Xor.h
         quadruples/ZeroCompare.h
+        Address.h
         Amd64Registers.h
         AssemblyGenerator.h
         ATandTInstructionSet.h
@@ -81,6 +82,7 @@ add_library(codegen
         InstructionSet.h
         GlobalVariable.h
         IntelInstructionSet.h
+        MemoryOperand.h
         QuadrupleGenerator.h
         Register.h
         StackMachine.h

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -121,10 +121,10 @@ void StackMachine::emitStore(Register& source, Value& symbol) {
     assembly << instructionSet->mov(source, memoryOperand(symbol));
 }
 
-// Bind a freshly computed result to its destination symbol. A global is never register-resident,
-// so write it straight to [rel name]; a local/temp stays register-resident for lazy write-back.
+// Bind a freshly computed result to its destination symbol. Global homes are never register-
+// resident (commit via Address); locals/temps stay register-resident for lazy write-back.
 void StackMachine::bindResult(Register& reg, Value& result) {
-    if (result.isGlobal()) {
+    if (addressOf(result).isGlobal()) {
         emitStore(reg, result);
     } else {
         reg.assign(&result);
@@ -557,13 +557,25 @@ int StackMachine::memoryOffset(const Value& symbol) const {
     return symbol.getIndex() * MACHINE_WORD_SIZE + calleeSavedRegisters.size() * MACHINE_WORD_SIZE;
 }
 
-MemoryOperand StackMachine::memoryOperand(const Value& symbol, int extraOffset) const {
+Address StackMachine::addressOf(const Value& symbol, int extraOffset) const {
     if (symbol.isGlobal()) {
-        return MemoryOperand::global(symbol.getName());
+        return Address::globalLabel(symbol.getName(), symbol.getSizeInBytes());
     }
-    // Arguments are addressed off rbp, locals off rsp.
-    const Register& base = symbol.isFunctionArgument() ? registers->getBasePointer() : registers->getStackPointer();
-    return MemoryOperand::at(base, memoryOffset(symbol) + extraOffset);
+    const FrameBase base = symbol.isFunctionArgument() ? FrameBase::Rbp : FrameBase::Rsp;
+    return Address::frame(base, memoryOffset(symbol) + extraOffset, symbol.getSizeInBytes());
+}
+
+MemoryOperand StackMachine::memoryOperand(const Address& address) const {
+    if (address.isGlobal()) {
+        return MemoryOperand::global(address.label());
+    }
+    const Register& base = address.frameBase() == FrameBase::Rbp ?
+            registers->getBasePointer() : registers->getStackPointer();
+    return MemoryOperand::at(base, address.offsetBytes());
+}
+
+MemoryOperand StackMachine::memoryOperand(const Value& symbol, int extraOffset) const {
+    return memoryOperand(addressOf(symbol, extraOffset));
 }
 
 Register& StackMachine::get64BitRegister() {

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -19,8 +19,9 @@ StackMachine::StackMachine(std::ostream *ostream, std::unique_ptr<InstructionSet
 void StackMachine::generatePreamble(const std::map<std::string, std::string>& constants,
         const std::vector<GlobalVariable>& globalVariables) {
     assembly.raw(instructionSet->preamble(constants, globalVariables));
-    // Register every global once with real size/type; resolve() falls back here for non-frame names.
+    // Global object homes + Value caches for resolve() (register assign still needs a Value).
     for (const auto& global : globalVariables) {
+        globalHomes.emplace(global.name, Address::globalLabel(global.name, global.sizeInBytes));
         globals.emplace(global.name, global.toValue());
     }
 }
@@ -28,6 +29,7 @@ void StackMachine::generatePreamble(const std::map<std::string, std::string>& co
 void StackMachine::startProcedure(std::string procedureName, std::vector<Value> values, std::vector<Value> arguments) {
 
     emptyGeneralPurposeRegisters();
+    frameHomes.clear();
     assembly.label(instructionSet->label(procedureName));
     assembly << instructionSet->push(registers->getBasePointer());
     assembly << instructionSet->mov(registers->getStackPointer(), registers->getBasePointer());
@@ -61,11 +63,16 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
     }
 
     pushCalleeSavedRegisters();
+    // Frame offsets include callee-saved space; register homes only after that is known.
+    for (const auto& entry : scopeValues) {
+        registerFrameHome(entry.second);
+    }
 }
 
 void StackMachine::endProcedure() {
     emptyGeneralPurposeRegisters();
     scopeValues.clear();
+    frameHomes.clear();
     calleeSavedRegisters.clear();
 }
 
@@ -121,10 +128,10 @@ void StackMachine::emitStore(Register& source, Value& symbol) {
     assembly << instructionSet->mov(source, memoryOperand(symbol));
 }
 
-// Bind a freshly computed result to its destination symbol. Global homes are never register-
-// resident (commit via Address); locals/temps stay register-resident for lazy write-back.
+// Bind a freshly computed result to its destination symbol. Global object homes are never
+// register-resident (commit via Address); locals/temps stay register-resident for lazy write-back.
 void StackMachine::bindResult(Register& reg, Value& result) {
-    if (addressOf(result).isGlobal()) {
+    if (isGlobalHome(result.getName())) {
         emitStore(reg, result);
     } else {
         reg.assign(&result);
@@ -557,12 +564,42 @@ int StackMachine::memoryOffset(const Value& symbol) const {
     return symbol.getIndex() * MACHINE_WORD_SIZE + calleeSavedRegisters.size() * MACHINE_WORD_SIZE;
 }
 
-Address StackMachine::addressOf(const Value& symbol, int extraOffset) const {
+Address StackMachine::addressFromValueFlags(const Value& symbol, int extraOffset) const {
     if (symbol.isGlobal()) {
         return Address::globalLabel(symbol.getName(), symbol.getSizeInBytes());
     }
     const FrameBase base = symbol.isFunctionArgument() ? FrameBase::Rbp : FrameBase::Rsp;
     return Address::frame(base, memoryOffset(symbol) + extraOffset, symbol.getSizeInBytes());
+}
+
+void StackMachine::registerFrameHome(const Value& symbol) {
+    frameHomes.insert_or_assign(symbol.getName(), addressFromValueFlags(symbol, 0));
+}
+
+bool StackMachine::hasObjectHome(const std::string& name) const {
+    return frameHomes.count(name) || globalHomes.count(name);
+}
+
+bool StackMachine::isGlobalHome(const std::string& name) const {
+    return globalHomes.count(name) > 0;
+}
+
+Address StackMachine::addressOf(const Value& symbol, int extraOffset) const {
+    const std::string& name = symbol.getName();
+    auto frame = frameHomes.find(name);
+    if (frame != frameHomes.end()) {
+        const Address& home = frame->second;
+        if (extraOffset == 0) {
+            return home;
+        }
+        return Address::frame(home.frameBase(), home.offsetBytes() + extraOffset, home.sizeBytes());
+    }
+    auto global = globalHomes.find(name);
+    if (global != globalHomes.end()) {
+        return global->second;
+    }
+    // Pure temps (and any name without a registered home): derive from Value flags if set.
+    return addressFromValueFlags(symbol, extraOffset);
 }
 
 MemoryOperand StackMachine::memoryOperand(const Address& address) const {
@@ -627,6 +664,7 @@ Register& StackMachine::assignRegisterExcluding(Value& symbol, Register& registe
 void StackMachine::setScope(std::vector<Value> variables) {
     for (auto& var : variables) {
         scopeValues.insert({var.getName(), var});
+        registerFrameHome(var);
     }
 }
 

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "Address.h"
 #include "InstructionSet.h"
 #include "Amd64Registers.h"
 #include "GlobalVariable.h"
@@ -95,6 +96,9 @@ private:
     Value& resolve(const std::string& name);
 
     int memoryOffset(const Value& symbol) const;
+    // Build an Address from legacy Value storage flags (adapter until Phase 2 object map).
+    Address addressOf(const Value& symbol, int extraOffset = 0) const;
+    MemoryOperand memoryOperand(const Address& address) const;
     MemoryOperand memoryOperand(const Value& symbol, int extraOffset = 0) const;
     void emitLoad(Value& symbol, Register& dest);
     void emitStore(Register& source, Value& symbol);

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -96,8 +96,13 @@ private:
     Value& resolve(const std::string& name);
 
     int memoryOffset(const Value& symbol) const;
-    // Build an Address from legacy Value storage flags (adapter until Phase 2 object map).
+    // Prefer registered object homes; fall back to Value storage flags (temps have no home).
     Address addressOf(const Value& symbol, int extraOffset = 0) const;
+    Address addressFromValueFlags(const Value& symbol, int extraOffset = 0) const;
+    bool hasObjectHome(const std::string& name) const;
+    // True if this name is a global object home (must commit stores; never stay reg-only).
+    bool isGlobalHome(const std::string& name) const;
+    void registerFrameHome(const Value& symbol);
     MemoryOperand memoryOperand(const Address& address) const;
     MemoryOperand memoryOperand(const Value& symbol, int extraOffset = 0) const;
     void emitLoad(Value& symbol, Register& dest);
@@ -117,8 +122,12 @@ private:
     std::unique_ptr<Amd64Registers> registers;
     std::vector<Register*> calleeSavedRegisters;
 
+    // Allocation / register-cache entities (temps and variable caches share IR names with homes).
     std::map<std::string, Value> scopeValues;
     std::map<std::string, Value> globals;
+    // Object homes: where named variables live (not temps). Looked up before Value flags.
+    std::map<std::string, Address> globalHomes;
+    std::map<std::string, Address> frameHomes;
     std::vector<Value*> integerArguments;
     std::vector<Value*> stackArguments;
 


### PR DESCRIPTION
## Summary
Phase **B** of Address vs temp `Value`: explicit object homes in codegen (no behavior change intended).

### B1
- Add `Address` (frame `Rsp`/`Rbp` + offset + size, or global label)
- Lower mem via `addressOf` → `Address` → `MemoryOperand`
- Policy notes on `Address.h`

### B2
- `globalHomes` (preamble) and `frameHomes` (per procedure)
- `addressOf` prefers registered homes over `Value` storage flags
- `bindResult` commits stores when `isGlobalHome(name)`
- Frame homes registered **after** callee-saved push so offsets match `memoryOffset`

`Value` flags remain for temp spill and for deriving homes at registration (Phase **C** will slim `Value`).

Stacked commits on `refactor/codegen-address-phase1`; not merging until you say so.

## Test plan
- [x] Full local `ctest` on the branch
- [ ] CI `build`