### PR TITLE
Separate object homes from register allocation in codegen

### DIFF
--- a/src/codegen/Address.h
+++ b/src/codegen/Address.h
@@ -1,0 +1,74 @@
+#ifndef ADDRESS_H_
+#define ADDRESS_H_
+
+#include <cassert>
+#include <string>
+#include <utility>
+
+namespace codegen {
+
+// Where a named object lives (not a register-allocation temp).
+//
+// Policy:
+// - Locals / register-arg spill slots: StackPointer + offset; Value may cache in a register.
+// - Stack arguments: BasePointer + offset; same cache model for the Value.
+// - Globals: label in globalHomes; stores via bindResult; Values are resolve shells only
+//   (loads use scratch registers - never assign the global Value to a register).
+// - Homes are only in globalHomes / frameHomes.
+
+// Which pointer register a frame slot is addressed from (not an ISA-specific mnemonic).
+enum class FrameBase {
+    StackPointer,
+    BasePointer
+};
+
+class Address {
+public:
+    static Address frame(FrameBase base, int offsetBytes, int sizeBytes) {
+        return Address { Kind::Frame, base, offsetBytes, sizeBytes, {} };
+    }
+
+    static Address globalLabel(std::string label, int sizeBytes) {
+        return Address { Kind::Global, FrameBase::StackPointer, 0, sizeBytes, std::move(label) };
+    }
+
+    bool isGlobal() const { return kind_ == Kind::Global; }
+
+    FrameBase frameBase() const {
+        assert(!isGlobal() && "frameBase() is only valid for frame slots");
+        return frameBase_;
+    }
+
+    int offsetBytes() const {
+        assert(!isGlobal() && "offsetBytes() is only valid for frame slots");
+        return offsetBytes_;
+    }
+
+    int sizeBytes() const { return sizeBytes_; }
+
+    const std::string& label() const {
+        assert(isGlobal() && "label() is only valid for global homes");
+        return label_;
+    }
+
+private:
+    enum class Kind { Frame, Global };
+
+    Address(Kind kind, FrameBase frameBase, int offsetBytes, int sizeBytes, std::string label) :
+            kind_ { kind },
+            frameBase_ { frameBase },
+            offsetBytes_ { offsetBytes },
+            sizeBytes_ { sizeBytes },
+            label_ { std::move(label) } {}
+
+    Kind kind_;
+    FrameBase frameBase_;
+    int offsetBytes_;
+    int sizeBytes_;
+    std::string label_;
+};
+
+} // namespace codegen
+
+#endif // ADDRESS_H_
+

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(codegen
         quadruples/ValueCompare.h
         quadruples/Xor.h
         quadruples/ZeroCompare.h
+        Address.h
         Amd64Registers.h
         AssemblyGenerator.h
         ATandTInstructionSet.h
@@ -81,6 +82,7 @@ add_library(codegen
         InstructionSet.h
         GlobalVariable.h
         IntelInstructionSet.h
+        MemoryOperand.h
         QuadrupleGenerator.h
         Register.h
         StackMachine.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -514,8 +514,7 @@ void CodeGeneratingVisitor::visit(ast::FunctionDefinition& function) {
                 argumentSymbol.getIndex(),
                 // FIXME:
                 Type::INTEGRAL,
-                argumentSymbol.getType().getSize(),
-                true
+                argumentSymbol.getType().getSize()
         });
     }
     instructions.push_back(std::make_unique<StartProcedure>(function.getSymbol()->getName(), std::move(values), std::move(arguments)));

