### PR TITLE
Implement C structs with member access

### DIFF
--- a/resources/configuration/scanner.lex
+++ b/resources/configuration/scanner.lex
@@ -40,6 +40,7 @@
 @closing_brack  ]
 @opening_paren  (
 @closing_paren  )
+@dot            .
 @star           *
 @modulo         %
 @slash          /
@@ -104,6 +105,9 @@
 :closing_paren  )
 @fin
 
+:dot            .
+@fin
+
 :star           *
 @star_eq        =
 @fin
@@ -145,12 +149,16 @@
 :hyphen         -
 @minus_eq       =
 @decrement      -
+@arrow          >
 @fin
 
 :minus_eq       -=
 @fin
 
 :decrement      --
+@fin
+
+:arrow          ->
 @fin
 
 :plus           +
@@ -254,8 +262,9 @@
 
 :fin
 
-%int char void float
+%int char void float double short long signed unsigned
 %if else
 %while for continue break return
+%struct union
 %input output
 

--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -281,29 +281,6 @@ void AbstractSyntaxTreeBuilderContext::pushStructMemberList(std::vector<std::pai
 }
 
 
-void AbstractSyntaxTreeBuilderContext::newStructDeclaratorNameList() {
-    structDeclaratorNameLists.push({});
-}
-
-void AbstractSyntaxTreeBuilderContext::addStructDeclaratorName(std::string name) {
-    if (structDeclaratorNameLists.empty()) {
-        structDeclaratorNameLists.push({});
-    }
-    structDeclaratorNameLists.top().push_back(std::move(name));
-}
-
-std::vector<std::string> AbstractSyntaxTreeBuilderContext::popStructDeclaratorNameList() {
-    auto list = std::move(structDeclaratorNameLists.top());
-    structDeclaratorNameLists.pop();
-    return list;
-}
-
-
-void AbstractSyntaxTreeBuilderContext::defineStructTag(const std::string& tag, type::Type type) {
-    if (!tag.empty()) {
-        structTags.insert_or_assign(tag, std::move(type));
-    }
-}
 
 std::optional<type::Type> AbstractSyntaxTreeBuilderContext::lookupStructTag(const std::string& tag) const {
     auto it = structTags.find(tag);
@@ -311,6 +288,33 @@ std::optional<type::Type> AbstractSyntaxTreeBuilderContext::lookupStructTag(cons
         return std::nullopt;
     }
     return it->second;
+}
+
+
+void AbstractSyntaxTreeBuilderContext::addStructDeclarator(std::unique_ptr<Declarator> declarator) {
+    if (structDeclaratorLists.empty()) {
+        structDeclaratorLists.push({});
+    }
+    structDeclaratorLists.top().push_back(std::move(declarator));
+}
+
+std::vector<std::unique_ptr<Declarator>> AbstractSyntaxTreeBuilderContext::popStructDeclarators() {
+    if (structDeclaratorLists.empty()) {
+        return {};
+    }
+    auto list = std::move(structDeclaratorLists.top());
+    structDeclaratorLists.pop();
+    return list;
+}
+
+type::Type AbstractSyntaxTreeBuilderContext::ensureStructTag(const std::string& tag) {
+    auto it = structTags.find(tag);
+    if (it != structTags.end()) {
+        return it->second;
+    }
+    type::Type incomplete = type::incompleteStructure();
+    structTags.insert_or_assign(tag, incomplete);
+    return incomplete;
 }
 
 } // namespace ast

--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -253,4 +253,64 @@ std::vector<std::unique_ptr<AbstractSyntaxTreeNode> > AbstractSyntaxTreeBuilderC
     return std::move(translationUnit);
 }
 
+void AbstractSyntaxTreeBuilderContext::newStructMemberList() {
+    structMemberLists.push({});
+}
+
+void AbstractSyntaxTreeBuilderContext::addStructMember(std::string name, type::Type type) {
+    if (structMemberLists.empty()) {
+        structMemberLists.push({});
+    }
+    structMemberLists.top().emplace_back(std::move(name), std::move(type));
+}
+
+void AbstractSyntaxTreeBuilderContext::addStructMembersFromList(std::vector<std::pair<std::string, type::Type>> members) {
+    for (auto& m : members) {
+        structMemberLists.top().push_back(std::move(m));
+    }
+}
+
+std::vector<std::pair<std::string, type::Type>> AbstractSyntaxTreeBuilderContext::popStructMemberList() {
+    auto list = std::move(structMemberLists.top());
+    structMemberLists.pop();
+    return list;
+}
+
+void AbstractSyntaxTreeBuilderContext::pushStructMemberList(std::vector<std::pair<std::string, type::Type>> members) {
+    structMemberLists.push(std::move(members));
+}
+
+
+void AbstractSyntaxTreeBuilderContext::newStructDeclaratorNameList() {
+    structDeclaratorNameLists.push({});
+}
+
+void AbstractSyntaxTreeBuilderContext::addStructDeclaratorName(std::string name) {
+    if (structDeclaratorNameLists.empty()) {
+        structDeclaratorNameLists.push({});
+    }
+    structDeclaratorNameLists.top().push_back(std::move(name));
+}
+
+std::vector<std::string> AbstractSyntaxTreeBuilderContext::popStructDeclaratorNameList() {
+    auto list = std::move(structDeclaratorNameLists.top());
+    structDeclaratorNameLists.pop();
+    return list;
+}
+
+
+void AbstractSyntaxTreeBuilderContext::defineStructTag(const std::string& tag, type::Type type) {
+    if (!tag.empty()) {
+        structTags.insert_or_assign(tag, std::move(type));
+    }
+}
+
+std::optional<type::Type> AbstractSyntaxTreeBuilderContext::lookupStructTag(const std::string& tag) const {
+    auto it = structTags.find(tag);
+    if (it == structTags.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
 } // namespace ast

--- a/src/ast/AbstractSyntaxTreeBuilderContext.h
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.h
@@ -4,6 +4,9 @@
 #include <memory>
 #include <stack>
 #include <vector>
+#include <utility>
+#include <map>
+#include <optional>
 
 #include "Constant.h"
 #include "DeclarationSpecifiers.h"
@@ -96,6 +99,19 @@ public:
     void addToTranslationUnit(std::unique_ptr<AbstractSyntaxTreeNode> externalDeclaration);
     std::vector<std::unique_ptr<AbstractSyntaxTreeNode>> popTranslationUnit();
 
+    void newStructMemberList();
+    void addStructMember(std::string name, type::Type type);
+    void addStructMembersFromList(std::vector<std::pair<std::string, type::Type>> members);
+    std::vector<std::pair<std::string, type::Type>> popStructMemberList();
+    void pushStructMemberList(std::vector<std::pair<std::string, type::Type>> members);
+
+    void newStructDeclaratorNameList();
+    void addStructDeclaratorName(std::string name);
+    std::vector<std::string> popStructDeclaratorNameList();
+
+    void defineStructTag(const std::string& tag, type::Type type);
+    std::optional<type::Type> lookupStructTag(const std::string& tag) const;
+
 private:
     std::stack<TerminalSymbol> terminalSymbols;
 
@@ -123,6 +139,9 @@ private:
     std::stack<std::vector<std::unique_ptr<AbstractSyntaxTreeNode>>> statementLists;
     std::stack<std::unique_ptr<AbstractSyntaxTreeNode>> externalDeclarations;
     std::vector<std::unique_ptr<AbstractSyntaxTreeNode>> translationUnit;
+    std::stack<std::vector<std::pair<std::string, type::Type>>> structMemberLists;
+    std::stack<std::vector<std::string>> structDeclaratorNameLists;
+    std::map<std::string, type::Type> structTags;
 };
 
 }

--- a/src/ast/AbstractSyntaxTreeBuilderContext.h
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.h
@@ -105,11 +105,11 @@ public:
     std::vector<std::pair<std::string, type::Type>> popStructMemberList();
     void pushStructMemberList(std::vector<std::pair<std::string, type::Type>> members);
 
-    void newStructDeclaratorNameList();
-    void addStructDeclaratorName(std::string name);
-    std::vector<std::string> popStructDeclaratorNameList();
+    void addStructDeclarator(std::unique_ptr<Declarator> declarator);
+    std::vector<std::unique_ptr<Declarator>> popStructDeclarators();
 
-    void defineStructTag(const std::string& tag, type::Type type);
+    // Returns existing tag type or creates an incomplete struct type for the tag.
+    type::Type ensureStructTag(const std::string& tag);
     std::optional<type::Type> lookupStructTag(const std::string& tag) const;
 
 private:
@@ -140,7 +140,7 @@ private:
     std::stack<std::unique_ptr<AbstractSyntaxTreeNode>> externalDeclarations;
     std::vector<std::unique_ptr<AbstractSyntaxTreeNode>> translationUnit;
     std::stack<std::vector<std::pair<std::string, type::Type>>> structMemberLists;
-    std::stack<std::vector<std::string>> structDeclaratorNameLists;
+    std::stack<std::vector<std::unique_ptr<Declarator>>> structDeclaratorLists;
     std::map<std::string, type::Type> structTags;
 };
 

--- a/src/ast/AbstractSyntaxTreeVisitor.h
+++ b/src/ast/AbstractSyntaxTreeVisitor.h
@@ -35,6 +35,7 @@
 #include "ast/Declarator.h"
 #include "ast/InitializedDeclarator.h"
 #include "ast/Declaration.h"
