### PR TITLE
perf(parser): value-type Action and flat (state,symbol) tables

### DIFF
--- a/src/parser/Action.cpp
+++ b/src/parser/Action.cpp
@@ -1,138 +1,170 @@
 #include "Action.h"
 
 #include <sstream>
+#include <stdexcept>
 
 #include "Grammar.h"
+#include "ParsingTable.h"
+#include "Production.h"
 #include "util/Logger.h"
 #include "util/LogManager.h"
 
 namespace parser {
 
+namespace {
 const char SHIFT_ACTION = 's';
 const char REDUCE_ACTION = 'r';
 const char ERROR_ACTION = 'e';
 const char ACCEPT_ACTION = 'a';
 
-static Logger& err = LogManager::getErrorLogger();
+Logger& err = LogManager::getErrorLogger();
+} // namespace
 
-ShiftAction::ShiftAction(parse_state state) :
-    state { state }
-{
+Action Action::shift(parse_state state) {
+    Action action;
+    action.kind_ = Kind::Shift;
+    action.state_ = state;
+    return action;
 }
 
-ReduceAction::ReduceAction(const Production& production, const ParsingTable* parsingTable) :
-    production { production },
-    parsingTable { parsingTable }
-{
+Action Action::reduce(const Production& production, const ParsingTable* parsingTable) {
+    Action action;
+    action.kind_ = Kind::Reduce;
+    action.production_ = &production;
+    action.parsingTable_ = parsingTable;
+    return action;
 }
 
-ErrorAction::ErrorAction(parse_state state, std::vector<int> candidateSymbols, const Grammar* grammar) :
-    state { state },
-    candidateSymbols { candidateSymbols },
-    grammar { grammar }
-{
+Action Action::accept() {
+    Action action;
+    action.kind_ = Kind::Accept;
+    return action;
 }
 
-Action::~Action() = default;
-AcceptAction::~AcceptAction() = default;
-ShiftAction::~ShiftAction() = default;
-ReduceAction::~ReduceAction() = default;
-ErrorAction::~ErrorAction() = default;
-
-std::string AcceptAction::serialize() const {
-    return std::string{ACCEPT_ACTION};
+Action Action::error(parse_state state,
+        std::shared_ptr<const std::vector<int>> candidateSymbols,
+        const Grammar* grammar) {
+    Action action;
+    action.kind_ = Kind::Error;
+    action.state_ = state;
+    action.candidateSymbols_ = std::move(candidateSymbols);
+    action.grammar_ = grammar;
+    return action;
 }
 
-std::string ShiftAction::serialize() const {
-    return std::string{SHIFT_ACTION} + " " + std::to_string(state);
-}
-
-std::string ReduceAction::serialize() const {
-    return std::string{REDUCE_ACTION} + " " + std::to_string(production.getId());
-}
-
-std::string ErrorAction::serialize() const {
-    std::stringstream s;
-    s << ERROR_ACTION << " " << state;
-    for (const auto& candidate: candidateSymbols) {
-        s << " " << candidate;
+std::string Action::serialize() const {
+    switch (kind_) {
+    case Kind::Accept:
+        return std::string{ACCEPT_ACTION};
+    case Kind::Shift:
+        return std::string{SHIFT_ACTION} + " " + std::to_string(state_);
+    case Kind::Reduce:
+        return std::string{REDUCE_ACTION} + " " + std::to_string(production_->getId());
+    case Kind::Error: {
+        std::ostringstream s;
+        s << ERROR_ACTION << " " << state_;
+        if (candidateSymbols_) {
+            for (const auto candidate : *candidateSymbols_) {
+                s << " " << candidate;
+            }
+        }
+        return s.str();
     }
-    return s.str();
+    }
+    __builtin_unreachable();
 }
 
-std::unique_ptr<Action> Action::deserialize(std::string serializedAction, const ParsingTable& parsingTable, const Grammar& grammar) {
+bool Action::equals(const Action& other) const {
+    if (kind_ != other.kind_) {
+        return false;
+    }
+    switch (kind_) {
+    case Kind::Accept:
+        return true;
+    case Kind::Shift:
+        return state_ == other.state_;
+    case Kind::Reduce:
+        return production_->getId() == other.production_->getId();
+    case Kind::Error:
+        return state_ == other.state_
+                && candidateSymbols_ && other.candidateSymbols_
+                && *candidateSymbols_ == *other.candidateSymbols_;
+    }
+    __builtin_unreachable();
+}
+
+Action Action::deserialize(const std::string& serializedAction,
+        const ParsingTable& parsingTable, const Grammar& grammar) {
     std::istringstream actionStream { serializedAction };
     char type;
     actionStream >> type;
     switch (type) {
-        case SHIFT_ACTION: {
-            parse_state state;
-            actionStream >> state;
-            return std::make_unique<ShiftAction>(state);
+    case SHIFT_ACTION: {
+        parse_state state;
+        actionStream >> state;
+        return Action::shift(state);
+    }
+    case REDUCE_ACTION: {
+        size_t productionId;
+        actionStream >> productionId;
+        return Action::reduce(grammar.getRuleById(static_cast<int>(productionId)), &parsingTable);
+    }
+    case ERROR_ACTION: {
+        parse_state state;
+        actionStream >> state;
+        std::vector<int> candidates;
+        int candidate;
+        while (actionStream >> candidate) {
+            candidates.push_back(candidate);
         }
-        case REDUCE_ACTION: {
-            size_t productionId;
-            actionStream >> productionId;
-            const auto& production = grammar.getRuleById(productionId);
-            return std::make_unique<ReduceAction>(production, &parsingTable);
+        return Action::error(state,
+                std::make_shared<const std::vector<int>>(std::move(candidates)),
+                &grammar);
+    }
+    case ACCEPT_ACTION:
+        return Action::accept();
+    default:
+        throw std::runtime_error(
+                "Error reading serialized parsing table: invalid action type: "
+                        + std::to_string(type));
+    }
+}
+
+bool Action::parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream,
+        SyntaxTreeBuilder& syntaxTreeBuilder) const {
+    switch (kind_) {
+    case Kind::Accept:
+        return true;
+    case Kind::Shift: {
+        parsingStack.push(state_);
+        scanner::Token token = tokenStream.getCurrentToken();
+        syntaxTreeBuilder.makeTerminalNode(token.id, token.lexeme, token.context);
+        tokenStream.nextToken();
+        return false;
+    }
+    case Kind::Reduce: {
+        for (size_t i = production_->size(); i > 0; --i) {
+            parsingStack.pop();
         }
-        case ERROR_ACTION: {
-            parse_state state;
-            actionStream >> state;
-            std::vector<int> candidateSymbols;
-            int candidate;
-            while (actionStream >> candidate) {
-                candidateSymbols.push_back(candidate);
+        parsingStack.push(parsingTable_->go_to(parsingStack.top(), production_->getDefiningSymbol()));
+        syntaxTreeBuilder.makeNonterminalNode(*production_);
+        return false;
+    }
+    case Kind::Error: {
+        syntaxTreeBuilder.err();
+        scanner::Token currentToken = tokenStream.getCurrentToken();
+        err << "Error: " << currentToken.context << ": unexpected token: " << currentToken.lexeme
+                << " expected:";
+        if (candidateSymbols_ && grammar_) {
+            for (const auto candidate : *candidateSymbols_) {
+                err << " " << grammar_->getSymbolById(candidate);
             }
-            return std::make_unique<ErrorAction>(state, candidateSymbols, &grammar);
         }
-        case ACCEPT_ACTION:
-            return std::make_unique<AcceptAction>();
-        default:
-            throw std::runtime_error("Error reading serialized parsing table: invalid action type: " + std::to_string(type));
+        err << "\n";
+        return true;
     }
-}
-
-bool AcceptAction::parse(std::stack<parse_state>&, TokenStream&, SyntaxTreeBuilder&) const {
-    return true;
-}
-
-bool ShiftAction::parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream, SyntaxTreeBuilder& syntaxTreeBuilder) const {
-    parsingStack.push(state);
-    scanner::Token token = tokenStream.getCurrentToken();
-    syntaxTreeBuilder.makeTerminalNode(token.id, token.lexeme, token.context);
-    tokenStream.nextToken();
-    return false;
-}
-
-bool ReduceAction::parse(std::stack<parse_state>& parsingStack, TokenStream&, SyntaxTreeBuilder& syntaxTreeBuilder) const {
-    for (size_t i = production.size(); i > 0; --i) {
-        parsingStack.pop();
     }
-    parsingStack.push(parsingTable->go_to(parsingStack.top(), production.getDefiningSymbol()));
-    syntaxTreeBuilder.makeNonterminalNode(production);
-    return false;
-}
-
-bool ErrorAction::parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream, SyntaxTreeBuilder& syntaxTreeBuilder) const {
-    syntaxTreeBuilder.err();
-    scanner::Token currentToken = tokenStream.getCurrentToken();
-
-    err << "Error: " << currentToken.context << ": unexpected token: " << currentToken.lexeme << " expected:";
-    for (const auto& candidate : candidateSymbols) {
-        err << " " << grammar->getSymbolById(candidate);
-    }
-    err << "\n";
-    return true;
-}
-
-bool Action::isCorrective() const {
-    return false;
-}
-
-bool ReduceAction::isCorrective() const {
-    return true;
+    __builtin_unreachable();
 }
 
 } // namespace parser
-

--- a/src/parser/Action.h
+++ b/src/parser/Action.h
@@ -1,81 +1,62 @@
 #ifndef _ACTION_H_
 #define _ACTION_H_
 
+#include <cstddef>
 #include <memory>
 #include <stack>
 #include <string>
+#include <vector>
 
-#include "ParsingTable.h"
 #include "TokenStream.h"
-
 #include "SyntaxTreeBuilder.h"
 
 namespace parser {
 
+class ParsingTable;
+class Grammar;
+class Production;
+using parse_state = size_t;
+
+// Value-type LR action cell (shift / reduce / accept / error).
+// Replaces the former virtual Action hierarchy + unique_ptr heap cells.
 class Action {
 public:
-    virtual ~Action();
+    enum class Kind : char {
+        Shift = 's',
+        Reduce = 'r',
+        Accept = 'a',
+        Error = 'e',
+    };
 
-    virtual bool parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream, SyntaxTreeBuilder& syntaxTreeBuilder) const = 0;
+    Action() = default;
 
-    virtual std::string serialize() const = 0;
+    static Action shift(parse_state state);
+    static Action reduce(const Production& production, const ParsingTable* parsingTable);
+    static Action accept();
+    static Action error(parse_state state,
+            std::shared_ptr<const std::vector<int>> candidateSymbols,
+            const Grammar* grammar);
 
-    static std::unique_ptr<Action> deserialize(std::string serializedAction, const ParsingTable& parsingTable, const Grammar& grammar);
+    Kind kind() const noexcept { return kind_; }
 
-    virtual bool isCorrective() const;
-};
+    // Returns true when the parse is finished (accept or error).
+    bool parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream,
+            SyntaxTreeBuilder& syntaxTreeBuilder) const;
 
-class AcceptAction: public Action {
-public:
-    virtual ~AcceptAction();
+    std::string serialize() const;
+    bool equals(const Action& other) const;
+    bool isCorrective() const noexcept { return kind_ == Kind::Reduce; }
 
-    bool parse(std::stack<parse_state>&, TokenStream&, SyntaxTreeBuilder&) const override;
-
-    std::string serialize() const override;
-};
-
-class ShiftAction: public Action {
-public:
-    ShiftAction(parse_state state);
-    virtual ~ShiftAction();
-
-    bool parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream, SyntaxTreeBuilder& syntaxTreeBuilder) const override;
-
-    std::string serialize() const override;
-
-private:
-    parse_state state;
-};
-
-class ReduceAction: public Action {
-public:
-    ReduceAction(const Production& production, const ParsingTable* parsingTable);
-    virtual ~ReduceAction();
-
-    bool parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream, SyntaxTreeBuilder& syntaxTreeBuilder) const override;
-
-    std::string serialize() const override;
-
-    virtual bool isCorrective() const override;
+    static Action deserialize(const std::string& serializedAction,
+            const ParsingTable& parsingTable, const Grammar& grammar);
 
 private:
-    Production production;
-    const ParsingTable* parsingTable;
-};
-
-class ErrorAction: public Action {
-public:
-    ErrorAction(parse_state state, std::vector<int> candidateSymbols, const Grammar* grammar);
-    virtual ~ErrorAction();
-
-    bool parse(std::stack<parse_state>& parsingStack, TokenStream& tokenStream, SyntaxTreeBuilder& syntaxTreeBuilder) const override;
-
-    std::string serialize() const override;
-
-private:
-    const parse_state state;
-    std::vector<int> candidateSymbols;
-    const Grammar* grammar;
+    Kind kind_ { Kind::Accept };
+    parse_state state_ { 0 };
+    const Production* production_ { nullptr };
+    const ParsingTable* parsingTable_ { nullptr };
+    std::shared_ptr<const std::vector<int>> candidateSymbols_;
+    const Grammar* grammar_ { nullptr };
 };
 
 } // namespace parser

--- a/src/parser/FilePersistedParsingTable.cpp
+++ b/src/parser/FilePersistedParsingTable.cpp
@@ -16,7 +16,8 @@ FilePersistedParsingTable::FilePersistedParsingTable(std::string parsingTableFil
     for (parse_state stateNumber = 0; stateNumber < stateCount; ++stateNumber) {
         for (const auto& terminal : grammar->getTerminalIDs()) {
             std::string serializedAction = tableReader.readSerializedAction();
-            lookaheadActionTable.addAction(stateNumber, terminal, Action::deserialize(serializedAction, *this, *grammar));
+            lookaheadActionTable.addAction(
+                    stateNumber, terminal, Action::deserialize(serializedAction, *this, *grammar));
         }
     }
 
@@ -24,11 +25,8 @@ FilePersistedParsingTable::FilePersistedParsingTable(std::string parsingTableFil
 
     while(!tableReader.endOfFile()) {
         std::tuple<parse_state, int, parse_state> gotoRecord = tableReader.readGotoRecord();
-        gotoTable[std::get<0>(gotoRecord)][std::get<1>(gotoRecord)] = std::get<2>(gotoRecord);
+        gotoTable[{ std::get<0>(gotoRecord), std::get<1>(gotoRecord) }] = std::get<2>(gotoRecord);
     }
-}
-
-FilePersistedParsingTable::~FilePersistedParsingTable() {
 }
 
 } // namespace parser

--- a/src/parser/FilePersistedParsingTable.h
+++ b/src/parser/FilePersistedParsingTable.h
@@ -10,7 +10,7 @@ namespace parser {
 class FilePersistedParsingTable: public ParsingTable {
 public:
 	FilePersistedParsingTable(std::string parsingTableFilename, const Grammar* grammar);
-	virtual ~FilePersistedParsingTable();
+	~FilePersistedParsingTable() override = default;
 };
 
 } // namespace parser

--- a/src/parser/GeneratedParsingTable.cpp
+++ b/src/parser/GeneratedParsingTable.cpp
@@ -5,7 +5,7 @@
 
 #include <algorithm>
 #include <fstream>
-#include <optional>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -24,6 +24,10 @@ GeneratedParsingTable::GeneratedParsingTable(const Grammar* grammar, AutomatonKi
 
 void GeneratedParsingTable::computeActionTable(const CanonicalCollection& canonicalCollection) {
     size_t stateCount = canonicalCollection.stateCount();
+    lookaheadActionTable.reserve(stateCount);
+    lookaheadActionTable.setStateCount(stateCount);
+    const int topRuleId = grammar->getTopRule().getId();
+    const int endSymbol = grammar->getEndSymbol();
     for (parse_state currentState = 0; currentState < stateCount; ++currentState) {
         const auto& setOfItemsForCurrentState = canonicalCollection.setOfItemsAtState(currentState);
         for (const auto& item : setOfItemsForCurrentState) {
@@ -33,16 +37,16 @@ void GeneratedParsingTable::computeActionTable(const CanonicalCollection& canoni
                     lookaheadActionTable.addAction(
                             currentState,
                             nextExpectedSymbolForItem,
-                            std::make_unique<ShiftAction>(canonicalCollection.goTo(currentState, nextExpectedSymbolForItem)));
+                            Action::shift(canonicalCollection.goTo(currentState, nextExpectedSymbolForItem)));
                 }
-            } else if ((item.getProduction().getId() == grammar->getTopRule().getId())
-                    && item.hasLookahead(grammar->getEndSymbol(), *grammar)) {
+            } else if ((item.getProduction().getId() == topRuleId)
+                    && item.hasLookahead(endSymbol, *grammar)) {
                 lookaheadActionTable.addAction(
                         currentState,
-                        grammar->getEndSymbol(),
-                        std::make_unique<AcceptAction>());
+                        endSymbol,
+                        Action::accept());
             } else {
-                // Dense bitset path: iterate terminal bits instead of materializing a vector.
+                const Production& production = item.getProduction();
                 const auto& lookaheadBits = item.lookaheads();
                 const std::size_t terminalCount = grammar->terminalCount();
                 for (std::size_t bit = 0; bit < terminalCount; ++bit) {
@@ -50,7 +54,7 @@ void GeneratedParsingTable::computeActionTable(const CanonicalCollection& canoni
                         lookaheadActionTable.addAction(
                                 currentState,
                                 grammar->terminalIdFromBit(bit),
-                                std::make_unique<ReduceAction>(item.getProduction(), this));
+                                Action::reduce(production, this));
                     }
                 }
             }
@@ -60,29 +64,32 @@ void GeneratedParsingTable::computeActionTable(const CanonicalCollection& canoni
 
 void GeneratedParsingTable::computeGotoTable(const CanonicalCollection& canonicalCollection) {
     const auto& transitions = canonicalCollection.computedTransitions();
-    // Nested goto map retained until the action-table layer flattens keys.
+    gotoTable.reserve(transitions.size());
+    // Copy only nonterminal transitions; terminal gotos are shifts in the action table.
     for (const auto& entry : transitions) {
         if (!grammar->isTerminal(entry.first.second)) {
-            gotoTable[entry.first.first][entry.first.second] = entry.second;
+            gotoTable[entry.first] = entry.second;
         }
     }
 }
 
 void GeneratedParsingTable::computeErrorActions(size_t stateCount) {
-    int errorState = 0;
+    const auto& terminals = grammar->getTerminalIDs();
     for (std::size_t state = 0; state < stateCount; ++state) {
-        for (const auto& terminal : grammar->getTerminalIDs()) {
-            if (!lookaheadActionTable.hasAction(state, terminal)) {
-                std::vector<int> candidateTerminals;
-                for (const auto& candidate : grammar->getTerminalIDs()) {
-                    if (candidate != terminal
-                            && lookaheadActionTable.hasAction(state, candidate)
-                            && lookaheadActionTable.action(state, candidate).isCorrective()) {
-                        candidateTerminals.push_back(candidate);
-                    }
-                }
-                lookaheadActionTable.addAction(state, terminal, std::make_unique<ErrorAction>(errorState, candidateTerminals, grammar));
+        std::vector<int> candidates;
+        for (const auto candidate : terminals) {
+            if (lookaheadActionTable.hasCorrectiveAction(state, candidate)) {
+                candidates.push_back(candidate);
             }
+        }
+        if (candidates.empty()) {
+            // Registers grammar for bare errors; no per-state empty candidate storage.
+            lookaheadActionTable.setErrorCandidates(state, nullptr, grammar);
+        } else {
+            lookaheadActionTable.setErrorCandidates(
+                    state,
+                    std::make_shared<const std::vector<int>>(std::move(candidates)),
+                    grammar);
         }
     }
 }
@@ -98,22 +105,21 @@ void GeneratedParsingTable::persistToFile(std::string fileName) const {
     tableOutput << "%%" << std::endl;
     for (std::size_t i = 0; i < stateCount; i++) {
         for (auto& terminal : grammar->getTerminalIDs()) {
-            auto& act = lookaheadActionTable.action(i, terminal);
-            tableOutput << act.serialize() << "\n";
+            tableOutput << lookaheadActionTable.action(i, terminal).serialize() << "\n";
         }
     }
     tableOutput << "%%" << std::endl;
 
     // Stable order for checked-in table identity tests.
-    std::vector<std::tuple<parse_state, int, parse_state>> gotos;
-    for (const auto& stateGotos : gotoTable) {
-        for (const auto& nonterminalGotoState : stateGotos.second) {
-            gotos.emplace_back(stateGotos.first, nonterminalGotoState.first, nonterminalGotoState.second);
+    std::vector<std::pair<StateSymbolKey, parse_state>> gotos(gotoTable.begin(), gotoTable.end());
+    std::sort(gotos.begin(), gotos.end(), [](const auto& left, const auto& right) {
+        if (left.first.first != right.first.first) {
+            return left.first.first < right.first.first;
         }
-    }
-    std::sort(gotos.begin(), gotos.end());
+        return left.first.second < right.first.second;
+    });
     for (const auto& entry : gotos) {
-        tableOutput << std::get<0>(entry) << " " << std::get<1>(entry) << " " << std::get<2>(entry) << "\n";
+        tableOutput << entry.first.first << " " << entry.first.second << " " << entry.second << "\n";
     }
 }
 

--- a/src/parser/LookaheadActionTable.cpp
+++ b/src/parser/LookaheadActionTable.cpp
@@ -1,39 +1,81 @@
 #include "LookaheadActionTable.h"
 
-#include "Action.h"
+#include <stdexcept>
+#include <string>
 
 namespace parser {
 
-LookaheadActionTable::LookaheadActionTable() {
+namespace {
+std::shared_ptr<const std::vector<int>> emptyErrorCandidates() {
+    static const auto empty = std::make_shared<const std::vector<int>>();
+    return empty;
 }
+} // namespace
 
-LookaheadActionTable::~LookaheadActionTable() {
-}
-
-void LookaheadActionTable::addAction(parse_state state, int lookahead, std::unique_ptr<Action> actionToAdd) {
-    if (lookaheadActions[state].find(lookahead) == lookaheadActions[state].end()) {
-        lookaheadActions[state][lookahead] = std::move(actionToAdd);
-    } else {
-        auto& existingAction = lookaheadActions[state].at(lookahead);
-        if (existingAction->serialize() != actionToAdd->serialize()) {
-            throw std::runtime_error { "Lookahead action conflict at state: " + std::to_string(state) + " existing action: "
-                    + existingAction->serialize() + " attempted add of action: " + actionToAdd->serialize() };
-        }
+void LookaheadActionTable::addAction(parse_state state, int lookahead, Action actionToAdd) {
+    if (state + 1 > stateCount_) {
+        stateCount_ = state + 1;
+    }
+    const StateSymbolKey key { state, lookahead };
+    const auto existingIt = lookaheadActions.find(key);
+    if (existingIt == lookaheadActions.end()) {
+        lookaheadActions.emplace(key, std::move(actionToAdd));
+    } else if (!existingIt->second.equals(actionToAdd)) {
+        throw std::runtime_error { "Lookahead action conflict at state: " + std::to_string(state) + " existing action: "
+                + existingIt->second.serialize() + " attempted add of action: " + actionToAdd.serialize() };
     }
 }
 
-const Action& LookaheadActionTable::action(parse_state state, int lookahead) const {
-    return *lookaheadActions.at(state).at(lookahead);
+Action LookaheadActionTable::action(parse_state state, int lookahead) const {
+    const auto actionIt = lookaheadActions.find({ state, lookahead });
+    if (actionIt != lookaheadActions.end()) {
+        return actionIt->second;
+    }
+    const auto errorIt = errorActionsByState.find(state);
+    if (errorIt != errorActionsByState.end()) {
+        return errorIt->second;
+    }
+    // No stored candidates for this state: still synthesize a bare error when grammar is known.
+    if (errorGrammar_ != nullptr) {
+        return Action::error(0, emptyErrorCandidates(), errorGrammar_);
+    }
+    throw std::out_of_range {
+        "No action for state " + std::to_string(state) + " lookahead " + std::to_string(lookahead)
+    };
 }
 
-bool LookaheadActionTable::hasAction(parse_state state, int lookahead) const {
-    const auto& stateActions = lookaheadActions.at(state);
-    return stateActions.find(lookahead) != stateActions.end();
+bool LookaheadActionTable::hasCorrectiveAction(parse_state state, int lookahead) const {
+    const auto it = lookaheadActions.find({ state, lookahead });
+    return it != lookaheadActions.end() && it->second.isCorrective();
 }
 
 size_t LookaheadActionTable::size() const {
-    return lookaheadActions.size();
+    return stateCount_;
+}
+
+void LookaheadActionTable::reserve(size_t stateCount) {
+    lookaheadActions.reserve(stateCount * 4);
+    errorActionsByState.reserve(stateCount);
+}
+
+void LookaheadActionTable::setStateCount(size_t stateCount) {
+    stateCount_ = stateCount;
+}
+
+void LookaheadActionTable::setErrorCandidates(
+        parse_state state,
+        std::shared_ptr<const std::vector<int>> candidates,
+        const Grammar* grammar) {
+    if (state + 1 > stateCount_) {
+        stateCount_ = state + 1;
+    }
+    errorGrammar_ = grammar;
+    // Skip per-state storage when there are no recovery candidates.
+    if (!candidates || candidates->empty()) {
+        errorActionsByState.erase(state);
+        return;
+    }
+    errorActionsByState[state] = Action::error(0, std::move(candidates), grammar);
 }
 
 } // namespace parser
-

--- a/src/parser/LookaheadActionTable.h
+++ b/src/parser/LookaheadActionTable.h
@@ -3,25 +3,36 @@
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
+
+#include "Action.h"
+#include "HashCombine.h"
 
 namespace parser {
 
-class Action;
-
-using parse_state = size_t;
+class Grammar;
 
 class LookaheadActionTable {
 public:
-	LookaheadActionTable();
-	virtual ~LookaheadActionTable();
+	LookaheadActionTable() = default;
 
-	void addAction(parse_state state, int lookahead, std::unique_ptr<Action> actionToAdd);
-	const Action& action(parse_state state, int lookahead) const;
-	bool hasAction(parse_state state, int lookahead) const;
+	void addAction(parse_state state, int lookahead, Action actionToAdd);
+	Action action(parse_state state, int lookahead) const;
+	// Single lookup: explicit action present and isCorrective() (used for error recovery).
+	bool hasCorrectiveAction(parse_state state, int lookahead) const;
 	size_t size() const;
+	void reserve(size_t stateCount);
+	void setStateCount(size_t stateCount);
+
+	// Register per-state error recovery candidates for missing terminals.
+	// Empty candidate lists are not stored; missing cells synthesize Error with no hints.
+	void setErrorCandidates(parse_state state, std::shared_ptr<const std::vector<int>> candidates, const Grammar* grammar);
 
 private:
-	std::unordered_map<parse_state, std::unordered_map<int, std::unique_ptr<Action>>>lookaheadActions;
+	std::unordered_map<StateSymbolKey, Action, StateSymbolHash> lookaheadActions;
+	std::unordered_map<parse_state, Action> errorActionsByState;
+	const Grammar* errorGrammar_ { nullptr };
+	size_t stateCount_ { 0 };
 };
 
 } // namespace parser

--- a/src/parser/ParsingTable.cpp
+++ b/src/parser/ParsingTable.cpp
@@ -1,5 +1,6 @@
 #include "ParsingTable.h"
 
+#include "Action.h"
 #include "util/Logger.h"
 #include "util/LogManager.h"
 
@@ -14,16 +15,13 @@ ParsingTable::ParsingTable(const Grammar* grammar) :
 	logger << *this->grammar;
 }
 
-ParsingTable::~ParsingTable() {
-}
-
-const Action& ParsingTable::action(parse_state state, scanner::Token lookahead) const {
+Action ParsingTable::action(parse_state state, scanner::Token lookahead) const {
     int lookaheadId = grammar->symbolId(lookahead.id);
     return lookaheadActionTable.action(state, lookaheadId);
 }
 
 parse_state ParsingTable::go_to(parse_state state, int nonterminal) const {
-    return gotoTable.at(state).at(nonterminal);
+    return gotoTable.at({ state, nonterminal });
 }
 
 } // namespace parser

--- a/src/parser/ParsingTable.h
+++ b/src/parser/ParsingTable.h
@@ -1,29 +1,28 @@
 #ifndef _PARSING_TABLE_H_
 #define _PARSING_TABLE_H_
 
-#include <map>
-#include <memory>
+#include <unordered_map>
 
 #include "LookaheadActionTable.h"
 #include "parser/Grammar.h"
+#include "parser/HashCombine.h"
 #include "scanner/Token.h"
 
 namespace parser {
 
-class LR1Item;
 class Action;
 
 class ParsingTable {
 public:
 	ParsingTable(const Grammar* grammar);
-	virtual ~ParsingTable();
+	virtual ~ParsingTable() = default;
 
-	const Action& action(parse_state state, scanner::Token lookahead) const;
+	Action action(parse_state state, scanner::Token lookahead) const;
 	parse_state go_to(parse_state state, int nonterminal) const;
 protected:
 	const Grammar* grammar;
 
-	std::unordered_map<parse_state, std::unordered_map<int, parse_state>> gotoTable;
+	std::unordered_map<StateSymbolKey, parse_state, StateSymbolHash> gotoTable;
 
 	LookaheadActionTable lookaheadActionTable;
 };

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_test(parserGeneratorTest parserGeneratorTest)
 
 add_executable(parserTest gtest.cpp
         parserTest/AcceptActionTest.cpp
+        parserTest/ActionValueTest.cpp
         parserTest/BNFGrammarReaderTest.cpp
         parserTest/CanonicalCollectionTest.cpp
         parserTest/ClosureTest.cpp
@@ -29,6 +30,7 @@ add_executable(parserTest gtest.cpp
         parserTest/FirstTableTest.cpp
         parserTest/GrammarBuilderTest.cpp
         parserTest/GrammarTerminalMapTest.cpp
+        parserTest/LookaheadActionTableTest.cpp
         parserTest/LR1ItemTest.cpp
         parserTest/LR1ParserTest.cpp
         parserTest/ParseTreeNodeTest.cpp

--- a/test/src/parserTest/AcceptActionTest.cpp
+++ b/test/src/parserTest/AcceptActionTest.cpp
@@ -7,6 +7,7 @@
 #include "parser/Action.h"
 #include "parser/Grammar.h"
 #include "parser/GrammarBuilder.h"
+#include "parser/ParsingTable.h"
 #include "parser/ParseTreeBuilder.h"
 
 #include "scanner/Scanner.h"
@@ -18,7 +19,7 @@ using namespace parser;
 using testing::Eq;
 
 TEST(AcceptAction, isSerializedAsAcceptWithNoState) {
-    AcceptAction acceptAction;
+    Action acceptAction = Action::accept();
 
     EXPECT_THAT(acceptAction.serialize(), Eq("a"));
 }
@@ -28,13 +29,13 @@ TEST(AcceptAction, isDeserializedFromString) {
     grammarBuilder.defineRule("<foo>", {"bar"});
     Grammar grammar = grammarBuilder.build();
     ParsingTable parsingTable {&grammar};
-    std::unique_ptr<Action> action { Action::deserialize(std::string { "a" }, parsingTable, grammar) };
+    Action action = Action::deserialize(std::string { "a" }, parsingTable, grammar);
 
-    EXPECT_THAT(action->serialize(), Eq("a"));
+    EXPECT_THAT(action.serialize(), Eq("a"));
 }
 
 TEST(AcceptAction, acceptsTheParse) {
-    AcceptAction acceptAction;
+    Action acceptAction = Action::accept();
     std::stack<parse_state> parsingStack;
     TokenStream tokenStream { [](){ return scanner::Token{"", "", {"",2}}; }};
     ParseTreeBuilder builder {"test", nullptr};

--- a/test/src/parserTest/ActionValueTest.cpp
+++ b/test/src/parserTest/ActionValueTest.cpp
@@ -1,0 +1,90 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "parser/Action.h"
+#include "parser/GrammarBuilder.h"
+#include "parser/ParsingTable.h"
+#include "parser/ParseTreeBuilder.h"
+#include "parser/TokenStream.h"
+
+#include <memory>
+#include <stack>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+using namespace parser;
+using testing::Eq;
+
+TEST(Action, equalsComparesKindsAndPayloads) {
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    ParsingTable table { &grammar };
+    const Production& production = grammar.getRuleById(0);
+
+    Action shift1 = Action::shift(1);
+    Action shift2 = Action::shift(2);
+    Action reduce = Action::reduce(production, &table);
+    Action accept = Action::accept();
+    auto cands = std::make_shared<const std::vector<int>>(std::vector<int>{ 1, 2 });
+    Action error = Action::error(0, cands, &grammar);
+    Action errorSame = Action::error(0, cands, &grammar);
+    Action errorOther = Action::error(0,
+            std::make_shared<const std::vector<int>>(std::vector<int>{ 3 }),
+            &grammar);
+
+    EXPECT_TRUE(shift1.equals(Action::shift(1)));
+    EXPECT_FALSE(shift1.equals(shift2));
+    EXPECT_FALSE(shift1.equals(accept));
+    EXPECT_TRUE(accept.equals(Action::accept()));
+    EXPECT_TRUE(reduce.equals(Action::reduce(production, &table)));
+    EXPECT_TRUE(error.equals(errorSame));
+    EXPECT_FALSE(error.equals(errorOther));
+    EXPECT_FALSE(reduce.equals(error));
+    EXPECT_TRUE(reduce.isCorrective());
+    EXPECT_FALSE(shift1.isCorrective());
+}
+
+TEST(Action, serializesAndDeserializesReduceAndError) {
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    ParsingTable table { &grammar };
+    const Production& production = grammar.getRuleById(0);
+
+    Action reduce = Action::reduce(production, &table);
+    EXPECT_THAT(reduce.serialize(), Eq("r " + std::to_string(production.getId())));
+    Action reduceRoundTrip = Action::deserialize(reduce.serialize(), table, grammar);
+    EXPECT_TRUE(reduce.equals(reduceRoundTrip));
+
+    auto cands = std::make_shared<const std::vector<int>>(std::vector<int>{ grammar.getEndSymbol() });
+    Action error = Action::error(0, cands, &grammar);
+    EXPECT_THAT(error.serialize(), Eq("e 0 " + std::to_string(grammar.getEndSymbol())));
+    Action errorRoundTrip = Action::deserialize(error.serialize(), table, grammar);
+    EXPECT_TRUE(error.equals(errorRoundTrip));
+}
+
+TEST(Action, deserializeRejectsUnknownType) {
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    ParsingTable table { &grammar };
+    EXPECT_THROW(Action::deserialize("x 1", table, grammar), std::runtime_error);
+}
+
+TEST(Action, errorParseReportsAndStops) {
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    auto cands = std::make_shared<const std::vector<int>>(std::vector<int>{ grammar.getTerminalIDs().front() });
+    Action error = Action::error(0, cands, &grammar);
+
+    std::stack<parse_state> stack;
+    TokenStream tokens { []() { return scanner::Token{ "a", "a", { "", 1 } }; } };
+    ParseTreeBuilder treeBuilder { "test", &grammar };
+    EXPECT_TRUE(error.parse(stack, tokens, treeBuilder));
+}
+
+} // namespace

--- a/test/src/parserTest/FilePersistedParsingTableTest.cpp
+++ b/test/src/parserTest/FilePersistedParsingTableTest.cpp
@@ -5,22 +5,20 @@
 #include "gmock/gmock.h"
 
 #include "ResourceHelpers.h"
+#include "scanner/Token.h"
 
 using namespace parser;
 
-
 TEST(FilePersistedParsingTable, readsTheParsingTable) {
-    constexpr int stateCount = 809;
     BNFFileReader reader;
     Grammar grammar = reader.readGrammar(getResourcePath("configuration/grammar.bnf"));
 
     FilePersistedParsingTable table(getResourcePath("configuration/parsing_table"), &grammar);
 
-    // FIXME:
-    for (parse_state state = 0; state < stateCount; ++state) {
-        /*for (auto& terminal : grammar.getTerminals()) {
-            ASSERT_NO_THROW(table.action(state, terminal->getName()));
-        }*/
+    // Smoke: every terminal has an action cell in the start state.
+    for (const int terminalId : grammar.getTerminalIDs()) {
+        scanner::Token token { grammar.getSymbolById(terminalId), "", { "", 0 } };
+        ASSERT_NO_THROW(table.action(0, token));
     }
 }
 

--- a/test/src/parserTest/LookaheadActionTableTest.cpp
+++ b/test/src/parserTest/LookaheadActionTableTest.cpp
@@ -1,0 +1,82 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "parser/Action.h"
+#include "parser/GrammarBuilder.h"
+#include "parser/LookaheadActionTable.h"
+#include "parser/ParsingTable.h"
+
+#include <memory>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+using namespace parser;
+using testing::Eq;
+
+TEST(LookaheadActionTable, reportsMissingExplicitAction) {
+    LookaheadActionTable table;
+    EXPECT_THROW(table.action(0, 1), std::out_of_range);
+    table.addAction(0, 1, Action::shift(3));
+    EXPECT_THAT(table.action(0, 1).serialize(), Eq("s 3"));
+    EXPECT_FALSE(table.hasCorrectiveAction(0, 1)); // shift is not corrective
+    EXPECT_THROW(table.action(0, 2), std::out_of_range);
+    EXPECT_THROW(table.action(1, 1), std::out_of_range);
+}
+
+TEST(LookaheadActionTable, ignoresDuplicateCompatibleAction) {
+    LookaheadActionTable table;
+    table.addAction(0, 7, Action::shift(4));
+    EXPECT_NO_THROW(table.addAction(0, 7, Action::shift(4)));
+    EXPECT_THAT(table.action(0, 7).serialize(), Eq("s 4"));
+}
+
+TEST(LookaheadActionTable, throwsOnConflictingAction) {
+    LookaheadActionTable table;
+    table.addAction(0, 7, Action::shift(4));
+    EXPECT_THROW(table.addAction(0, 7, Action::shift(5)), std::runtime_error);
+    EXPECT_THROW(table.addAction(0, 7, Action::accept()), std::runtime_error);
+}
+
+TEST(LookaheadActionTable, synthesizesPerStateErrorWhenTerminalMissing) {
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    LookaheadActionTable table;
+    table.setStateCount(1);
+    auto candidates = std::make_shared<const std::vector<int>>(std::vector<int>{ grammar.getTerminalIDs().front() });
+    table.setErrorCandidates(0, candidates, &grammar);
+
+    Action err = table.action(0, grammar.getEndSymbol());
+    EXPECT_THAT(err.kind(), Eq(Action::Kind::Error));
+    EXPECT_THAT(err.serialize(), Eq("e 0 " + std::to_string(grammar.getTerminalIDs().front())));
+}
+
+TEST(LookaheadActionTable, throwsWhenNoActionAndNoErrorCandidates) {
+    LookaheadActionTable table;
+    EXPECT_THROW(table.action(0, 1), std::out_of_range);
+}
+
+TEST(LookaheadActionTable, setErrorCandidatesGrowsStateCount) {
+    LookaheadActionTable table;
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    table.setErrorCandidates(3, nullptr, &grammar);
+    EXPECT_THAT(table.size(), Eq(4u));
+}
+
+TEST(LookaheadActionTable, emptyErrorCandidatesSynthesizeBareError) {
+    GrammarBuilder builder;
+    builder.defineRule("<S>", { "a" });
+    Grammar grammar = builder.build();
+    LookaheadActionTable table;
+    table.setErrorCandidates(0, nullptr, &grammar);
+
+    Action err = table.action(0, grammar.getEndSymbol());
+    EXPECT_THAT(err.kind(), Eq(Action::Kind::Error));
+    EXPECT_THAT(err.serialize(), Eq("e 0"));
+}
+
+} // namespace

--- a/test/src/parserTest/ShiftActionTest.cpp
+++ b/test/src/parserTest/ShiftActionTest.cpp
@@ -8,6 +8,7 @@
 #include "parser/GrammarBuilder.h"
 #include "parser/Action.h"
 #include "parser/Grammar.h"
+#include "parser/ParsingTable.h"
 #include "parser/ParseTreeBuilder.h"
 #include "parser/SyntaxTree.h"
 #include "parser/Production.h"
@@ -34,7 +35,7 @@ public:
 };
 
 TEST(ShiftAction, isSerializedAsShiftWithState) {
-    ShiftAction shiftAction { 42 };
+    Action shiftAction = Action::shift(42);
 
     ASSERT_THAT(shiftAction.serialize(), Eq("s 42"));
 }
@@ -45,13 +46,13 @@ TEST(ShiftAction, isDeserializedFromString) {
     Grammar grammar = grammarBuilder.build();
     ParsingTable parsingTable {&grammar};
 
-    std::unique_ptr<Action> action { Action::deserialize(std::string { "s 42" }, parsingTable, grammar) };
+    Action action = Action::deserialize(std::string { "s 42" }, parsingTable, grammar);
 
-    ASSERT_THAT(action->serialize(), Eq("s 42"));
+    ASSERT_THAT(action.serialize(), Eq("s 42"));
 }
 
 TEST(ShiftAction, pushesItsStateOnStackAndAdvancesTokenStream) {
-    ShiftAction shiftAction { 42 };
+    Action shiftAction = Action::shift(42);
     std::stack<parse_state> parsingStack;
     std::vector<scanner::Token> tokens { { "a", "a", { "", 0 } }, { "b", "b", { "", 1 } } };
     int currentToken {0};


### PR DESCRIPTION
## Summary
- Replace the virtual `Action` hierarchy and nested `unique_ptr` maps with value-type action cells.
- Flat `unordered_map<StateSymbolKey, …>` for lookahead actions and gotos.
- Sparse per-state error candidates instead of dense error cells.
- Unit tests for value `Action` and sparse `LookaheadActionTable`.

## Stack (merge bottom → top)
1. #47 `perf/parser/1-lookahead-model`
2. #48 `perf/parser/2-automaton`
3. **This PR** (#49)
4. #50 `perf/parser/4-tests-cleanup`

Depends on #48.

## Test plan
- [x] `parserTest` + `parserGeneratorTest` (Release)
- [ ] CI green after base merges