--- a/src/codegen/GlobalVariable.h
+++ b/src/codegen/GlobalVariable.h
@@ -7,15 +7,15 @@
 
 namespace codegen {
 
-// File-scope variable for preamble emission and StackMachine::globals registration.
+// File-scope variable for .data emission. StackMachine records the home in globalHomes and
+// a resolve()-only Value via toValue() (not a register cache).
 struct GlobalVariable {
     std::string name;
     int sizeInBytes;
     std::string initializerLiteral;
 
-    // Stack machine currently models only integral/pointer-sized words as INTEGRAL.
     Value toValue() const {
-        return Value { name, 0, Type::INTEGRAL, sizeInBytes, false, true };
+        return Value { name, 0, Type::INTEGRAL, sizeInBytes };
     }
 };
 

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -1,5 +1,6 @@
 #include "StackMachine.h"
 
+#include <cassert>
 #include <stdexcept>
 
 #include "InstructionSet.h"
@@ -19,8 +20,9 @@ StackMachine::StackMachine(std::ostream *ostream, std::unique_ptr<InstructionSet
 void StackMachine::generatePreamble(const std::map<std::string, std::string>& constants,
         const std::vector<GlobalVariable>& globalVariables) {
     assembly.raw(instructionSet->preamble(constants, globalVariables));
-    // Register every global once with real size/type; resolve() falls back here for non-frame names.
     for (const auto& global : globalVariables) {
+        globalHomes.emplace(global.name, Address::globalLabel(global.name, global.sizeInBytes));
+        // resolve() shell only; home is globalHomes, never register-cached.
         globals.emplace(global.name, global.toValue());
     }
 }
@@ -28,6 +30,7 @@ void StackMachine::generatePreamble(const std::map<std::string, std::string>& co
 void StackMachine::startProcedure(std::string procedureName, std::vector<Value> values, std::vector<Value> arguments) {
 
     emptyGeneralPurposeRegisters();
+    frameHomes.clear();
     assembly.label(instructionSet->label(procedureName));
     assembly << instructionSet->push(registers->getBasePointer());
     assembly << instructionSet->mov(registers->getStackPointer(), registers->getBasePointer());
@@ -46,8 +49,11 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
             ++integerArgumentRegisterIndex;
             ++localIndex;
         } else {
-            Value stackArgument{argument.getName(), argumentIndex, argument.getType(), argument.getSizeInBytes(), true};
+            Value stackArgument{argument.getName(), argumentIndex, argument.getType(), argument.getSizeInBytes()};
             scopeValues.insert({argument.getName(), stackArgument});
+            // Stack args live at fixed base-pointer offsets; independent of callee-saved size.
+            registerFrameHome(argument.getName(), Address::frame(FrameBase::BasePointer,
+                    (argumentIndex + 2) * MACHINE_WORD_SIZE, argument.getSizeInBytes()));
             ++argumentIndex;
         }
     }
@@ -61,11 +67,19 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
     }
 
     pushCalleeSavedRegisters();
+    // Stack-pointer locals / reg-arg spill slots include callee-saved space.
+    for (const auto& entry : scopeValues) {
+        if (frameHomes.count(entry.first)) {
+            continue;
+        }
+        registerFrameHome(entry.first, spillSlotAddress(entry.second));
+    }
 }
 
 void StackMachine::endProcedure() {
     emptyGeneralPurposeRegisters();
     scopeValues.clear();
+    frameHomes.clear();
     calleeSavedRegisters.clear();
 }
 
@@ -117,24 +131,32 @@ void StackMachine::emitLoad(Value& symbol, Register& dest) {
     assembly << instructionSet->mov(memoryOperand(symbol), dest);
 }
 
+void StackMachine::loadWithoutBinding(Value& symbol, Register& dest) {
+    emitLoad(symbol, dest);
+}
+
 void StackMachine::emitStore(Register& source, Value& symbol) {
     assembly << instructionSet->mov(source, memoryOperand(symbol));
 }
 