+#include "ast/MemberAccess.h"
 
 namespace ast {
 
@@ -64,6 +65,7 @@ public:
     virtual void visit(LogicalAndExpression& expression) = 0;
     virtual void visit(LogicalOrExpression& expression) = 0;
     virtual void visit(AssignmentExpression& expression) = 0;
+    virtual void visit(MemberAccess& expression) = 0;
     virtual void visit(ExpressionList& expression) = 0;
 
     virtual void visit(Operator& op) = 0;

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(ast
         LogicalAndExpression.cpp
         LogicalExpression.cpp
         LogicalOrExpression.cpp
+        MemberAccess.cpp
         LoopHeader.cpp
         LoopStatement.cpp
         Operator.cpp

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -833,8 +833,9 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
             context.popTerminal();
             auto tag = context.popTerminal();
             auto members = context.popStructMemberList();
-            auto structType = type::structure(std::move(members));
-            context.defineStructTag(tag.value, structType);
+            // Same Type instance as any earlier incomplete references (e.g. self-pointers).
+            type::Type structType = context.ensureStructTag(tag.value);
+            type::completeStructure(structType, std::move(members));
             context.pushTypeSpecifier(TypeSpecifier { structType, tag.value });
         };
     nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, grammar.symbolId("{"), s_struct_decl_list, grammar.symbolId("}") }] =
@@ -847,11 +848,8 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, s_identifier }] =
         [](AbstractSyntaxTreeBuilderContext& context) {
             auto tag = context.popTerminal();
-            auto found = context.lookupStructTag(tag.value);
-            if (!found) {
-                throw std::runtime_error { "unknown struct type: " + tag.value };
-            }
-            context.pushTypeSpecifier(TypeSpecifier { *found, tag.value });
+            // Incomplete until a defining `struct Tag { ... }` completes the shared body.
+            context.pushTypeSpecifier(TypeSpecifier { context.ensureStructTag(tag.value), tag.value });
         };
 
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier }] = doNothing;
@@ -860,8 +858,7 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier, s_spec_qualifier_list }] = [](AbstractSyntaxTreeBuilderContext& context) { context.popTypeQualifier(); };
 
     nodeCreatorRegistry[s_struct_declarator][{ s_declarator }] = [](AbstractSyntaxTreeBuilderContext& context) {
-        auto declarator = context.popDeclarator();
-        context.addStructDeclaratorName(declarator->getName());
+        context.addStructDeclarator(context.popDeclarator());
     };
     nodeCreatorRegistry[s_struct_declarator_list][{ s_struct_declarator }] = doNothing;
     nodeCreatorRegistry[s_struct_declarator_list][{ s_struct_declarator_list, s_comma, s_struct_declarator }] =
@@ -870,11 +867,11 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_struct_decl][{ s_spec_qualifier_list, s_struct_declarator_list, s_semicolon }] =
         [](AbstractSyntaxTreeBuilderContext& context) {
             context.popTerminal();
-            auto names = context.popStructDeclaratorNameList();
+            auto declarators = context.popStructDeclarators();
             auto typeSpec = context.popTypeSpecifier();
-            auto fieldType = typeSpec.getType();
-            for (const auto& name : names) {
-                context.addStructMember(name, fieldType);
+            auto baseType = typeSpec.getType();
+            for (auto& declarator : declarators) {
+                context.addStructMember(declarator->getName(), declarator->getFundamentalType(baseType));
             }
         };
     nodeCreatorRegistry[s_struct_decl_list][{ s_struct_decl }] = doNothing;

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -1,4 +1,5 @@
 #include "ContextualSyntaxNodeBuilder.h"
+#include "MemberAccess.h"
 
 #include <algorithm>
 #include <sstream>
@@ -82,7 +83,7 @@ void typedefName(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void structOrUnionType(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "structOrUnionType type is not implemented yet" };
+    // type_spec -> struct_or_union_spec: TypeSpecifier already pushed.
 }
 
 void enumType(AbstractSyntaxTreeBuilderContext& context) {
@@ -275,11 +276,17 @@ void noargFunctionCall(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void directMemberAccess(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "directMemberAccess is not implemented yet" };
+    auto member = context.popTerminal();
+    context.popTerminal();
+    auto base = context.popExpression();
+    context.pushExpression(std::make_unique<MemberAccess>(std::move(base), member.value, false, member.context));
 }
 
 void pointeeMemberAccess(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "pointeeMemberAccess is not implemented yet" };
+    auto member = context.popTerminal();
+    context.popTerminal();
+    auto base = context.popExpression();
+    context.pushExpression(std::make_unique<MemberAccess>(std::move(base), member.value, true, member.context));
 }
 
 void postfixIncrementDecrement(AbstractSyntaxTreeBuilderContext& context) {
@@ -644,8 +651,8 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, s_open_bracket, s_exp, s_close_bracket }] = arrayAccess;
     nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, s_open_paren, s_argument_exp_list, s_close_paren }] = functionCall;
     nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, s_open_paren, s_close_paren }] = noargFunctionCall;
-    nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, grammar.symbolId(".") }] = directMemberAccess;
-    nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, grammar.symbolId("->") }] = pointeeMemberAccess;
+    nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, grammar.symbolId("."), s_identifier }] = directMemberAccess;
+    nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, grammar.symbolId("->"), s_identifier }] = pointeeMemberAccess;
     nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, grammar.symbolId("++") }] = postfixIncrementDecrement;
     nodeCreatorRegistry[s_postfix_exp][{ s_postfix_exp, grammar.symbolId("--") }] = postfixIncrementDecrement;
 
@@ -804,6 +811,75 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     //nodeCreatorRegistry[s_jump][{ grammar.symbolId("break"), s_semicolon }] = breakStatement;
     nodeCreatorRegistry[s_jump_stat][{ s_return, s_exp, s_semicolon }] = returnExpressionStatement;
     nodeCreatorRegistry[s_jump_stat][{ s_return, s_semicolon }] = returnVoidStatement;
+
+
+    int s_struct_or_union = grammar.symbolId("<struct_or_union>");
+    int s_struct_or_union_spec = grammar.symbolId("<struct_or_union_spec>");
+    int s_struct_decl_list = grammar.symbolId("<struct_decl_list>");
+    int s_struct_decl = grammar.symbolId("<struct_decl>");
+    int s_struct_declarator_list = grammar.symbolId("<struct_declarator_list>");
+    int s_struct_declarator = grammar.symbolId("<struct_declarator>");
+    int s_spec_qualifier_list = grammar.symbolId("<spec_qualifier_list>");
+
+    nodeCreatorRegistry[s_struct_or_union][{ grammar.symbolId("struct") }] = [](AbstractSyntaxTreeBuilderContext& context) { context.popTerminal(); };
+    nodeCreatorRegistry[s_struct_or_union][{ grammar.symbolId("union") }] = [](AbstractSyntaxTreeBuilderContext& context) {
+        context.popTerminal();
+        throw std::runtime_error { "union is not implemented" };
+    };
+
+    nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, s_identifier, grammar.symbolId("{"), s_struct_decl_list, grammar.symbolId("}") }] =
+        [](AbstractSyntaxTreeBuilderContext& context) {
+            context.popTerminal();
+            context.popTerminal();
+            auto tag = context.popTerminal();
+            auto members = context.popStructMemberList();
+            auto structType = type::structure(std::move(members));
+            context.defineStructTag(tag.value, structType);
+            context.pushTypeSpecifier(TypeSpecifier { structType, tag.value });
+        };
+    nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, grammar.symbolId("{"), s_struct_decl_list, grammar.symbolId("}") }] =
+        [](AbstractSyntaxTreeBuilderContext& context) {
+            context.popTerminal();
+            context.popTerminal();
+            auto members = context.popStructMemberList();
+            context.pushTypeSpecifier(TypeSpecifier { type::structure(std::move(members)), "" });
+        };
+    nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, s_identifier }] =
+        [](AbstractSyntaxTreeBuilderContext& context) {
+            auto tag = context.popTerminal();
+            auto found = context.lookupStructTag(tag.value);
+            if (!found) {
+                throw std::runtime_error { "unknown struct type: " + tag.value };
+            }
+            context.pushTypeSpecifier(TypeSpecifier { *found, tag.value });
+        };
+
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier }] = doNothing;
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier, s_spec_qualifier_list }] = doNothing;
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier }] = [](AbstractSyntaxTreeBuilderContext& context) { context.popTypeQualifier(); };
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier, s_spec_qualifier_list }] = [](AbstractSyntaxTreeBuilderContext& context) { context.popTypeQualifier(); };
+
+    nodeCreatorRegistry[s_struct_declarator][{ s_declarator }] = [](AbstractSyntaxTreeBuilderContext& context) {
+        auto declarator = context.popDeclarator();
+        context.addStructDeclaratorName(declarator->getName());
+    };
+    nodeCreatorRegistry[s_struct_declarator_list][{ s_struct_declarator }] = doNothing;
+    nodeCreatorRegistry[s_struct_declarator_list][{ s_struct_declarator_list, s_comma, s_struct_declarator }] =
+        [](AbstractSyntaxTreeBuilderContext& context) { context.popTerminal(); };
+
+    nodeCreatorRegistry[s_struct_decl][{ s_spec_qualifier_list, s_struct_declarator_list, s_semicolon }] =
+        [](AbstractSyntaxTreeBuilderContext& context) {
+            context.popTerminal();
+            auto names = context.popStructDeclaratorNameList();
+            auto typeSpec = context.popTypeSpecifier();
+            auto fieldType = typeSpec.getType();
+            for (const auto& name : names) {
+                context.addStructMember(name, fieldType);
+            }
+        };
+    nodeCreatorRegistry[s_struct_decl_list][{ s_struct_decl }] = doNothing;
+    nodeCreatorRegistry[s_struct_decl_list][{ s_struct_decl_list, s_struct_decl }] = doNothing;
+
 
     nodeCreatorRegistry[s_argument_exp_list][{ s_assignment }] = createActualArgumentsList;
     nodeCreatorRegistry[s_argument_exp_list][{ s_argument_exp_list, s_comma, s_assignment }] = addToActualArgumentsList;

--- a/src/ast/FunctionDefinition.cpp
+++ b/src/ast/FunctionDefinition.cpp
@@ -53,6 +53,10 @@ std::string FunctionDefinition::getName() const {
     return declarator->getName();
 }
 
