### PR TITLE
Parallelize tests via ctest -j and functional gtest shards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Build
         run: make
 
+      # Serial ctest: functionalTest shards share .gcda and race under ctest -j.
       - name: Test
-        run: make test
+        run: make test JOBS=1
 
       - name: Coverage report
         run: make coverage-report

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Parallelism for the day-to-day path lives in the root Makefile (-j$(JOBS)).
+# Do not bake -j into CMAKE_CTEST_ARGUMENTS: coverage must run serial (gcov).
 list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 
 FetchContent_Declare(
@@ -88,10 +90,11 @@ add_custom_target(coverage-report
   COMMENT "Produce coverage/lcov.info from existing gcov data"
 )
 add_custom_target(coverage
-  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+  # Serial ctest: parallel functionalTest shards race on shared .gcda files.
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -j1
   COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target coverage-report
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  COMMENT "Run tests and produce coverage/lcov.info"
+  COMMENT "Run tests (serial for gcov) and produce coverage/lcov.info"
   DEPENDS trans
 )
 set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES coverage)

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ build: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) -j$(JOBS)
 
 test: build
-	cd $(BUILD_DIR) && ctest --output-on-failure $(ARGS)
+	cd $(BUILD_DIR) && ctest --output-on-failure -j$(JOBS) $(ARGS)
 
-# lcov only — assumes tests already ran (CI uses this after make test).
+# lcov only — assumes tests already ran serially (CI: make test JOBS=1).
+# Parallel ctest races gcov counters when functionalTest is sharded.
 coverage-report: $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) --target coverage-report
 
@@ -53,5 +54,8 @@ help:
 	@echo "  make scrub            Clean build outputs and gcov artifacts"
 	@echo ""
 	@echo "Variables: BUILD_DIR=$(BUILD_DIR) BUILD_TYPE=$(BUILD_TYPE) JOBS=$(JOBS)"
-	@echo "  make test ARGS='-R parser -V'"
+	@echo "  make test ARGS='-R parser -V'   # filter / verbose ctest"
+	@echo "  make test ARGS='-L functional'  # functional shards only"
+	@echo "  make test JOBS=1               # serial ctest"
 	@echo "  make BUILD_TYPE=Release configure"
+	@echo "  cmake -S . -B build -DFUNCTIONAL_TEST_SHARDS=16  # more functional shards"

--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ From the repo root:
 
 ```shell
 make              # configure on first run if needed, then build
-make test         # build and run tests
+make test         # build and run tests (ctest -j by default)
 make test ARGS='-R parser -V'   # filter / verbose ctest
-make coverage     # tests + build/coverage/lcov.info (needs lcov; use Debug)
+make test ARGS='-L functional'  # functional shards only
+make test JOBS=1  # serial ctest
+make coverage     # serial tests + build/coverage/lcov.info (needs lcov; use Debug)
 make help         # list targets
+```
+
+Functional tests run as gtest **shards** (default 8) so `make test` / `ctest -j` can parallelize them. New `TEST()` cases need no CMake changes. Parallelism for day-to-day runs is owned by the root Makefile (`JOBS`); `make coverage` always runs ctest serial so gcov `.gcda` files stay consistent. To change shard count, reconfigure:
+
+```shell
+cmake -S . -B build -DFUNCTIONAL_TEST_SHARDS=16
 ```
 
 Equivalent CMake commands (no root Makefile):
@@ -55,7 +63,8 @@ Equivalent CMake commands (no root Makefile):
 ```shell
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
 cmake --build build -j$(nproc)
-cd build && ctest --output-on-failure
+cd build && ctest --output-on-failure -j$(nproc)   # day-to-day
+cd build && ctest --output-on-failure -j1            # before lcov / coverage
 ```
 
 ## History

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -120,4 +120,20 @@ add_executable(functionalTest
         functionalTest/FuzzCrashRegressionTest.cpp
         )
 target_link_libraries(functionalTest PRIVATE GTest::gmock_main driver translation_unit scanner util parser testUtil)