-// Bind a freshly computed result to its destination symbol. A global is never register-resident,
-// so write it straight to [rel name]; a local/temp stays register-resident for lazy write-back.
+// Bind a freshly computed result to its destination symbol. Global homes are Address-only:
+// commit to memory; never attach a register to the global Value (loads use scratch only).
+// Locals/temps use register residence and lazy write-back.
 void StackMachine::bindResult(Register& reg, Value& result) {
-    if (result.isGlobal()) {
+    if (addressOf(result).isGlobal()) {
         emitStore(reg, result);
-    } else {
-        reg.assign(&result);
+        assert(result.isStored() && "global Value must not be register-linked");
+        return;
     }
+    reg.assign(&result);
 }
 
 void StackMachine::assignRegisterToSymbol(Register& reg, Value& symbol) {
-    if (symbol.isStored()) {
+    // Always load without binding when the symbol is memory-resident (includes all globals:
+    // their homes are Address-only; never reg.assign the global Value).
+    if (residesInMemory(symbol)) {
         storeRegisterValue(reg);
-        emitLoad(symbol, reg);
+        loadWithoutBinding(symbol, reg);
     } else if (&reg != &symbol.getAssignedRegister()) {
         storeRegisterValue(reg);
         Register& valueRegister = symbol.getAssignedRegister();
@@ -147,12 +169,12 @@ void StackMachine::compare(std::string leftSymbolName, std::string rightSymbolNa
     auto& leftSymbol = resolve(leftSymbolName);
     auto& rightSymbol = resolve(rightSymbolName);
 
-    if (leftSymbol.isStored() && rightSymbol.isStored()) {
+    if (residesInMemory(leftSymbol) && residesInMemory(rightSymbol)) {
         Register& rightSymbolRegister = assignRegisterTo(rightSymbol);
         assembly << instructionSet->cmp(memoryOperand(leftSymbol), rightSymbolRegister);
-    } else if (leftSymbol.isStored()) {
+    } else if (residesInMemory(leftSymbol)) {
         assembly << instructionSet->cmp(memoryOperand(leftSymbol), rightSymbol.getAssignedRegister());
-    } else if (rightSymbol.isStored()) {
+    } else if (residesInMemory(rightSymbol)) {
         assembly << instructionSet->cmp(leftSymbol.getAssignedRegister(), memoryOperand(rightSymbol));
     } else {
         assembly << instructionSet->cmp(leftSymbol.getAssignedRegister(), rightSymbol.getAssignedRegister());
@@ -161,7 +183,7 @@ void StackMachine::compare(std::string leftSymbolName, std::string rightSymbolNa
 
 void StackMachine::zeroCompare(std::string symbolName) {
     auto& symbol = resolve(symbolName);
-    if (symbol.isStored()) {
+    if (residesInMemory(symbol)) {
         assembly << instructionSet->cmp(memoryOperand(symbol), 0);
     } else {
         assembly << instructionSet->cmp(symbol.getAssignedRegister(), 0);
@@ -178,21 +200,20 @@ void StackMachine::addressOf(std::string operandName, std::string resultName) {
 
 void StackMachine::dereference(std::string operandName, std::string lvalueName, std::string resultName) {
     auto& operand = resolve(operandName);
-    if (operand.isStored()) {
-        assignRegisterTo(operand);
-    }
-    Register& resultRegister = get64BitRegisterExcluding(operand.getAssignedRegister());
-    assembly << instructionSet->mov(MemoryOperand::at(operand.getAssignedRegister(), 0), resultRegister);
+    // Use the register returned by the load path; global pointer homes are not register-bound.
+    Register& pointerRegister = residesInMemory(operand) ? assignRegisterTo(operand) : operand.getAssignedRegister();
+    Register& resultRegister = get64BitRegisterExcluding(pointerRegister);
+    assembly << instructionSet->mov(MemoryOperand::at(pointerRegister, 0), resultRegister);
     bindResult(resultRegister, resolve(resultName));
 
-    Register& lvalueRegister = get64BitRegisterExcluding(operand.getAssignedRegister());
-    assembly << instructionSet->mov(operand.getAssignedRegister(), lvalueRegister);
+    Register& lvalueRegister = get64BitRegisterExcluding(pointerRegister);
+    assembly << instructionSet->mov(pointerRegister, lvalueRegister);
     lvalueRegister.assign(&resolve(lvalueName));
 }
 
 void StackMachine::unaryMinus(std::string operandName, std::string resultName) {
     auto& operand = resolve(operandName);
-    if (operand.isStored()) {
+    if (residesInMemory(operand)) {
         Register& resultRegister = get64BitRegister();
         emitLoad(operand, resultRegister);
         assembly << instructionSet->neg(resultRegister);
@@ -210,13 +231,13 @@ void StackMachine::assign(std::string operandName, std::string resultName) {
     auto& operand = resolve(operandName);
     auto& result = resolve(resultName);
 
-    if (operand.isStored() && result.isStored()) {
+    if (residesInMemory(operand) && residesInMemory(result)) {
         Register& reg = get64BitRegister();
         emitLoad(operand, reg);
         emitStore(reg, result);
-    } else if (operand.isStored()) {
+    } else if (residesInMemory(operand)) {
         emitLoad(operand, result.getAssignedRegister());
-    } else if (result.isStored()) {
+    } else if (residesInMemory(result)) {
         emitStore(operand.getAssignedRegister(), result);
     } else {
         assembly << instructionSet->mov(operand.getAssignedRegister(), result.getAssignedRegister());
@@ -225,7 +246,7 @@ void StackMachine::assign(std::string operandName, std::string resultName) {
 
 void StackMachine::assignConstant(std::string constant, std::string resultName) {
     auto& result = resolve(resultName);
-    if (result.isStored()) {
+    if (residesInMemory(result)) {
         assembly << instructionSet->mov(constant, memoryOperand(result));
     } else {
         assembly << instructionSet->mov(constant, result.getAssignedRegister());
@@ -236,8 +257,8 @@ void StackMachine::lvalueAssign(std::string operandName, std::string resultName)
     auto& operand = resolve(operandName);
     auto& result = resolve(resultName);
 
-    Register& operandRegister = operand.isStored() ? assignRegisterTo(operand) : operand.getAssignedRegister();
-    Register& resultRegister = result.isStored() ? assignRegisterExcluding(result, operandRegister) : result.getAssignedRegister();
+    Register& operandRegister = residesInMemory(operand) ? assignRegisterTo(operand) : operand.getAssignedRegister();
+    Register& resultRegister = residesInMemory(result) ? assignRegisterExcluding(result, operandRegister) : result.getAssignedRegister();
     assembly << instructionSet->mov(operandRegister, MemoryOperand::at(resultRegister, 0));
 }
 
@@ -280,11 +301,14 @@ void StackMachine::callProcedure(std::string procedureName) {
 }
 
 void StackMachine::pushProcedureArgument(Value& symbolToPush, int argumentOffset) {
-    if (symbolToPush.isStored()) {
+    if (residesInMemory(symbolToPush)) {
         Register& reg = get64BitRegister();
-        // rsp moves as stack args are pushed, so a non-argument stack operand needs the running offset.
-        int extraOffset = symbolToPush.isFunctionArgument() ? 0 : argumentOffset;
-        assembly << instructionSet->mov(memoryOperand(symbolToPush, extraOffset), reg);
+        // Stack-pointer homes move as call args are pushed; base-pointer / global do not.
+        Address home = addressOf(symbolToPush);
+        if (!home.isGlobal() && home.frameBase() == FrameBase::StackPointer) {
+            home = Address::frame(home.frameBase(), home.offsetBytes() + argumentOffset, home.sizeBytes());
+        }
+        assembly << instructionSet->mov(memoryOperand(home), reg);
         assembly << instructionSet->push(reg);
     } else {
         assembly << instructionSet->push(symbolToPush.getAssignedRegister());
@@ -294,7 +318,7 @@ void StackMachine::pushProcedureArgument(Value& symbolToPush, int argumentOffset
 void StackMachine::returnFromProcedure(std::string returnSymbolName) {
     if (!returnSymbolName.empty()) {
         Value& returnSymbol = resolve(returnSymbolName);
-        if (returnSymbol.isStored()) {
+        if (residesInMemory(returnSymbol)) {
             emitLoad(returnSymbol, registers->getRetrievalRegister());
         } else if (&registers->getRetrievalRegister() != &returnSymbol.getAssignedRegister()) {
             assembly << instructionSet->mov(returnSymbol.getAssignedRegister(), registers->getRetrievalRegister());
@@ -315,12 +339,12 @@ void StackMachine::xorCommand(std::string leftOperandName, std::string rightOper
     Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored()) {
+    if (residesInMemory(leftOperand)) {
         emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
     }
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->xor_(memoryOperand(rightOperand), resultRegister);
     } else {
         assembly << instructionSet->xor_(rightOperand.getAssignedRegister(), resultRegister);
@@ -333,12 +357,12 @@ void StackMachine::orCommand(std::string leftOperandName, std::string rightOpera
     Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored()) {
+    if (residesInMemory(leftOperand)) {
         emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
     }
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->or_(memoryOperand(rightOperand), resultRegister);
     } else {
         assembly << instructionSet->or_(rightOperand.getAssignedRegister(), resultRegister);
@@ -351,12 +375,12 @@ void StackMachine::andCommand(std::string leftOperandName, std::string rightOper
     Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored()) {
+    if (residesInMemory(leftOperand)) {
         emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
     }
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->and_(memoryOperand(rightOperand), resultRegister);
     } else {
         assembly << instructionSet->and_(rightOperand.getAssignedRegister(), resultRegister);
@@ -369,12 +393,12 @@ void StackMachine::add(std::string leftOperandName, std::string rightOperandName
     Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored()) {
+    if (residesInMemory(leftOperand)) {
         emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
     }
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->add(memoryOperand(rightOperand), resultRegister);
     } else {
         assembly << instructionSet->add(rightOperand.getAssignedRegister(), resultRegister);
@@ -387,12 +411,12 @@ void StackMachine::sub(std::string leftOperandName, std::string rightOperandName
     Value& rightOperand = resolve(rightOperandName);
     Register& resultRegister = get64BitRegister();
 
-    if (leftOperand.isStored()) {
+    if (residesInMemory(leftOperand)) {
         emitLoad(leftOperand, resultRegister);
     } else {
         assembly << instructionSet->mov(leftOperand.getAssignedRegister(), resultRegister);
     }
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->sub(memoryOperand(rightOperand), resultRegister);
     } else {
         assembly << instructionSet->sub(rightOperand.getAssignedRegister(), resultRegister);
@@ -413,7 +437,7 @@ void StackMachine::mul(std::string leftOperandName, std::string rightOperandName
     assignRegisterToSymbol(multiplicationRegister, leftOperand);
     // imul writes RDX:RAX; spill RDX if it holds a live value (e.g. pointer for *p *= ...)
     storeRegisterValue(registers->getRemainderRegister());
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->imul(memoryOperand(rightOperand));
     } else {
         assembly << instructionSet->imul(rightOperand.getAssignedRegister());
@@ -434,7 +458,7 @@ void StackMachine::div(std::string leftOperandName, std::string rightOperandName
     assignRegisterToSymbol(multiplicationRegister, leftOperand);
     storeRegisterValue(registers->getRemainderRegister());
     assembly << instructionSet->xor_(registers->getRemainderRegister(), registers->getRemainderRegister());
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->idiv(memoryOperand(rightOperand));
     } else {
         assembly << instructionSet->idiv(rightOperand.getAssignedRegister());
@@ -455,7 +479,7 @@ void StackMachine::mod(std::string leftOperandName, std::string rightOperandName
     assignRegisterToSymbol(multiplicationRegister, leftOperand);
     storeRegisterValue(registers->getRemainderRegister());
     assembly << instructionSet->xor_(registers->getRemainderRegister(), registers->getRemainderRegister());
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         assembly << instructionSet->idiv(memoryOperand(rightOperand));
     } else {
         assembly << instructionSet->idiv(rightOperand.getAssignedRegister());
@@ -465,7 +489,7 @@ void StackMachine::mod(std::string leftOperandName, std::string rightOperandName
 
 void StackMachine::inc(std::string operandName) {
     Value& operand = resolve(operandName);
-    if (operand.isStored()) {
+    if (residesInMemory(operand)) {
         assembly << instructionSet->inc(memoryOperand(operand));
     } else {
         assembly << instructionSet->inc(operand.getAssignedRegister());
@@ -474,7 +498,7 @@ void StackMachine::inc(std::string operandName) {
 
 void StackMachine::dec(std::string operandName) {
     Value& operand = resolve(operandName);
-    if (operand.isStored()) {
+    if (residesInMemory(operand)) {
         assembly << instructionSet->dec(memoryOperand(operand));
     } else {
         assembly << instructionSet->dec(operand.getAssignedRegister());
@@ -486,13 +510,16 @@ void StackMachine::shiftBy(std::string leftOperandName, std::string rightOperand
     // Count must live in %cl (RCX) and be tracked so the value is not placed in RCX.
     Register& counterRegister = getCounterRegister();
     Value& rightOperand = resolve(rightOperandName);
-    if (rightOperand.isStored()) {
+    if (residesInMemory(rightOperand)) {
         emitLoad(rightOperand, counterRegister);
     } else if (&counterRegister != &rightOperand.getAssignedRegister()) {
         assembly << instructionSet->mov(rightOperand.getAssignedRegister(), counterRegister);
         storeRegisterValue(rightOperand.getAssignedRegister());
     }
-    counterRegister.assign(&rightOperand);
+    // Count in %cl is scratch only; never register-cache a global home on RCX.
+    if (!addressOf(rightOperand).isGlobal()) {
+        counterRegister.assign(&rightOperand);
+    }
 
     Value& leftOperand = resolve(leftOperandName);
     Register& resultRegister = get64BitRegisterExcluding(counterRegister);
@@ -550,20 +577,47 @@ void StackMachine::storeInMemory(Value& symbol) {
     }
 }
 
-int StackMachine::memoryOffset(const Value& symbol) const {
-    if (symbol.isFunctionArgument()) {
-        return (symbol.getIndex() + 2) * MACHINE_WORD_SIZE;
-    }
-    return symbol.getIndex() * MACHINE_WORD_SIZE + calleeSavedRegisters.size() * MACHINE_WORD_SIZE;
+Address StackMachine::spillSlotAddress(const Value& symbol) const {
+    int offset = symbol.getIndex() * MACHINE_WORD_SIZE
+            + static_cast<int>(calleeSavedRegisters.size()) * MACHINE_WORD_SIZE;
+    return Address::frame(FrameBase::StackPointer, offset, symbol.getSizeInBytes());
 }
 
-MemoryOperand StackMachine::memoryOperand(const Value& symbol, int extraOffset) const {
-    if (symbol.isGlobal()) {
-        return MemoryOperand::global(symbol.getName());
+void StackMachine::registerFrameHome(const std::string& name, Address address) {
+    auto inserted = frameHomes.emplace(name, std::move(address)).second;
+    assert(inserted && "duplicate frame home registration");
+}
+
+bool StackMachine::residesInMemory(const Value& symbol) const {
+    return addressOf(symbol).isGlobal() || symbol.isStored();
+}
+
+Address StackMachine::addressOf(const Value& symbol) const {
+    const std::string& name = symbol.getName();
+    auto frame = frameHomes.find(name);
+    if (frame != frameHomes.end()) {
+        return frame->second;
     }
-    // Arguments are addressed off rbp, locals off rsp.
-    const Register& base = symbol.isFunctionArgument() ? registers->getBasePointer() : registers->getStackPointer();
-    return MemoryOperand::at(base, memoryOffset(symbol) + extraOffset);
+    auto global = globalHomes.find(name);
+    if (global != globalHomes.end()) {
+        return global->second;
+    }
+    // No registered home: a temporary. Its spill slot is derived from Value::index, which the
+    // code generator must keep consistent with the value's position among the frame's locals.
+    return spillSlotAddress(symbol);
+}
+
+MemoryOperand StackMachine::memoryOperand(const Address& address) const {
+    if (address.isGlobal()) {
+        return MemoryOperand::global(address.label());
+    }
+    const Register& base = address.frameBase() == FrameBase::BasePointer ?
+            registers->getBasePointer() : registers->getStackPointer();
+    return MemoryOperand::at(base, address.offsetBytes());
+}
+
+MemoryOperand StackMachine::memoryOperand(const Value& symbol) const {
+    return memoryOperand(addressOf(symbol));
 }
 
 Register& StackMachine::get64BitRegister() {
@@ -600,21 +654,27 @@ Register& StackMachine::getCounterRegister() {
 
 Register& StackMachine::assignRegisterTo(Value& symbol) {
     Register& reg = get64BitRegister();
-    emitLoad(symbol, reg);
-    reg.assign(&symbol);
+    loadWithoutBinding(symbol, reg);
+    // Bind only non-global homes; globals stay Address-only (scratch in reg).
+    if (!addressOf(symbol).isGlobal()) {
+        reg.assign(&symbol);
+    }
     return reg;
 }
 
 Register& StackMachine::assignRegisterExcluding(Value& symbol, Register& registerToExclude) {
     Register& reg = get64BitRegisterExcluding(registerToExclude);
-    emitLoad(symbol, reg);
-    reg.assign(&symbol);
+    loadWithoutBinding(symbol, reg);
+    if (!addressOf(symbol).isGlobal()) {
+        reg.assign(&symbol);
+    }
     return reg;
 }
 
 void StackMachine::setScope(std::vector<Value> variables) {
     for (auto& var : variables) {
         scopeValues.insert({var.getName(), var});
+        registerFrameHome(var.getName(), spillSlotAddress(var));
     }
 }
 

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "Address.h"
 #include "InstructionSet.h"
 #include "Amd64Registers.h"
 #include "GlobalVariable.h"
@@ -94,8 +95,16 @@ private:
     // Resolve a symbol name to its Value: a per-frame local/argument, or a program-scoped global.
     Value& resolve(const std::string& name);
 
-    int memoryOffset(const Value& symbol) const;
-    MemoryOperand memoryOperand(const Value& symbol, int extraOffset = 0) const;
+    // Prefer registered object homes; fall back to stack-pointer spill from Value::index.
+    Address addressOf(const Value& symbol) const;
+    Address spillSlotAddress(const Value& symbol) const;
+    // True if the operand should be read/written in memory (global home or no register).
+    bool residesInMemory(const Value& symbol) const;
+    void registerFrameHome(const std::string& name, Address address);
+    // Load into dest without reg.assign; required for globals (Address-only homes).
+    void loadWithoutBinding(Value& symbol, Register& dest);
+    MemoryOperand memoryOperand(const Address& address) const;
+    MemoryOperand memoryOperand(const Value& symbol) const;
     void emitLoad(Value& symbol, Register& dest);
     void emitStore(Register& source, Value& symbol);
     void bindResult(Register& reg, Value& result);
@@ -113,8 +122,13 @@ private:
     std::unique_ptr<Amd64Registers> registers;
     std::vector<Register*> calleeSavedRegisters;
 
+    // Per-frame Values for resolve (temps and locals; may be register-resident).
     std::map<std::string, Value> scopeValues;
+    // resolve() shells for globals only - not homes and never register-cached.
     std::map<std::string, Value> globals;
+    // Object homes (Address); globals and frame slots.
+    std::map<std::string, Address> globalHomes;
+    std::map<std::string, Address> frameHomes;
     std::vector<Value*> integerArguments;
     std::vector<Value*> stackArguments;
 

--- a/src/codegen/Value.cpp
+++ b/src/codegen/Value.cpp
@@ -4,13 +4,11 @@
 
 namespace codegen {
 
-Value::Value(std::string name, int index, Type type, int sizeInBytes, bool functionArgument, bool global) :
+Value::Value(std::string name, int index, Type type, int sizeInBytes) :
         name { name },
         index { index },
         type { type },
-        sizeInBytes { sizeInBytes },
-        functionArgument { functionArgument },
-        global { global }
+        sizeInBytes { sizeInBytes }
 {
 }
 
@@ -23,8 +21,7 @@ void Value::assignRegister(Register* reg) {
 }
 
 bool Value::isStored() const {
-    // A global's home is [rel name]; it is never register-resident, so it is always "stored".
-    return global || !assignedRegister;
+    return !assignedRegister;
 }
 
 void Value::removeRegister(Register* reg) {
@@ -36,14 +33,6 @@ void Value::removeRegister(Register* reg) {
 Register& Value::getAssignedRegister() const {
     assert(assignedRegister != nullptr);
     return *assignedRegister;
-}
-
-bool Value::isFunctionArgument() const {
-    return functionArgument;
-}
-
-bool Value::isGlobal() const {
-    return global;
 }
 
 int Value::getIndex() const {
@@ -59,4 +48,3 @@ int Value::getSizeInBytes() const {
 }
 
 } // namespace codegen
-

--- a/src/codegen/Value.h
+++ b/src/codegen/Value.h
@@ -10,9 +10,11 @@ enum class Type {
     INTEGRAL, FLOATING
 };
 
+// Register-allocation entity for temps and non-global named objects.
+// Object homes are Address entries in StackMachine (global Values are resolve-only).
 class Value {
 public:
-    Value(std::string name, int index, Type type, int sizeInBytes, bool functionArgument = false, bool global = false);
+    Value(std::string name, int index, Type type, int sizeInBytes);
     ~Value() = default;
 
     std::string getName() const;
@@ -20,10 +22,9 @@ public:
     void assignRegister(Register* reg);
     void removeRegister(Register* reg);
     Register& getAssignedRegister() const;
+    // True when no register holds this Value (memory / not yet loaded).
     bool isStored() const;
 
-    bool isFunctionArgument() const;
-    bool isGlobal() const;
     int getIndex() const;
     Type getType() const;
     int getSizeInBytes() const;
@@ -33,8 +34,6 @@ private:
     int index;
     Type type;
     int sizeInBytes;
-    bool functionArgument;
-    bool global;
 
     Register* assignedRegister { nullptr };
 };

--- a/test/src/functionalTest/GlobalVariablesTest.cpp
+++ b/test/src/functionalTest/GlobalVariablesTest.cpp
@@ -309,8 +309,8 @@ TEST(Compiler, globalOperandInShifts) {
     program.runAndExpect("32 2");
 }
 
-// A global read into a register (here as a shift count) must not stay register-resident:
-// a subsequent write to that global has to reach its [rel g] home, so the caller sees it.
+// Shift count is loaded into scratch (%cl) without register-caching the global home;
+// a later write must update memory so the caller sees it.
 TEST(Compiler, globalWrittenAfterBeingUsedAsShiftCountIsVisibleInCaller) {
     SourceProgram program{R"prg(
         int g;
@@ -513,6 +513,162 @@ TEST(Compiler, globalInitializerLogicalOr) {
     )prg"};
     program.compile();
     program.runAndExpect("0 1");
+}
+
+// Globals must not be register-cached on their home Value. After a read, a write, and a call
+// (spill of caller-saved regs), memory must still hold the written value - not a stale load.
+TEST(Compiler, globalWriteAfterReadSurvivesCallSpill) {
+    SourceProgram program{R"prg(
+        int g;
+        int t;
+
+        void touch() {
+            printf("%d", t);
+            return;
+        }
+
+        int main() {
+            g = 1;
+            t = g;
+            g = 2;
+            touch();
+            printf(" %d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2");
+}
+
+// Two globals loaded for an expression; later assign one; call; reread.
+TEST(Compiler, globalAssignAfterTwoGlobalExpressionSurvivesCall) {
+    SourceProgram program{R"prg(
+        int a;
+        int b;
+
+        void bump() {
+            return;
+        }
+
+        int main() {
+            a = 3;
+            b = 4;
+            printf("%d", a + b);
+            a = 9;
+            bump();
+            printf(" %d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7 9");
+}
+
+// Use global, compound-assign, print again (home must be updated; no stale cache).
+TEST(Compiler, globalUseThenCompoundAssignThenRead) {
+    SourceProgram program{R"prg(
+        int g;
+        int main() {
+            g = 10;
+            printf("%d", g);
+            g += 5;
+            printf(" %d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("10 15");
+}
+
+// Pass global by value into a callee (arg regs are scratch; home must not be bound).
+TEST(Compiler, globalPassedByValueThenUpdated) {
+    SourceProgram program{R"prg(
+        int g;
+
+        void f(int x) {
+            printf("%d ", x);
+            return;
+        }
+
+        int main() {
+            g = 7;
+            f(g);
+            g = 8;
+            f(g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7 8 ");
+}
+
+// Global pointer operand to * must load into scratch and use that register; must not
+// call getAssignedRegister on the global home (no register cache on globals).
+TEST(Compiler, readThroughGlobalPointer) {
+    SourceProgram program{R"prg(
+        int x;
+        int *p;
+
+        int main() {
+            x = 3;
+            p = &x;
+            printf("%d", *p);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, writeThroughGlobalPointer) {
+    SourceProgram program{R"prg(
+        int x;
+        int *p;
+
+        int main() {
+            x = 1;
+            p = &x;
+            *p = 9;
+            printf("%d", x);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9");
+}
+
+TEST(Compiler, readWriteThroughGlobalPointerToGlobal) {
+    SourceProgram program{R"prg(
+        int g;
+        int *p;
+
+        int main() {
+            g = 2;
+            p = &g;
+            *p = 4;
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("4");
+}
+
+TEST(Compiler, rmwThroughGlobalPointer) {
+    SourceProgram program{R"prg(
+        int x;
+        int *p;
+
+        int main() {
+            x = 5;
+            p = &x;
+            *p = *p + 1;
+            printf("%d", x);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("6");
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- Add `Address` (stack/base pointer frame slots vs global labels) and register homes in `globalHomes` / `frameHomes`.
- Slim codegen `Value` to name/index/type/size/register only; object homes are not flags on `Value`.
- Globals are never register-cached: `loadWithoutBinding`, `addressOf().isGlobal()` for bind/policy, `bindResult` stores only (with assert).
- Frame homes: base-pointer for stack args, stack-pointer for locals (after callee-saved push); call-arg push adjusts SP homes only.
- Fix `dereference` to use the `Register&` returned by the load path (global pointers).
- Expand `GlobalVariablesTest` for cache/spill, pass-by-value, and global pointer deref/RMW.

## Test plan
- [x] Local `ctest` / `functionalTest`
- [ ] CI `build`