+const DeclarationSpecifiers& FunctionDefinition::getReturnTypeSpecifiers() const {
+    return returnType;
+}
+
 
 void FunctionDefinition::setLocalVariables(std::map<std::string, semantic_analyzer::ValueEntry> localVariables) {
     this->localVariables = localVariables;

--- a/src/ast/FunctionDefinition.h
+++ b/src/ast/FunctionDefinition.h
@@ -34,6 +34,7 @@ public:
     std::vector<semantic_analyzer::ValueEntry> getArguments() const;
 
     std::string getName() const;
+    const DeclarationSpecifiers& getReturnTypeSpecifiers() const;
 
 private:
     DeclarationSpecifiers returnType;

--- a/src/ast/LoggingSyntaxTreeVisitor.cpp
+++ b/src/ast/LoggingSyntaxTreeVisitor.cpp
@@ -30,5 +30,6 @@ void LoggingSyntaxTreeVisitor::visit(parser::ParseTree& parseTree) {
     parseTree.accept(toSource);
 }
 
+
 } // namespace ast
 

--- a/src/ast/MemberAccess.cpp
+++ b/src/ast/MemberAccess.cpp
@@ -1,0 +1,64 @@
+#include "MemberAccess.h"
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+MemberAccess::MemberAccess(std::unique_ptr<Expression> base, std::string memberName, bool arrow,
+        translation_unit::Context context) :
+        base { std::move(base) },
+        memberName { std::move(memberName) },
+        arrow { arrow },
+        context { context }
+{
+    lval = true;
+}
+
+void MemberAccess::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+translation_unit::Context MemberAccess::getContext() const {
+    return context;
+}
+
+Expression* MemberAccess::getBase() const {
+    return base.get();
+}
+
+const std::string& MemberAccess::getMemberName() const {
+    return memberName;
+}
+
+bool MemberAccess::isArrow() const {
+    return arrow;
+}
+
+void MemberAccess::setMemberOffset(int offsetBytes) {
+    memberOffsetBytes = offsetBytes;
+}
+
+int MemberAccess::getMemberOffset() const {
+    return memberOffsetBytes;
+}
+
+void MemberAccess::setBaseResultSymbol(semantic_analyzer::ValueEntry symbol) {
+    baseResultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(symbol);
+}
+
+semantic_analyzer::ValueEntry* MemberAccess::getBaseResultSymbol() const {
+    return baseResultSymbol.get();
+}
+
+void MemberAccess::setFieldAddressSymbol(semantic_analyzer::ValueEntry symbol) {
+    fieldAddressSymbol = std::make_unique<semantic_analyzer::ValueEntry>(symbol);
+}
+
+semantic_analyzer::ValueEntry* MemberAccess::getFieldAddressSymbol() const {
+    return fieldAddressSymbol.get();
+}
+
+semantic_analyzer::ValueEntry* MemberAccess::getLvalueSymbol() const {
+    return fieldAddressSymbol.get();
+}
+
+} // namespace ast

--- a/src/ast/MemberAccess.h
+++ b/src/ast/MemberAccess.h
@@ -1,0 +1,50 @@
+#ifndef MEMBERACCESS_H_
+#define MEMBERACCESS_H_
+
+#include <memory>
+#include <string>
+
+#include "Expression.h"
+#include "translation_unit/Context.h"
+
+namespace ast {
+
+// postfix . id  or  postfix -> id
+class MemberAccess: public Expression {
+public:
+    MemberAccess(std::unique_ptr<Expression> base, std::string memberName, bool arrow,
+            translation_unit::Context context);
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    translation_unit::Context getContext() const override;
+    Expression* getBase() const;
+    const std::string& getMemberName() const;
+    bool isArrow() const;
+
+    void setMemberOffset(int offsetBytes);
+    int getMemberOffset() const;
+
+    // Base object's result symbol (struct value or pointer).
+    void setBaseResultSymbol(semantic_analyzer::ValueEntry symbol);
+    semantic_analyzer::ValueEntry* getBaseResultSymbol() const;
+
+    // Temp holding address of the field (for stores through the member).
+    void setFieldAddressSymbol(semantic_analyzer::ValueEntry symbol);
+    semantic_analyzer::ValueEntry* getFieldAddressSymbol() const;
+
+    semantic_analyzer::ValueEntry* getLvalueSymbol() const override;
+
+private:
+    std::unique_ptr<Expression> base;
+    std::string memberName;
+    bool arrow;
+    translation_unit::Context context;
+    int memberOffsetBytes { 0 };
+    std::unique_ptr<semantic_analyzer::ValueEntry> baseResultSymbol;
+    std::unique_ptr<semantic_analyzer::ValueEntry> fieldAddressSymbol;
+};
+
+} // namespace ast
+
+#endif

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -136,5 +136,18 @@ void AssemblyGenerator::generateCodeFor(const Shr& shr) {
     stackMachine->shr(shr.getLeftOperandName(), shr.getRightOperandName(), shr.getResultName());
 }
 
-} // namespace codegen
 