-add_test(NAME functionalTest COMMAND functionalTest)
+
+# Split functionalTest across N gtest processes so ctest -j can run them in parallel.
+# Adding new TEST() cases needs no CMake changes — gtest assigns each case to a shard by name.
+# Override at configure time: cmake -DFUNCTIONAL_TEST_SHARDS=16 ...
+# Note: make coverage runs ctest -j1 so shards do not race on gcov .gcda files.
+set(FUNCTIONAL_TEST_SHARDS 8 CACHE STRING "Number of gtest shards for functionalTest (ctest -j runs them in parallel)")
+if(NOT FUNCTIONAL_TEST_SHARDS MATCHES "^[1-9][0-9]*$")
+  message(FATAL_ERROR "FUNCTIONAL_TEST_SHARDS must be a positive integer (got: ${FUNCTIONAL_TEST_SHARDS})")
+endif()
+math(EXPR functional_last_shard "${FUNCTIONAL_TEST_SHARDS} - 1")
+foreach(shard RANGE 0 ${functional_last_shard})
+  add_test(NAME functionalTest_shard${shard} COMMAND functionalTest)
+  set_tests_properties(functionalTest_shard${shard} PROPERTIES
+    LABELS "functional"
+    ENVIRONMENT "GTEST_TOTAL_SHARDS=${FUNCTIONAL_TEST_SHARDS};GTEST_SHARD_INDEX=${shard}"
+  )
+endforeach()

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -145,9 +145,24 @@ void Program::assertExecuted() const {
     }
 }
 
-SourceProgram::SourceProgram(std::string sourceCode) : SourceProgram(sourceCode, "test") {}
-SourceProgram::SourceProgram(std::string sourceCode, std::string programName) :
-    Program{"tmp/" + programName}, programDirectory{getTestResourcePath("programs/tmp/")}
+namespace {
+
+// Unique basename under programs/tmp/ so concurrent processes (ctest -j / gtest
+// shards) do not clobber each other's .src / .S / .o / .out artifacts.
+std::string uniqueProgramNameForCurrentTest() {
+    const auto* info = ::testing::UnitTest::GetInstance()->current_test_info();
+    if (info == nullptr) {
+        throw std::logic_error(
+                "SourceProgram requires an active gtest (current_test_info is null)");
+    }
+    return std::string(info->test_suite_name()) + "_" + info->name();
+}
+
+} // namespace
+
+SourceProgram::SourceProgram(std::string sourceCode) :
+    Program{"tmp/" + uniqueProgramNameForCurrentTest()},
+    programDirectory{getTestResourcePath("programs/tmp/")}
 {
     if (mkdir(programDirectory.c_str(), 0777) == -1 && errno != 17) {
         throw std::runtime_error("Could not create directory " + programDirectory + ": " + std::to_string(errno) + ":" + strerror(errno));

--- a/test/src/functionalTest/TestFixtures.h
+++ b/test/src/functionalTest/TestFixtures.h
@@ -43,8 +43,8 @@ class Program {
 
 class SourceProgram : public Program {
   public:
-    SourceProgram(std::string sourceCode);
-    SourceProgram(std::string sourceCode, std::string programName);
+    // Writes under programs/tmp/<Suite>_<Name>.* so parallel shards cannot collide.
+    explicit SourceProgram(std::string sourceCode);
 
   private:
     const std::string programDirectory;


### PR DESCRIPTION
## Summary
- Run `ctest -j$(JOBS)` by default from `make test` so unit suites and functional work overlap.
- Split `functionalTest` into configurable gtest shards (default 8, `FUNCTIONAL_TEST_SHARDS`) labeled `functional`, so new `TEST()` cases need no CMake changes.
- Give each `SourceProgram` a unique `programs/tmp/<Suite>_<Name>` path so concurrent shards cannot clobber compiler/run artifacts; drop the unused named overload and fail hard outside an active gtest.
- Keep coverage trustworthy: `make coverage` and CI use serial ctest (`-j1` / `JOBS=1`) so sharded processes do not race on shared gcov `.gcda` files.

## Test plan
- [x] `make test` — 17/17 passed with parallel shards (~7s wall locally)
- [ ] CI green on this PR (serial `make test JOBS=1` + `coverage-report`)
- [ ] Optional: `make test ARGS='-L functional'` and `cmake -DFUNCTIONAL_TEST_SHARDS=16` reconfigure check