+
+void AssemblyGenerator::generateCodeFor(const FieldLoad& fieldLoad) {
+    stackMachine->fieldLoad(fieldLoad.getBase(), fieldLoad.getOffsetBytes(), fieldLoad.getResult(), fieldLoad.baseIsPointer());
+}
+
+void AssemblyGenerator::generateCodeFor(const FieldStore& fieldStore) {
+    stackMachine->fieldStore(fieldStore.getValue(), fieldStore.getBase(), fieldStore.getOffsetBytes(), fieldStore.baseIsPointer());
+}
+
+void AssemblyGenerator::generateCodeFor(const FieldAddress& fieldAddress) {
+    stackMachine->fieldAddress(fieldAddress.getBase(), fieldAddress.getOffsetBytes(), fieldAddress.getResult(), fieldAddress.baseIsPointer());
+}
+
+} // namespace codegen

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -138,13 +138,7 @@ void AssemblyGenerator::generateCodeFor(const Shr& shr) {
 
 
 
-void AssemblyGenerator::generateCodeFor(const FieldLoad& fieldLoad) {
-    stackMachine->fieldLoad(fieldLoad.getBase(), fieldLoad.getOffsetBytes(), fieldLoad.getResult(), fieldLoad.baseIsPointer());
-}
 
-void AssemblyGenerator::generateCodeFor(const FieldStore& fieldStore) {
-    stackMachine->fieldStore(fieldStore.getValue(), fieldStore.getBase(), fieldStore.getOffsetBytes(), fieldStore.baseIsPointer());
-}
 
 void AssemblyGenerator::generateCodeFor(const FieldAddress& fieldAddress) {
     stackMachine->fieldAddress(fieldAddress.getBase(), fieldAddress.getOffsetBytes(), fieldAddress.getResult(), fieldAddress.baseIsPointer());

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -34,6 +34,7 @@
 #include "quadruples/Dec.h"
 #include "quadruples/Shl.h"
 #include "quadruples/Shr.h"
+#include "quadruples/FieldAccess.h"
 
 namespace codegen {
 
@@ -74,6 +75,9 @@ public:
     void generateCodeFor(const Dec& dec);
     void generateCodeFor(const Shl& shl);
     void generateCodeFor(const Shr& shr);
+    void generateCodeFor(const FieldLoad& fieldLoad);
+    void generateCodeFor(const FieldStore& fieldStore);
+    void generateCodeFor(const FieldAddress& fieldAddress);
 
 private:
     std::unique_ptr<StackMachine> stackMachine;

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -75,8 +75,6 @@ public:
     void generateCodeFor(const Dec& dec);
     void generateCodeFor(const Shl& shl);
     void generateCodeFor(const Shr& shr);
-    void generateCodeFor(const FieldLoad& fieldLoad);
-    void generateCodeFor(const FieldStore& fieldStore);
     void generateCodeFor(const FieldAddress& fieldAddress);
 
 private:

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(codegen
         quadruples/Div.cpp
         quadruples/DoubleOperandQuadruple.cpp
         quadruples/EndProcedure.cpp
+        quadruples/FieldAccess.cpp
         quadruples/Inc.cpp
         quadruples/Jump.cpp
         quadruples/Label.cpp
@@ -54,6 +55,7 @@ add_library(codegen
         quadruples/Div.h
         quadruples/DoubleOperandQuadruple.h
         quadruples/EndProcedure.h
+        quadruples/FieldAccess.h
         quadruples/Inc.h
         quadruples/Jump.h
         quadruples/Label.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -34,6 +34,7 @@
 #include "quadruples/EndProcedure.h"
 #include "quadruples/Shl.h"
 #include "quadruples/Shr.h"
+#include "quadruples/FieldAccess.h"
 
 namespace codegen {
 
@@ -498,23 +499,32 @@ void CodeGeneratingVisitor::visit(ast::FunctionDefinition& function) {
     function.visitDeclarator(*this);
 
     std::vector<Value> values;
+    int nextSlot = 0;
     for (auto& valueSymbol : function.getLocalVariables()) {
+        int sizeBytes = valueSymbol.second.getType().getSize();
+        if (sizeBytes < 8) {
+            sizeBytes = 8;
+        }
+        int words = (sizeBytes + 7) / 8;
         values.push_back( {
                 valueSymbol.second.getName(),
-                valueSymbol.second.getIndex(),
-                // FIXME:
+                nextSlot,
                 Type::INTEGRAL,
-                valueSymbol.second.getType().getSize()
+                sizeBytes
         });
+        nextSlot += words;
     }
     std::vector<Value> arguments;
     for (auto& argumentSymbol : function.getArguments()) {
+        int sizeBytes = argumentSymbol.getType().getSize();
+        if (sizeBytes < 8) {
+            sizeBytes = 8;
+        }
         arguments.push_back( {
                 argumentSymbol.getName(),
                 argumentSymbol.getIndex(),
-                // FIXME:
                 Type::INTEGRAL,
-                argumentSymbol.getType().getSize()
+                sizeBytes
         });
     }
     instructions.push_back(std::make_unique<StartProcedure>(function.getSymbol()->getName(), std::move(values), std::move(arguments)));
@@ -560,5 +570,15 @@ std::vector<std::unique_ptr<BasicBlock>> toBasicBlocks(std::vector<std::unique_p
     return basicBlocks;
 }
 
-} // namespace codegen
+void CodeGeneratingVisitor::visit(ast::MemberAccess& expression) {
+    expression.getBase()->accept(*this);
+    const bool arrow = expression.isArrow();
+    const int offset = expression.getMemberOffset();
+    const std::string baseName = expression.getBaseResultSymbol()->getName();
+    const std::string addrName = expression.getFieldAddressSymbol()->getName();
+    const std::string resultName = expression.getResultSymbol()->getName();
+    instructions.push_back(std::make_unique<FieldAddress>(baseName, offset, addrName, arrow));
+    instructions.push_back(std::make_unique<FieldLoad>(baseName, offset, resultName, arrow));
+}
 
+} // namespace codegen

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -86,7 +86,8 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
     }
 
     instructions.push_back(std::make_unique<Call>(functionCall.getSymbol()->getName()));
-    if (!functionCall.getType().isVoid()) {
+    // Void calls have no result symbol / type set.
+    if (!functionCall.getSymbol()->returnType().isVoid()) {
         instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
     }
 }

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -577,8 +577,9 @@ void CodeGeneratingVisitor::visit(ast::MemberAccess& expression) {
     const std::string baseName = expression.getBaseResultSymbol()->getName();
     const std::string addrName = expression.getFieldAddressSymbol()->getName();
     const std::string resultName = expression.getResultSymbol()->getName();
+    // Materialize field address (dot: &object+off; arrow: pointer+off). Read via existing dereference.
     instructions.push_back(std::make_unique<FieldAddress>(baseName, offset, addrName, arrow));
-    instructions.push_back(std::make_unique<FieldLoad>(baseName, offset, resultName, arrow));
+    instructions.push_back(std::make_unique<Dereference>(addrName, addrName, resultName));
 }
 
 } // namespace codegen

--- a/src/codegen/CodeGeneratingVisitor.h
+++ b/src/codegen/CodeGeneratingVisitor.h
@@ -36,6 +36,7 @@ public:
     void visit(ast::LogicalAndExpression& expression) override;
     void visit(ast::LogicalOrExpression& expression) override;
     void visit(ast::AssignmentExpression& expression) override;
+    void visit(ast::MemberAccess& expression) override;
     void visit(ast::ExpressionList& expression) override;
 
     void visit(ast::Operator& op) override;

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -1,6 +1,7 @@
 #include "StackMachine.h"
 
 #include <cassert>
+#include <algorithm>
 #include <stdexcept>
 
 #include "InstructionSet.h"
@@ -58,7 +59,19 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
         }
     }
     int savedRegistersStack = registers->getCalleeSavedRegisters().size() * MACHINE_WORD_SIZE;
-    localVariableStackSize = (scopeValues.size() - argumentIndex) * MACHINE_WORD_SIZE;
+    // SP locals use word index; size may span multiple words (structs).
+    int maxWordEnd = 0;
+    for (const auto& entry : scopeValues) {
+        if (frameHomes.count(entry.first)) {
+            continue; // stack argument on RBP
+        }
+        int words = (entry.second.getSizeInBytes() + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
+        if (words < 1) {
+            words = 1;
+        }
+        maxWordEnd = std::max(maxWordEnd, entry.second.getIndex() + words);
+    }
+    localVariableStackSize = maxWordEnd * MACHINE_WORD_SIZE;
     int stackSize = savedRegistersStack + localVariableStackSize;
     if (stackSize % STACK_ALIGNMENT) {
         assembly << instructionSet->sub(registers->getStackPointer(), localVariableStackSize + MACHINE_WORD_SIZE);
@@ -684,6 +697,48 @@ Value& StackMachine::resolve(const std::string& name) {
         return local->second;
     }
     return globals.at(name);
+}
+
+
+
+void StackMachine::computeFieldAddress(Value& base, int offsetBytes, Register& addrReg, bool baseIsPointer) {
+    if (baseIsPointer) {
+        if (residesInMemory(base)) {
+            emitLoad(base, addrReg);
+        } else {
+            assembly << instructionSet->mov(base.getAssignedRegister(), addrReg);
+        }
+    } else {
+        assembly << instructionSet->lea(memoryOperand(base), addrReg);
+    }
+    if (offsetBytes) {
+        assembly << instructionSet->add(addrReg, offsetBytes);
+    }
+}
+
+void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
+    auto& base = resolve(baseName);
+    Register& addrReg = get64BitRegister();
+    computeFieldAddress(base, offsetBytes, addrReg, baseIsPointer);
+    bindResult(addrReg, resolve(resultName));
+}
+
+void StackMachine::fieldLoad(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
+    auto& base = resolve(baseName);
+    Register& addrReg = get64BitRegister();
+    computeFieldAddress(base, offsetBytes, addrReg, baseIsPointer);
+    Register& resultReg = get64BitRegisterExcluding(addrReg);
+    assembly << instructionSet->mov(MemoryOperand::at(addrReg, 0), resultReg);
+    bindResult(resultReg, resolve(resultName));
+}
+
+void StackMachine::fieldStore(std::string valueName, std::string baseName, int offsetBytes, bool baseIsPointer) {
+    auto& value = resolve(valueName);
+    auto& base = resolve(baseName);
+    Register& valueReg = residesInMemory(value) ? assignRegisterTo(value) : value.getAssignedRegister();
+    Register& addrReg = get64BitRegisterExcluding(valueReg);
+    computeFieldAddress(base, offsetBytes, addrReg, baseIsPointer);
+    assembly << instructionSet->mov(valueReg, MemoryOperand::at(addrReg, 0));
 }
 
 } // namespace codegen

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -41,21 +41,22 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
     }
     std::size_t integerArgumentRegisterIndex{0};
     std::size_t localIndex{scopeValues.size()};
-    int argumentIndex{0};
+    int argumentWordIndex{0};
     for (auto& argument : arguments) {
-        if (argument.getType() == Type::INTEGRAL && integerArgumentRegisterIndex < registers->getIntegerArgumentRegisters().size()) {
+        const int words = std::max(1, (argument.getSizeInBytes() + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE);
+        // Single-word args may use integer registers; multi-word (structs) always use the stack.
+        if (words == 1 && integerArgumentRegisterIndex < registers->getIntegerArgumentRegisters().size()) {
             Value registerArgument{argument.getName(), static_cast<int>(localIndex), argument.getType(), argument.getSizeInBytes()};
             scopeValues.insert({argument.getName(), registerArgument});
             registers->getIntegerArgumentRegisters()[integerArgumentRegisterIndex]->assign(&resolve(argument.getName()));
             ++integerArgumentRegisterIndex;
             ++localIndex;
         } else {
-            Value stackArgument{argument.getName(), argumentIndex, argument.getType(), argument.getSizeInBytes()};
+            Value stackArgument{argument.getName(), argumentWordIndex, argument.getType(), argument.getSizeInBytes()};
             scopeValues.insert({argument.getName(), stackArgument});
-            // Stack args live at fixed base-pointer offsets; independent of callee-saved size.
             registerFrameHome(argument.getName(), Address::frame(FrameBase::BasePointer,
-                    (argumentIndex + 2) * MACHINE_WORD_SIZE, argument.getSizeInBytes()));
-            ++argumentIndex;
+                    (argumentWordIndex + 2) * MACHINE_WORD_SIZE, argument.getSizeInBytes()));
+            argumentWordIndex += words;
         }
     }
     int savedRegistersStack = registers->getCalleeSavedRegisters().size() * MACHINE_WORD_SIZE;
@@ -243,7 +244,10 @@ void StackMachine::unaryMinus(std::string operandName, std::string resultName) {
 void StackMachine::assign(std::string operandName, std::string resultName) {
     auto& operand = resolve(operandName);
     auto& result = resolve(resultName);
-
+    if (wordCount(operand) > 1 || wordCount(result) > 1) {
+        copyWords(operand, result);
+        return;
+    }
     if (residesInMemory(operand) && residesInMemory(result)) {
         Register& reg = get64BitRegister();
         emitLoad(operand, reg);
@@ -277,7 +281,8 @@ void StackMachine::lvalueAssign(std::string operandName, std::string resultName)
 
 void StackMachine::procedureArgument(std::string argumentName) {
     auto argument = &resolve(argumentName);
-    if (integerArguments.size() < registers->getIntegerArgumentRegisters().size()) {
+    // Multi-word values (structs) always travel on the stack.
+    if (wordCount(*argument) == 1 && integerArguments.size() < registers->getIntegerArgumentRegisters().size()) {
         integerArguments.push_back(argument);
     } else {
         stackArguments.insert(stackArguments.begin(), argument);
@@ -291,15 +296,17 @@ void StackMachine::callProcedure(std::string procedureName) {
     storeRegisterValue(registers->getRetrievalRegister());
     spillCallerSavedRegisters();
     int argumentOffset{0};
-    // System V AMD64: RSP must be 16-byte aligned before call. Without stack args we are
-    // aligned; each stack arg is 8 bytes, so an odd count needs 8 bytes of padding.
-    if (stackArguments.size() % 2 == 1) {
+    int stackWords = 0;
+    for (auto argument : stackArguments) {
+        stackWords += wordCount(*argument);
+    }
+    // System V AMD64: RSP must be 16-byte aligned before call.
+    if (stackWords % 2 == 1) {
         assembly << instructionSet->sub(registers->getStackPointer(), MACHINE_WORD_SIZE);
         argumentOffset += MACHINE_WORD_SIZE;
     }
     for (auto argument : stackArguments) {
-        pushProcedureArgument(*argument, argumentOffset);
-        argumentOffset += MACHINE_WORD_SIZE;
+        argumentOffset += pushProcedureArgument(*argument, argumentOffset);
     }
     integerArguments.clear();
     stackArguments.clear();
@@ -313,28 +320,46 @@ void StackMachine::callProcedure(std::string procedureName) {
     }
 }
 
-void StackMachine::pushProcedureArgument(Value& symbolToPush, int argumentOffset) {
-    if (residesInMemory(symbolToPush)) {
+int StackMachine::pushProcedureArgument(Value& symbolToPush, int argumentOffset) {
+    const int words = wordCount(symbolToPush);
+    // Push high word first so the lowest address holds word 0 (matches callee RBP layout).
+    for (int w = words - 1; w >= 0; --w) {
         Register& reg = get64BitRegister();
-        // Stack-pointer homes move as call args are pushed; base-pointer / global do not.
-        Address home = addressOf(symbolToPush);
-        if (!home.isGlobal() && home.frameBase() == FrameBase::StackPointer) {
-            home = Address::frame(home.frameBase(), home.offsetBytes() + argumentOffset, home.sizeBytes());
+        if (residesInMemory(symbolToPush) || words > 1) {
+            Address home = addressOf(symbolToPush);
+            int byteOff = w * MACHINE_WORD_SIZE;
+            if (!home.isGlobal() && home.frameBase() == FrameBase::StackPointer) {
+                // Prior pushes in this argument (and earlier args) have moved RSP.
+                const int pushedInThisArg = (words - 1 - w) * MACHINE_WORD_SIZE;
+                byteOff += argumentOffset + pushedInThisArg;
+            }
+            if (home.isGlobal()) {
+                Register& addr = get64BitRegisterExcluding(reg);
+                assembly << instructionSet->lea(memoryOperand(home), addr);
+                if (byteOff) {
+                    assembly << instructionSet->add(addr, byteOff);
+                }
+                assembly << instructionSet->mov(MemoryOperand::at(addr, 0), reg);
+            } else {
+                Address wordHome = Address::frame(home.frameBase(), home.offsetBytes() + byteOff, MACHINE_WORD_SIZE);
+                assembly << instructionSet->mov(memoryOperand(wordHome), reg);
+            }
+            assembly << instructionSet->push(reg);
+        } else {
+            assembly << instructionSet->push(symbolToPush.getAssignedRegister());
         }
-        assembly << instructionSet->mov(memoryOperand(home), reg);
-        assembly << instructionSet->push(reg);
-    } else {
-        assembly << instructionSet->push(symbolToPush.getAssignedRegister());
     }
+    return words * MACHINE_WORD_SIZE;
 }
 
 void StackMachine::returnFromProcedure(std::string returnSymbolName) {
     if (!returnSymbolName.empty()) {
         Value& returnSymbol = resolve(returnSymbolName);
-        if (residesInMemory(returnSymbol)) {
-            emitLoad(returnSymbol, registers->getRetrievalRegister());
-        } else if (&registers->getRetrievalRegister() != &returnSymbol.getAssignedRegister()) {
-            assembly << instructionSet->mov(returnSymbol.getAssignedRegister(), registers->getRetrievalRegister());
+        const int words = wordCount(returnSymbol);
+        // Up to two words returned in RAX and RDX (enough for our word-aligned Point, etc.).
+        loadWord(returnSymbol, 0, registers->getRetrievalRegister());
+        if (words >= 2) {
+            loadWord(returnSymbol, 1, registers->getRemainderRegister());
         }
     }
     popCalleeSavedRegisters();
@@ -344,7 +369,11 @@ void StackMachine::returnFromProcedure(std::string returnSymbolName) {
 
 void StackMachine::retrieveProcedureReturnValue(std::string returnSymbolName) {
     Value& returnSymbol = resolve(returnSymbolName);
-    emitStore(registers->getRetrievalRegister(), returnSymbol);
+    const int words = wordCount(returnSymbol);
+    storeWord(registers->getRetrievalRegister(), returnSymbol, 0);
+    if (words >= 2) {
+        storeWord(registers->getRemainderRegister(), returnSymbol, 1);
+    }
 }
 
 void StackMachine::xorCommand(std::string leftOperandName, std::string rightOperandName, std::string resultName) {
@@ -701,6 +730,66 @@ Value& StackMachine::resolve(const std::string& name) {
 
 
 
+
+
+int StackMachine::wordCount(const Value& symbol) const {
+    int words = (symbol.getSizeInBytes() + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
+    return words < 1 ? 1 : words;
+}
+
+void StackMachine::loadWord(Value& symbol, int wordIndex, Register& dest) {
+    // Single-word values may be register-resident; multi-word objects always live in memory.
+    if (wordIndex == 0 && wordCount(symbol) == 1 && !residesInMemory(symbol)) {
+        if (&dest != &symbol.getAssignedRegister()) {
+            assembly << instructionSet->mov(symbol.getAssignedRegister(), dest);
+        }
+        return;
+    }
+    Address home = addressOf(symbol);
+    const int byteOff = wordIndex * MACHINE_WORD_SIZE;
+    if (home.isGlobal()) {
+        Register& addr = get64BitRegisterExcluding(dest);
+        assembly << instructionSet->lea(memoryOperand(home), addr);
+        if (byteOff) {
+            assembly << instructionSet->add(addr, byteOff);
+        }
+        assembly << instructionSet->mov(MemoryOperand::at(addr, 0), dest);
+    } else {
+        Address wordHome = Address::frame(home.frameBase(), home.offsetBytes() + byteOff, MACHINE_WORD_SIZE);
+        assembly << instructionSet->mov(memoryOperand(wordHome), dest);
+    }
+}
+
+void StackMachine::storeWord(Register& source, Value& symbol, int wordIndex) {
+    if (wordIndex == 0 && wordCount(symbol) == 1 && !residesInMemory(symbol)) {
+        if (&source != &symbol.getAssignedRegister()) {
+            assembly << instructionSet->mov(source, symbol.getAssignedRegister());
+        }
+        return;
+    }
+    Address home = addressOf(symbol);
+    const int byteOff = wordIndex * MACHINE_WORD_SIZE;
+    if (home.isGlobal()) {
+        Register& addr = get64BitRegisterExcluding(source);
+        assembly << instructionSet->lea(memoryOperand(home), addr);
+        if (byteOff) {
+            assembly << instructionSet->add(addr, byteOff);
+        }
+        assembly << instructionSet->mov(source, MemoryOperand::at(addr, 0));
+    } else {
+        Address wordHome = Address::frame(home.frameBase(), home.offsetBytes() + byteOff, MACHINE_WORD_SIZE);
+        assembly << instructionSet->mov(source, memoryOperand(wordHome));
+    }
+}
+
+void StackMachine::copyWords(Value& source, Value& destination) {
+    const int words = std::max(wordCount(source), wordCount(destination));
+    Register& reg = get64BitRegister();
+    for (int w = 0; w < words; ++w) {
+        loadWord(source, w, reg);
+        storeWord(reg, destination, w);
+    }
+}
 
 void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
     auto& base = resolve(baseName);

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -701,44 +701,25 @@ Value& StackMachine::resolve(const std::string& name) {
 
 
 
-void StackMachine::computeFieldAddress(Value& base, int offsetBytes, Register& addrReg, bool baseIsPointer) {
+
+void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
+    auto& base = resolve(baseName);
+    Register& addrReg = get64BitRegister();
     if (baseIsPointer) {
+        // Arrow: base holds a pointer value (object address).
         if (residesInMemory(base)) {
             emitLoad(base, addrReg);
         } else {
             assembly << instructionSet->mov(base.getAssignedRegister(), addrReg);
         }
     } else {
+        // Dot: base is the object; take its address.
         assembly << instructionSet->lea(memoryOperand(base), addrReg);
     }
     if (offsetBytes) {
         assembly << instructionSet->add(addrReg, offsetBytes);
     }
-}
-
-void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
-    auto& base = resolve(baseName);
-    Register& addrReg = get64BitRegister();
-    computeFieldAddress(base, offsetBytes, addrReg, baseIsPointer);
     bindResult(addrReg, resolve(resultName));
-}
-
-void StackMachine::fieldLoad(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
-    auto& base = resolve(baseName);
-    Register& addrReg = get64BitRegister();
-    computeFieldAddress(base, offsetBytes, addrReg, baseIsPointer);
-    Register& resultReg = get64BitRegisterExcluding(addrReg);
-    assembly << instructionSet->mov(MemoryOperand::at(addrReg, 0), resultReg);
-    bindResult(resultReg, resolve(resultName));
-}
-
-void StackMachine::fieldStore(std::string valueName, std::string baseName, int offsetBytes, bool baseIsPointer) {
-    auto& value = resolve(valueName);
-    auto& base = resolve(baseName);
-    Register& valueReg = residesInMemory(value) ? assignRegisterTo(value) : value.getAssignedRegister();
-    Register& addrReg = get64BitRegisterExcluding(valueReg);
-    computeFieldAddress(base, offsetBytes, addrReg, baseIsPointer);
-    assembly << instructionSet->mov(valueReg, MemoryOperand::at(addrReg, 0));
 }
 
 } // namespace codegen

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -78,7 +78,11 @@ private:
     void shiftBy(std::string leftOperandName, std::string rightOperandName, std::string resultName,
             std::string (InstructionSet::*emitShift)(const Register&) const);
 
-    void pushProcedureArgument(Value& argument, int argumentOffset);
+    int pushProcedureArgument(Value& argument, int argumentOffset);
+    int wordCount(const Value& symbol) const;
+    void copyWords(Value& source, Value& destination);
+    void loadWord(Value& symbol, int wordIndex, Register& dest);
+    void storeWord(Register& source, Value& symbol, int wordIndex);
 
     void storeRegisterValue(Register& reg);
     void spillGeneralPurposeRegisters();

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -71,6 +71,11 @@ public:
 
     void setScope(std::vector<Value> variables);
 
+    void fieldLoad(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer);
+    void fieldStore(std::string valueName, std::string baseName, int offsetBytes, bool baseIsPointer);
+    void fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer);
+    void computeFieldAddress(Value& base, int offsetBytes, Register& addrReg, bool baseIsPointer);
+
 private:
     void shiftBy(std::string leftOperandName, std::string rightOperandName, std::string resultName,
             std::string (InstructionSet::*emitShift)(const Register&) const);

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -71,10 +71,8 @@ public:
 
     void setScope(std::vector<Value> variables);
 
-    void fieldLoad(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer);
-    void fieldStore(std::string valueName, std::string baseName, int offsetBytes, bool baseIsPointer);
+    // result = (&object)+offset, or (pointer_value)+offset when baseIsPointer (for ->).
     void fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer);
-    void computeFieldAddress(Value& base, int offsetBytes, Register& addrReg, bool baseIsPointer);
 
 private:
     void shiftBy(std::string leftOperandName, std::string rightOperandName, std::string resultName,

--- a/src/codegen/quadruples/FieldAccess.cpp
+++ b/src/codegen/quadruples/FieldAccess.cpp
@@ -1,0 +1,28 @@
+#include "FieldAccess.h"
+#include "codegen/AssemblyGenerator.h"
+#include <iostream>
+
+namespace codegen {
+
+FieldLoad::FieldLoad(std::string base, int offsetBytes, std::string result, bool baseIsPointer) :
+        base { std::move(base) }, offsetBytes { offsetBytes }, result { std::move(result) }, baseIsPointer_ { baseIsPointer } {}
+void FieldLoad::generateCode(AssemblyGenerator& generator) const { generator.generateCodeFor(*this); }
+void FieldLoad::print(std::ostream& stream) const {
+    stream << "\t" << result << " := *(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ")\n";
+}
+
+FieldStore::FieldStore(std::string value, std::string base, int offsetBytes, bool baseIsPointer) :
+        value { std::move(value) }, base { std::move(base) }, offsetBytes { offsetBytes }, baseIsPointer_ { baseIsPointer } {}
+void FieldStore::generateCode(AssemblyGenerator& generator) const { generator.generateCodeFor(*this); }
+void FieldStore::print(std::ostream& stream) const {
+    stream << "\t*(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ") := " << value << "\n";
+}
+
+FieldAddress::FieldAddress(std::string base, int offsetBytes, std::string result, bool baseIsPointer) :
+        base { std::move(base) }, offsetBytes { offsetBytes }, result { std::move(result) }, baseIsPointer_ { baseIsPointer } {}
+void FieldAddress::generateCode(AssemblyGenerator& generator) const { generator.generateCodeFor(*this); }
+void FieldAddress::print(std::ostream& stream) const {
+    stream << "\t" << result << " := &(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ")\n";
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/FieldAccess.cpp
+++ b/src/codegen/quadruples/FieldAccess.cpp
@@ -4,23 +4,18 @@
 
 namespace codegen {
 
-FieldLoad::FieldLoad(std::string base, int offsetBytes, std::string result, bool baseIsPointer) :
-        base { std::move(base) }, offsetBytes { offsetBytes }, result { std::move(result) }, baseIsPointer_ { baseIsPointer } {}
-void FieldLoad::generateCode(AssemblyGenerator& generator) const { generator.generateCodeFor(*this); }
-void FieldLoad::print(std::ostream& stream) const {
-    stream << "\t" << result << " := *(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ")\n";
-}
-
-FieldStore::FieldStore(std::string value, std::string base, int offsetBytes, bool baseIsPointer) :
-        value { std::move(value) }, base { std::move(base) }, offsetBytes { offsetBytes }, baseIsPointer_ { baseIsPointer } {}
-void FieldStore::generateCode(AssemblyGenerator& generator) const { generator.generateCodeFor(*this); }
-void FieldStore::print(std::ostream& stream) const {
-    stream << "\t*(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ") := " << value << "\n";
-}
-
 FieldAddress::FieldAddress(std::string base, int offsetBytes, std::string result, bool baseIsPointer) :
-        base { std::move(base) }, offsetBytes { offsetBytes }, result { std::move(result) }, baseIsPointer_ { baseIsPointer } {}
-void FieldAddress::generateCode(AssemblyGenerator& generator) const { generator.generateCodeFor(*this); }
+        base { std::move(base) },
+        offsetBytes { offsetBytes },
+        result { std::move(result) },
+        baseIsPointer_ { baseIsPointer }
+{
+}
+
+void FieldAddress::generateCode(AssemblyGenerator& generator) const {
+    generator.generateCodeFor(*this);
+}
+
 void FieldAddress::print(std::ostream& stream) const {
     stream << "\t" << result << " := &(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ")\n";
 }

--- a/src/codegen/quadruples/FieldAccess.h
+++ b/src/codegen/quadruples/FieldAccess.h
@@ -6,38 +6,7 @@
 
 namespace codegen {
 
-class FieldLoad: public Quadruple {
-public:
-    FieldLoad(std::string base, int offsetBytes, std::string result, bool baseIsPointer = false);
-    void generateCode(AssemblyGenerator& generator) const override;
-    std::string getBase() const { return base; }
-    int getOffsetBytes() const { return offsetBytes; }
-    std::string getResult() const { return result; }
-    bool baseIsPointer() const { return baseIsPointer_; }
-private:
-    void print(std::ostream& stream) const override;
-    std::string base;
-    int offsetBytes;
-    std::string result;
-    bool baseIsPointer_;
-};
-
-class FieldStore: public Quadruple {
-public:
-    FieldStore(std::string value, std::string base, int offsetBytes, bool baseIsPointer = false);
-    void generateCode(AssemblyGenerator& generator) const override;
-    std::string getValue() const { return value; }
-    std::string getBase() const { return base; }
-    int getOffsetBytes() const { return offsetBytes; }
-    bool baseIsPointer() const { return baseIsPointer_; }
-private:
-    void print(std::ostream& stream) const override;
-    std::string value;
-    std::string base;
-    int offsetBytes;
-    bool baseIsPointer_;
-};
-
+// result = address of field: (&base) + offset, or (*base) + offset when baseIsPointer (arrow).
 class FieldAddress: public Quadruple {
 public:
     FieldAddress(std::string base, int offsetBytes, std::string result, bool baseIsPointer = false);

--- a/src/codegen/quadruples/FieldAccess.h
+++ b/src/codegen/quadruples/FieldAccess.h
@@ -1,0 +1,58 @@
+#ifndef FIELDACCESS_QUADRUPLE_H_
+#define FIELDACCESS_QUADRUPLE_H_
+
+#include <string>
+#include "Quadruple.h"
+
+namespace codegen {
+
+class FieldLoad: public Quadruple {
+public:
+    FieldLoad(std::string base, int offsetBytes, std::string result, bool baseIsPointer = false);
+    void generateCode(AssemblyGenerator& generator) const override;
+    std::string getBase() const { return base; }
+    int getOffsetBytes() const { return offsetBytes; }
+    std::string getResult() const { return result; }
+    bool baseIsPointer() const { return baseIsPointer_; }
+private:
+    void print(std::ostream& stream) const override;
+    std::string base;
+    int offsetBytes;
+    std::string result;
+    bool baseIsPointer_;
+};
+
+class FieldStore: public Quadruple {
+public:
+    FieldStore(std::string value, std::string base, int offsetBytes, bool baseIsPointer = false);
+    void generateCode(AssemblyGenerator& generator) const override;
+    std::string getValue() const { return value; }
+    std::string getBase() const { return base; }
+    int getOffsetBytes() const { return offsetBytes; }
+    bool baseIsPointer() const { return baseIsPointer_; }
+private:
+    void print(std::ostream& stream) const override;
+    std::string value;
+    std::string base;
+    int offsetBytes;
+    bool baseIsPointer_;
+};
+
+class FieldAddress: public Quadruple {
+public:
+    FieldAddress(std::string base, int offsetBytes, std::string result, bool baseIsPointer = false);
+    void generateCode(AssemblyGenerator& generator) const override;
+    std::string getBase() const { return base; }
+    int getOffsetBytes() const { return offsetBytes; }
+    std::string getResult() const { return result; }
+    bool baseIsPointer() const { return baseIsPointer_; }
+private:
+    void print(std::ostream& stream) const override;
+    std::string base;
+    int offsetBytes;
+    std::string result;
+    bool baseIsPointer_;
+};
+
+} // namespace codegen
+#endif

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -457,5 +457,33 @@ std::vector<ValueEntry> SemanticAnalysisVisitor::getGlobalVariables() const {
     return symbolTable.getGlobalVariables();
 }
 
-} // namespace semantic_analyzer
 
+void SemanticAnalysisVisitor::visit(ast::MemberAccess& expression) {
+    expression.getBase()->accept(*this);
+    type::Type baseType = expression.getBase()->getType();
+    type::Type structType = baseType;
+    if (expression.isArrow()) {
+        if (!baseType.isPointer()) {
+            semanticError("base of '->' is not a pointer", expression.getContext());
+            return;
+        }
+        structType = baseType.dereference();
+    }
+    if (!structType.isStructure()) {
+        semanticError("request for member in non-struct", expression.getContext());
+        return;
+    }
+    type::Type memberTy = type::signedInteger();
+    int offset = 0;
+    if (!structType.memberType(expression.getMemberName(), memberTy) ||
+            !structType.memberOffset(expression.getMemberName(), offset)) {
+        semanticError("struct has no member named `" + expression.getMemberName() + "`", expression.getContext());
+        return;
+    }
+    expression.setMemberOffset(offset);
+    expression.setBaseResultSymbol(*expression.getBase()->getResultSymbol());
+    expression.setResultSymbol(symbolTable.createTemporarySymbol(memberTy));
+    expression.setFieldAddressSymbol(symbolTable.createTemporarySymbol(type::pointer(memberTy)));
+}
+
+} // namespace semantic_analyzer

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -384,8 +384,8 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDeclarator& declarator) {
         argumentNames.push_back(argumentDeclaration.getName());
     }
 
-    // FIXME: return type is not known at this point!
-    type::Type functionType = type::function(type::signedInteger(), arguments);
+    type::Type returnType = definitionReturnType.value_or(type::signedInteger());
+    type::Type functionType = type::function(returnType, arguments);
     if (symbolTable.hasGlobalVariable(declarator.getName())) {
         semanticError("function `" + declarator.getName() + "` conflicts with global variable of the same name",
                 declarator.getContext());
@@ -412,7 +412,12 @@ void SemanticAnalysisVisitor::visit(ast::FormalArgument& argument) {
 
 void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
     function.visitReturnType(*this);
+    const auto& specs = function.getReturnTypeSpecifiers().getTypeSpecifiers();
+    if (!specs.empty()) {
+        definitionReturnType = specs.at(0).getType();
+    }
     function.visitDeclarator(*this);
+    definitionReturnType.reset();
 
     if (!symbolTable.hasFunction(function.getName())) {
         return;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -5,6 +5,7 @@
 
 #include "SymbolTable.h"
 #include "ast/AbstractSyntaxTreeVisitor.h"
+#include <optional>
 
 namespace semantic_analyzer {
 
@@ -73,6 +74,8 @@ private:
     void semanticError(std::string message, const translation_unit::Context& context);
 
     std::vector<std::string> argumentNames;
+    // Set while visiting a function definition declarator so return type is not assumed int.
+    std::optional<type::Type> definitionReturnType;
 
     bool containsSemanticErrors { false };
     std::ostream* errorStream;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -35,6 +35,7 @@ public:
     void visit(ast::LogicalAndExpression& expression) override;
     void visit(ast::LogicalOrExpression& expression) override;
     void visit(ast::AssignmentExpression& expression) override;
+    void visit(ast::MemberAccess& expression) override;
     void visit(ast::ExpressionList& expression) override;
 
     void visit(ast::Operator& op) override;

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -351,5 +351,9 @@ void SemanticXmlOutputVisitor::visit(ast::Block& block) {
     closeXmlNode(nodeId);
 }
 
+
+void SemanticXmlOutputVisitor::visit(ast::MemberAccess&) {
+}
+
 } // namespace semantic_analyzer
 

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.h
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.h
@@ -35,6 +35,7 @@ public:
     void visit(ast::LogicalAndExpression& expression) override;
     void visit(ast::LogicalOrExpression& expression) override;
     void visit(ast::AssignmentExpression& expression) override;
+    void visit(ast::MemberAccess& expression) override;
     void visit(ast::ExpressionList& expression) override;
 
     void visit(ast::Operator& op) override;

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -97,7 +97,9 @@ int Type::getSize() const {
     if (isPrimitive()) {
         return _primitive->getSize();
     }
-
+    if (isStructure()) {
+        return _structure->size;
+    }
     return _size;
 }
 
@@ -172,6 +174,7 @@ std::string Type::to_string() const {
     return "unknown type";
 }
 
+
 Type::Member::Member(std::string n, Type t, int off) :
         name { std::move(n) },
         type { std::make_unique<Type>(std::move(t)) },
@@ -207,37 +210,63 @@ int memberStride(const Type& memberType) {
     if (size < 1) {
         size = 1;
     }
+    // Pointers and incomplete structs still get a full word as a member slot.
     return alignUp(size, WORD_ALIGN);
 }
-} // namespace
 
-Type structure(std::vector<std::pair<std::string, Type>> members) {
-    Type result { std::vector<Qualifier> {} };
-    std::vector<Type::Member> laidOut;
+void layoutMembers(Type::StructBody& body, std::vector<std::pair<std::string, Type>> members) {
+    body.members.clear();
     int offset = 0;
     for (auto& entry : members) {
         offset = alignUp(offset, WORD_ALIGN);
-        laidOut.emplace_back(entry.first, entry.second, offset);
+        body.members.emplace_back(entry.first, entry.second, offset);
         offset += memberStride(entry.second);
     }
-    result._size = alignUp(offset, WORD_ALIGN);
-    result._structure = std::move(laidOut);
+    body.size = alignUp(offset, WORD_ALIGN);
+    body.complete = true;
+}
+} // namespace
+
+Type incompleteStructure() {
+    Type result { std::vector<Qualifier> {} };
+    result._structure = std::make_shared<Type::StructBody>();
+    result._structure->complete = false;
+    result._structure->size = 0;
+    result._size = 0;
     return result;
 }
 
+Type structure(std::vector<std::pair<std::string, Type>> members) {
+    Type result = incompleteStructure();
+    completeStructure(result, std::move(members));
+    return result;
+}
+
+void completeStructure(Type& structType, std::vector<std::pair<std::string, Type>> members) {
+    if (!structType._structure) {
+        structType._structure = std::make_shared<Type::StructBody>();
+    }
+    layoutMembers(*structType._structure, std::move(members));
+    structType._size = structType._structure->size;
+}
+
 bool Type::isStructure() const {
-    return _structure.has_value();
+    return _structure != nullptr;
+}
+
+bool Type::isCompleteStructure() const {
+    return _structure && _structure->complete;
 }
 
 const std::vector<Type::Member>& Type::getStructMembers() const {
-    return *_structure;
+    return _structure->members;
 }
 
 bool Type::memberOffset(const std::string& memberName, int& offsetBytes) const {
     if (!_structure) {
         return false;
     }
-    for (const auto& member : *_structure) {
+    for (const auto& member : _structure->members) {
         if (member.name == memberName) {
             offsetBytes = member.offsetBytes;
             return true;
@@ -250,7 +279,7 @@ bool Type::memberType(const std::string& memberName, Type& outType) const {
     if (!_structure) {
         return false;
     }
-    for (const auto& member : *_structure) {
+    for (const auto& member : _structure->members) {
         if (member.name == memberName) {
             outType = *member.type;
             return true;

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -1,6 +1,7 @@
 #include "Type.h"
 
 #include <stdexcept>
+#include <algorithm>
 #include <sstream>
 
 namespace type {
@@ -137,9 +138,6 @@ Function Type::getFunction() const {
     return *_function;
 }
 
-bool Type::isStructure() const {
-    return false;
-}
 
 Type Type::dereference() const {
     if (!isPointer()) {
@@ -174,5 +172,91 @@ std::string Type::to_string() const {
     return "unknown type";
 }
 
-} // namespace type
+Type::Member::Member(std::string n, Type t, int off) :
+        name { std::move(n) },
+        type { std::make_unique<Type>(std::move(t)) },
+        offsetBytes { off }
+{
+}
 
+Type::Member::Member(const Member& other) :
+        name { other.name },
+        type { other.type ? std::make_unique<Type>(*other.type) : nullptr },
+        offsetBytes { other.offsetBytes }
+{
+}
+
+Type::Member& Type::Member::operator=(const Member& other) {
+    if (this != &other) {
+        name = other.name;
+        type = other.type ? std::make_unique<Type>(*other.type) : nullptr;
+        offsetBytes = other.offsetBytes;
+    }
+    return *this;
+}
+
+namespace {
+constexpr int WORD_ALIGN = 8;
+
+int alignUp(int value, int alignment) {
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+int memberStride(const Type& memberType) {
+    int size = memberType.getSize();
+    if (size < 1) {
+        size = 1;
+    }
+    return alignUp(size, WORD_ALIGN);
+}
+} // namespace
+
+Type structure(std::vector<std::pair<std::string, Type>> members) {
+    Type result { std::vector<Qualifier> {} };
+    std::vector<Type::Member> laidOut;
+    int offset = 0;
+    for (auto& entry : members) {
+        offset = alignUp(offset, WORD_ALIGN);
+        laidOut.emplace_back(entry.first, entry.second, offset);
+        offset += memberStride(entry.second);
+    }
+    result._size = alignUp(offset, WORD_ALIGN);
+    result._structure = std::move(laidOut);
+    return result;
+}
+
+bool Type::isStructure() const {
+    return _structure.has_value();
+}
+
+const std::vector<Type::Member>& Type::getStructMembers() const {
+    return *_structure;
+}
+
+bool Type::memberOffset(const std::string& memberName, int& offsetBytes) const {
+    if (!_structure) {
+        return false;
+    }
+    for (const auto& member : *_structure) {
+        if (member.name == memberName) {
+            offsetBytes = member.offsetBytes;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Type::memberType(const std::string& memberName, Type& outType) const {
+    if (!_structure) {
+        return false;
+    }
+    for (const auto& member : *_structure) {
+        if (member.name == memberName) {
+            outType = *member.type;
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace type

--- a/src/types/Type.h
+++ b/src/types/Type.h
@@ -20,7 +20,6 @@ class Type {
 public:
     struct Member {
         std::string name;
-        // Stored by value after Type is complete enough via recursive optional vector.
         std::unique_ptr<Type> type;
         int offsetBytes { 0 };
 
@@ -32,11 +31,19 @@ public:
         Member& operator=(Member&&) noexcept = default;
     };
 
+    struct StructBody {
+        std::vector<Member> members;
+        int size { 0 };
+        bool complete { false };
+    };
+
     friend Type voidType();
     friend Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifiers);
     friend Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers);
     friend Type function(const Type& returnType, const std::vector<Type>& arguments);
+    friend Type incompleteStructure();
     friend Type structure(std::vector<std::pair<std::string, Type>> members);
+    friend void completeStructure(Type& structType, std::vector<std::pair<std::string, Type>> members);
 
     int getSize() const;
     bool canAssignFrom(const Type& other) const;
@@ -48,6 +55,7 @@ public:
     bool isFunction() const;
     Function getFunction() const;
     bool isStructure() const;
+    bool isCompleteStructure() const;
     const std::vector<Member>& getStructMembers() const;
     bool memberOffset(const std::string& memberName, int& offsetBytes) const;
     bool memberType(const std::string& memberName, Type& outType) const;
@@ -66,7 +74,8 @@ private:
 
     std::optional<Primitive> _primitive;
     std::optional<Function> _function;
-    std::optional<std::vector<Member>> _structure;
+    // Shared so struct tags and pointers to that struct see the same layout when completed.
+    std::shared_ptr<StructBody> _structure;
 
     int _size {0};
     bool _const {false};
@@ -79,7 +88,10 @@ Type voidType();
 Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifiers = {});
 Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers = {});
 Type function(const Type& returnType, const std::vector<Type>& arguments = {});
+// Incomplete struct (for tags / self-referential pointers); complete with completeStructure.
+Type incompleteStructure();
 Type structure(std::vector<std::pair<std::string, Type>> members);
+void completeStructure(Type& structType, std::vector<std::pair<std::string, Type>> members);
 
 Type signedCharacter(const std::vector<Qualifier>& qualifiers = {});
 Type unsignedCharacter(const std::vector<Qualifier>& qualifiers = {});

--- a/src/types/Type.h
+++ b/src/types/Type.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <optional>
 #include <memory>
+#include <utility>
 
 namespace type {
 
@@ -17,11 +18,25 @@ enum class Qualifier {
 
 class Type {
 public:
+    struct Member {
+        std::string name;
+        // Stored by value after Type is complete enough via recursive optional vector.
+        std::unique_ptr<Type> type;
+        int offsetBytes { 0 };
+
+        Member() = default;
+        Member(std::string n, Type t, int off);
+        Member(const Member& other);
+        Member& operator=(const Member& other);
+        Member(Member&&) noexcept = default;
+        Member& operator=(Member&&) noexcept = default;
+    };
+
     friend Type voidType();
     friend Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifiers);
     friend Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers);
     friend Type function(const Type& returnType, const std::vector<Type>& arguments);
-    friend Type structure(const std::vector<Type>& members);
+    friend Type structure(std::vector<std::pair<std::string, Type>> members);
 
     int getSize() const;
     bool canAssignFrom(const Type& other) const;
@@ -33,6 +48,9 @@ public:
     bool isFunction() const;
     Function getFunction() const;
     bool isStructure() const;
+    const std::vector<Member>& getStructMembers() const;
+    bool memberOffset(const std::string& memberName, int& offsetBytes) const;
+    bool memberType(const std::string& memberName, Type& outType) const;
 
     bool isConst() const;
     bool isVolatile() const;
@@ -48,6 +66,7 @@ private:
 
     std::optional<Primitive> _primitive;
     std::optional<Function> _function;
+    std::optional<std::vector<Member>> _structure;
 
     int _size {0};
     bool _const {false};
@@ -60,7 +79,7 @@ Type voidType();
 Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifiers = {});
 Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers = {});
 Type function(const Type& returnType, const std::vector<Type>& arguments = {});
-Type structure(const std::vector<Type>& members = {});
+Type structure(std::vector<std::pair<std::string, Type>> members);
 
 Type signedCharacter(const std::vector<Qualifier>& qualifiers = {});
 Type unsignedCharacter(const std::vector<Qualifier>& qualifiers = {});

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -119,6 +119,7 @@ add_executable(functionalTest gtest.cpp
         functionalTest/ScopeTest.cpp
         functionalTest/IntegrationTest.cpp
         functionalTest/GlobalVariablesTest.cpp
+        functionalTest/StructsTest.cpp
         )
 target_link_libraries(functionalTest gmock driver translation_unit scanner util parser testUtil)
 add_test(functionalTest functionalTest)

--- a/test/src/functionalTest/StructsTest.cpp
+++ b/test/src/functionalTest/StructsTest.cpp
@@ -62,8 +62,6 @@ TEST(Compiler, globalStructMembers) {
     program.runAndExpect("1 2");
 }
 
-} // namespace
-
 TEST(Compiler, structIntPointerMember) {
     SourceProgram program{R"prg(
         struct Holder {
@@ -106,3 +104,296 @@ TEST(Compiler, structSelfPointerMember) {
     program.compile();
     program.runAndExpect("2 1");
 }
+
+TEST(Compiler, structPassByValue) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int sum(struct Point p) {
+            return p.x + p.y;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 3;
+            p.y = 4;
+            printf("%d", sum(p));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+TEST(Compiler, structPassByAddress) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int sum(struct Point *p) {
+            return p->x + p->y;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 3;
+            p.y = 4;
+            printf("%d", sum(&p));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+TEST(Compiler, structPassByAddressMiddleArg) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int mix(int a, struct Point *p, int b) {
+            return a + p->x + p->y + b;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 10;
+            p.y = 20;
+            printf("%d", mix(1, &p, 2));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("33");
+}
+
+TEST(Compiler, structPassByValueAfterInts) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int mix(int a, int b, struct Point p) {
+            return a + b + p.x + p.y;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 10;
+            p.y = 20;
+            printf("%d", mix(1, 2, p));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("33");
+}
+
+TEST(Compiler, structPassByValueBeforeInts) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int mix(struct Point p, int a, int b) {
+            return p.x + p.y + a + b;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 10;
+            p.y = 20;
+            printf("%d", mix(p, 1, 2));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("33");
+}
+
+TEST(Compiler, structPassByValueMutatesOnlyCopy) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        void bump(struct Point p) {
+            p.x = 100;
+            p.y = 200;
+            return;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 1;
+            p.y = 2;
+            bump(p);
+            printf("%d %d", p.x, p.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2");
+}
+
+TEST(Compiler, structPassByAddressMutatesOriginal) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        void bump(struct Point *p) {
+            p->x = 100;
+            p->y = 200;
+            return;
+        }
+
+        int main() {
+            struct Point p;
+            p.x = 1;
+            p.y = 2;
+            bump(&p);
+            printf("%d %d", p.x, p.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("100 200");
+}
+
+TEST(Compiler, structReturnByValue) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        struct Point make(void) {
+            struct Point p;
+            p.x = 9;
+            p.y = 10;
+            return p;
+        }
+
+        int main() {
+            struct Point p;
+            p = make();
+            printf("%d %d", p.x, p.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9 10");
+}
+
+TEST(Compiler, structReturnByPointer) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        struct Point g;
+
+        struct Point *get(void) {
+            g.x = 1;
+            g.y = 2;
+            return &g;
+        }
+
+        int main() {
+            struct Point *p;
+            p = get();
+            printf("%d %d", p->x, p->y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2");
+}
+
+TEST(Compiler, structAssignCopies) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct Point a;
+            struct Point b;
+            a.x = 5;
+            a.y = 6;
+            b = a;
+            a.x = 0;
+            a.y = 0;
+            printf("%d %d", b.x, b.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5 6");
+}
+
+TEST(Compiler, structNestedMemberViaPointerChain) {
+    SourceProgram program{R"prg(
+        struct Node {
+            int value;
+            struct Node *next;
+        };
+
+        int main() {
+            struct Node a;
+            struct Node b;
+            struct Node c;
+            a.value = 1;
+            b.value = 2;
+            c.value = 3;
+            a.next = &b;
+            b.next = &c;
+            c.next = 0;
+            printf("%d", a.next->next->value);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, structThreeMembers) {
+    SourceProgram program{R"prg(
+        struct Triple {
+            int a;
+            int b;
+            int c;
+        };
+
+        int sum(struct Triple t) {
+            return t.a + t.b + t.c;
+        }
+
+        int main() {
+            struct Triple t;
+            t.a = 1;
+            t.b = 2;
+            t.c = 3;
+            printf("%d", sum(t));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("6");
+}
+
+} // namespace

--- a/test/src/functionalTest/StructsTest.cpp
+++ b/test/src/functionalTest/StructsTest.cpp
@@ -1,0 +1,65 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, structMemberReadWrite) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct Point p;
+            p.x = 3;
+            p.y = 4;
+            printf("%d %d", p.x, p.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3 4");
+}
+
+TEST(Compiler, structPointerArrow) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct Point p;
+            struct Point *pp;
+            pp = &p;
+            pp->x = 7;
+            pp->y = 8;
+            printf("%d %d", p.x, p.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7 8");
+}
+
+TEST(Compiler, globalStructMembers) {
+    SourceProgram program{R"prg(
+        struct Point {
+            int x;
+            int y;
+        };
+
+        struct Point g;
+
+        int main() {
+            g.x = 1;
+            g.y = 2;
+            printf("%d %d", g.x, g.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2");
+}
+
+} // namespace

--- a/test/src/functionalTest/StructsTest.cpp
+++ b/test/src/functionalTest/StructsTest.cpp
@@ -63,3 +63,46 @@ TEST(Compiler, globalStructMembers) {
 }
 
 } // namespace
+
+TEST(Compiler, structIntPointerMember) {
+    SourceProgram program{R"prg(
+        struct Holder {
+            int value;
+            int *ptr;
+        };
+
+        int main() {
+            int x;
+            struct Holder h;
+            x = 5;
+            h.value = 1;
+            h.ptr = &x;
+            printf("%d %d", h.value, *h.ptr);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 5");
+}
+
+TEST(Compiler, structSelfPointerMember) {
+    SourceProgram program{R"prg(
+        struct Node {
+            int value;
+            struct Node *next;
+        };
+
+        int main() {
+            struct Node a;
+            struct Node b;
+            a.value = 1;
+            b.value = 2;
+            a.next = &b;
+            b.next = &a;
+            printf("%d %d", a.next->value, b.next->value);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2 1");
+}


### PR DESCRIPTION
## Summary
- **Types:** `type::structure` with named members, word-aligned offsets, `memberOffset` / `memberType`.
- **Parse/AST:** struct definitions and tags; `.` / `->` member access (`MemberAccess`); scanner keywords `struct`/`union` and tokens `.` / `->`.
- **Semantics:** resolve member types/offsets; field address temp for stores.
- **Codegen:** `FieldAddress` / `FieldLoad` / `FieldStore`; multi-word frame allocation; multi-word `.data` for global structs.
- **Tests:** local read/write, arrow through pointer, global struct members.

### Limits (MVP)
- No `union`, bitfields, flexible arrays, or incomplete `struct Tag` before definition in another order.
- Whole-struct assignment not specially optimized (use members).
- Members stride-aligned to 8 bytes.

## Test plan
- [x] Full local `ctest`
- [x] `Compiler.struct*` functional tests
- [ ] CI `build`