### PR TITLE
Harden process invocation, exit codes, and ownership

### DIFF
--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -70,11 +70,7 @@ void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
 void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     arrayAccess.visitLeftOperand(*this);
     arrayAccess.visitRightOperand(*this);
-
-    // TODO: not implemented yet
-    //auto offset = arrayAccess.rightOperandSymbol();
-    //quadruples.push_back( { code_generator::INDEX, arrayAccess.leftOperandSymbol(), offset, arrayAccess.getResultSymbol() });
-    //quadruples.push_back( { code_generator::INDEX_ADDR, arrayAccess.leftOperandSymbol(), offset, arrayAccess.getLvalue() });
+    throw std::runtime_error { "code generation for array access is not implemented" };
 }
 
 void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
@@ -498,7 +494,7 @@ void CodeGeneratingVisitor::visit(ast::FunctionDeclarator& declarator) {
 
 void CodeGeneratingVisitor::visit(ast::ArrayDeclarator& declaration) {
     declaration.subscriptExpression->accept(*this);
-    throw std::runtime_error { "not implemented" };
+    throw std::runtime_error { "code generation for array declarators is not implemented" };
 }
 
 void CodeGeneratingVisitor::visit(ast::FormalArgument& parameter) {

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -11,4 +11,4 @@ add_library(driver
         Driver.h)
 
 target_include_directories(driver PUBLIC "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(driver PUBLIC ast codegen)
+target_link_libraries(driver PUBLIC ast codegen util)

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -1,6 +1,7 @@
 #include "Compiler.h"
 
 #include <fstream>
+#include <stdexcept>
 
 #include "CompilerComponentsFactory.h"
 #include "codegen/AssemblyGenerator.h"
@@ -12,20 +13,25 @@
 #include "codegen/quadruples/Quadruple.h"
 #include "util/Logger.h"
 #include "util/LogManager.h"
+#include "util/Process.h"
 
 static Logger& out = LogManager::getOutputLogger();
 
-int assemble(std::string assemblyFileName) {
-    std::string assemblerCommand { "nasm -O1 -f elf64 " + assemblyFileName };
-    return system(assemblerCommand.c_str());
+namespace {
+
+void assemble(const std::string& assemblyFileName) {
+    util::runProcessOrThrow({ "nasm", "-O1", "-f", "elf64", assemblyFileName });
 }
 
-int link(std::string sourceFileName) {
-    //-melf_x86_64 -L/usr/lib64
-    //std::string linkerCommand { "ld -lc -dynamic-linker /lib64/ld-linux-x86-64.so.2 -e main -o " + sourceFileName + ".out " + sourceFileName + ".o" };
-    std::string linkerCommand { "gcc -m64 -no-pie -o " + sourceFileName + ".out " + sourceFileName + ".o" };
-    return system(linkerCommand.c_str());
+void link(const std::string& sourceFileName) {
+    util::runProcessOrThrow({
+            "gcc", "-m64", "-no-pie",
+            "-o", sourceFileName + ".out",
+            sourceFileName + ".o"
+    });
 }
+
+} // namespace
 
 Compiler::Compiler(Configuration configuration) :
         configuration { configuration },
@@ -71,11 +77,14 @@ void Compiler::compile(std::string sourceFileName) const {
 
     std::string assemblyFileName { sourceFileName + ".S" };
     std::ofstream assemblyFile { assemblyFileName };
+    if (!assemblyFile) {
+        throw std::runtime_error { "Unable to open assembly output file " + assemblyFileName };
+    }
     std::unique_ptr<codegen::AssemblyGenerator> assemblyGenerator = compilerComponentsFactory.makeAssemblyGenerator(&assemblyFile);
     assemblyGenerator->generateAssemblyCode(std::move(quadruples), semanticAnalyzer.getConstants(), globalVariables);
     assemblyFile.close();
 
-    if (assemble(assemblyFileName) == 0 && link(sourceFileName) == 0) {
-        out << "Successfully compiled and linked\n";
-    }
+    assemble(assemblyFileName);
+    link(sourceFileName);
+    out << "Successfully compiled and linked\n";
 }

--- a/src/driver/CompilerComponentsFactory.cpp
+++ b/src/driver/CompilerComponentsFactory.cpp
@@ -39,21 +39,21 @@ std::unique_ptr<parser::Parser> CompilerComponentsFactory::makeParser(parser::Gr
     Logger logger { configuration.isParserLoggingEnabled() ? &std::cout : &NullStream::getInstance() };
     LogManager::registerComponentLogger(Component::PARSER, logger);
 
-    parser::ParsingTable* parsingTable;
+    std::unique_ptr<parser::ParsingTable> parsingTable;
     if (configuration.usingCustomGrammar()) {
         parsingTable = generateParsingTable(grammar);
     } else {
-        parsingTable = new parser::FilePersistedParsingTable(configuration.getParsingTablePath(), grammar);
+        parsingTable = std::make_unique<parser::FilePersistedParsingTable>(configuration.getParsingTablePath(), grammar);
     }
 
-    return std::make_unique<parser::LR1Parser>(parsingTable);
+    return std::make_unique<parser::LR1Parser>(std::move(parsingTable));
 }
 
-parser::ParsingTable* CompilerComponentsFactory::generateParsingTable(const parser::Grammar* grammar) const {
+std::unique_ptr<parser::ParsingTable> CompilerComponentsFactory::generateParsingTable(const parser::Grammar* grammar) const {
     std::cout << "Generating parsing table" << std::endl;
     std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
 
-    parser::GeneratedParsingTable* generatedTable = new parser::GeneratedParsingTable(grammar);
+    auto generatedTable = std::make_unique<parser::GeneratedParsingTable>(grammar);
 
     std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
     std::cout << "Parsing table generation took "

--- a/src/driver/CompilerComponentsFactory.h
+++ b/src/driver/CompilerComponentsFactory.h
@@ -25,9 +25,9 @@ public:
 
     std::unique_ptr<codegen::AssemblyGenerator> makeAssemblyGenerator(std::ostream* assemblyFile) const;
 
-    parser::ParsingTable* generateParsingTable(const parser::Grammar* grammar) const;
-
 private:
+    std::unique_ptr<parser::ParsingTable> generateParsingTable(const parser::Grammar* grammar) const;
+
     Configuration configuration;
 };
 

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -1,28 +1,29 @@
 #include "Driver.h"
 
-#include <iostream>
 #include <vector>
 
 #include "Compiler.h"
-#include "CompilerComponentsFactory.h"
 #include "util/Logger.h"
 #include "util/LogManager.h"
 
 static Logger& err = LogManager::getErrorLogger();
 
-void Driver::run(ConfigurationParser configurationParser) const {
-
+int Driver::run(ConfigurationParser configurationParser) const {
     Configuration configuration = configurationParser.getConfiguration();
-	Compiler compiler { configuration };
+    Compiler compiler { configuration };
 
+    int exitCode = 0;
     std::vector<std::string> sourceFilePaths = configuration.getSourceFiles();
-	for (std::string sourceFilePath : sourceFilePaths) {
-		try {
-			compiler.compile(sourceFilePath);
-		} catch (std::exception& exception) {
-			err << "Error: " << exception.what() << "\n";
-		} catch (...) {
-			err << "Uncaught exception while compiling " << sourceFilePath << "\n";
-		}
-	}
+    for (std::string sourceFilePath : sourceFilePaths) {
+        try {
+            compiler.compile(sourceFilePath);
+        } catch (std::exception& exception) {
+            err << "Error: " << exception.what() << "\n";
+            exitCode = 1;
+        } catch (...) {
+            err << "Uncaught exception while compiling " << sourceFilePath << "\n";
+            exitCode = 1;
+        }
+    }
+    return exitCode;
 }

--- a/src/driver/Driver.h
+++ b/src/driver/Driver.h
@@ -5,7 +5,8 @@
 
 class Driver {
 public:
-	void run(ConfigurationParser configuration) const;
+	// Returns 0 if every source file compiled successfully, non-zero otherwise.
+	int run(ConfigurationParser configuration) const;
 };
 
 #endif // DRIVER_H_

--- a/src/parser/LR1Parser.cpp
+++ b/src/parser/LR1Parser.cpp
@@ -9,8 +9,8 @@
 
 namespace parser {
 
-LR1Parser::LR1Parser(ParsingTable* parsingTable) :
-    parsingTable { parsingTable } {
+LR1Parser::LR1Parser(std::unique_ptr<ParsingTable> parsingTable) :
+    parsingTable { std::move(parsingTable) } {
 }
 
 LR1Parser::~LR1Parser() = default;

--- a/src/parser/LR1Parser.h
+++ b/src/parser/LR1Parser.h
@@ -11,7 +11,7 @@ class ParsingTable;
 
 class LR1Parser: public Parser {
 public:
-	LR1Parser(ParsingTable* parsingTable);
+	explicit LR1Parser(std::unique_ptr<ParsingTable> parsingTable);
 	virtual ~LR1Parser();
 
 	std::unique_ptr<SyntaxTree> parse(scanner::Scanner& scanner, SyntaxTreeBuilder& syntaxTreeBuilder) override;

--- a/src/scanner/LexFileScannerReader.cpp
+++ b/src/scanner/LexFileScannerReader.cpp
@@ -76,7 +76,7 @@ void parseConfigurationEntry(char entryType, std::string entry, std::string& cur
     }
 }
 
-FiniteAutomaton* LexFileScannerReader::fromConfiguration(std::string configPath) {
+std::unique_ptr<FiniteAutomaton> LexFileScannerReader::fromConfiguration(std::string configPath) {
     std::ifstream configurationFile { configPath };
 
     if (!configurationFile.is_open()) {

--- a/src/scanner/LexFileScannerReader.h
+++ b/src/scanner/LexFileScannerReader.h
@@ -11,7 +11,7 @@ namespace scanner {
 
 class LexFileScannerReader {
 public:
-    FiniteAutomaton* fromConfiguration(std::string configPath);
+    std::unique_ptr<FiniteAutomaton> fromConfiguration(std::string configPath);
 };
 
 } // namespace scanner

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -4,9 +4,9 @@
 
 namespace scanner {
 
-Scanner::Scanner(std::string fileName, FiniteAutomaton* stateMachine) :
+Scanner::Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine) :
         translationUnit { fileName },
-        automaton { stateMachine } {
+        automaton { std::move(stateMachine) } {
 }
 
 Token Scanner::nextToken() {

--- a/src/scanner/Scanner.h
+++ b/src/scanner/Scanner.h
@@ -11,7 +11,7 @@ namespace scanner {
 
 class Scanner {
 public:
-    Scanner(std::string fileName, FiniteAutomaton* stateMachine);
+    Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine);
 
     Token nextToken();
 

--- a/src/scanner/ScannerBuilder.cpp
+++ b/src/scanner/ScannerBuilder.cpp
@@ -18,7 +18,7 @@ void ScannerBuilder::addKeyword(std::string keyword) {
     keywordIds[keyword] = nextKeywordId++;
 }
 
-FiniteAutomaton* ScannerBuilder::build() {
+std::unique_ptr<FiniteAutomaton> ScannerBuilder::build() {
     for (auto& namedState : namedStates) {
         auto& state = namedState.second;
         auto transitionsAtState = namedStateTransitions.find(state->getName());
@@ -29,7 +29,7 @@ FiniteAutomaton* ScannerBuilder::build() {
         }
     }
 
-    return new FiniteAutomaton{startState, keywordIds, std::move(namedStates)};
+    return std::make_unique<FiniteAutomaton>(startState, keywordIds, std::move(namedStates));
 }
 
 } // namespace scanner

--- a/src/scanner/ScannerBuilder.h
+++ b/src/scanner/ScannerBuilder.h
@@ -16,7 +16,7 @@ public:
     void addTransition(std::string fromState, std::string transitionOn, std::string transitionTo);
     void addKeyword(std::string keyword);
 
-    FiniteAutomaton* build();
+    std::unique_ptr<FiniteAutomaton> build();
 
 private:
     int nextKeywordId {1};

--- a/src/trans.cpp
+++ b/src/trans.cpp
@@ -1,11 +1,7 @@
 #include "driver/ConfigurationParser.h"
 #include "driver/Driver.h"
 
-#include <iostream>
-
 int main(int argc, char **argv) {
 	Driver transDriver {};
-	transDriver.run(ConfigurationParser {argc, argv});
-	return 0;
+	return transDriver.run(ConfigurationParser {argc, argv});
 }
-

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(util
         LogManager.h
         NullStream.h
         NullStream.cpp
+        Process.cpp
+        Process.h
         )
 
 target_include_directories(util PUBLIC "${CMAKE_SOURCE_DIR}/src")

--- a/src/util/Process.cpp
+++ b/src/util/Process.cpp
@@ -1,0 +1,274 @@
+#include "util/Process.h"
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdexcept>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+namespace util {
+namespace {
+
+constexpr size_t kIoChunk = 4096;
+
+void closeFd(int& fd) {
+    if (fd >= 0) {
+        ::close(fd);
+        fd = -1;
+    }
+}
+
+void closePipe(int pipefds[2]) {
+    closeFd(pipefds[0]);
+    closeFd(pipefds[1]);
+}
+
+[[noreturn]] void throwErrno(const char* what) {
+    throw std::runtime_error(std::string(what) + ": " + std::strerror(errno));
+}
+
+std::string joinArgv(const std::vector<std::string>& argv) {
+    std::string joined;
+    for (size_t i = 0; i < argv.size(); ++i) {
+        if (i != 0) {
+            joined.push_back(' ');
+        }
+        joined += argv[i];
+    }
+    return joined;
+}
+
+// Multiplex stdin write + stdout/stderr reads until all pipe ends close.
+// Avoids the classic deadlock from draining one stream before the other.
+void pumpIo(int& stdinWriteFd, const std::string& stdinData, size_t& stdinOffset,
+        int& stdoutReadFd, std::string* stdoutOut,
+        int& stderrReadFd, std::string& stderrOut) {
+    std::array<char, kIoChunk> buf {};
+
+    while (stdinWriteFd >= 0 || stdoutReadFd >= 0 || stderrReadFd >= 0) {
+        std::array<pollfd, 3> pfds {};
+        nfds_t nfds = 0;
+
+        int stdinIdx = -1;
+        int stdoutIdx = -1;
+        int stderrIdx = -1;
+
+        if (stdinWriteFd >= 0) {
+            stdinIdx = static_cast<int>(nfds);
+            pfds[nfds++] = pollfd { stdinWriteFd, POLLOUT, 0 };
+        }
+        if (stdoutReadFd >= 0) {
+            stdoutIdx = static_cast<int>(nfds);
+            pfds[nfds++] = pollfd { stdoutReadFd, POLLIN, 0 };
+        }
+        if (stderrReadFd >= 0) {
+            stderrIdx = static_cast<int>(nfds);
+            pfds[nfds++] = pollfd { stderrReadFd, POLLIN, 0 };
+        }
+
+        int ready = ::poll(pfds.data(), nfds, -1);
+        if (ready < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            throwErrno("poll");
+        }
+
+        auto handleRead = [&](int& fd, short revents, std::string* dest) {
+            if (fd < 0) {
+                return;
+            }
+            if (!(revents & (POLLIN | POLLHUP | POLLERR))) {
+                return;
+            }
+            if (revents & POLLIN) {
+                ssize_t n = ::read(fd, buf.data(), buf.size());
+                if (n > 0) {
+                    if (dest != nullptr) {
+                        dest->append(buf.data(), static_cast<size_t>(n));
+                    }
+                    return;
+                }
+                if (n < 0 && errno == EINTR) {
+                    return;
+                }
+            }
+            closeFd(fd);
+        };
+
+        if (stdinIdx >= 0) {
+            short revents = pfds[static_cast<size_t>(stdinIdx)].revents;
+            if (revents & (POLLOUT | POLLERR | POLLHUP)) {
+                if (revents & POLLOUT) {
+                    size_t remaining = stdinData.size() - stdinOffset;
+                    ssize_t n = ::write(stdinWriteFd, stdinData.data() + stdinOffset, remaining);
+                    if (n > 0) {
+                        stdinOffset += static_cast<size_t>(n);
+                        if (stdinOffset >= stdinData.size()) {
+                            closeFd(stdinWriteFd);
+                        }
+                    } else if (n < 0 && errno == EINTR) {
+                        // retry
+                    } else {
+                        // EPIPE or other write error: child closed early.
+                        closeFd(stdinWriteFd);
+                    }
+                } else {
+                    closeFd(stdinWriteFd);
+                }
+            }
+        }
+
+        if (stdoutIdx >= 0) {
+            handleRead(stdoutReadFd, pfds[static_cast<size_t>(stdoutIdx)].revents, stdoutOut);
+        }
+        if (stderrIdx >= 0) {
+            handleRead(stderrReadFd, pfds[static_cast<size_t>(stderrIdx)].revents, &stderrOut);
+        }
+    }
+}
+
+} // namespace
+
+ProcessResult runProcess(const std::vector<std::string>& argv,
+        const std::string& stdinData,
+        const std::string& stdoutPath) {
+    if (argv.empty()) {
+        throw std::invalid_argument("runProcess: empty argv");
+    }
+
+    int stdinPipe[2] = { -1, -1 };
+    int stdoutPipe[2] = { -1, -1 };
+    int stderrPipe[2] = { -1, -1 };
+
+    const bool captureStdout = stdoutPath.empty();
+    const bool feedStdin = !stdinData.empty();
+
+    auto cleanupPipes = [&]() {
+        closePipe(stdinPipe);
+        closePipe(stdoutPipe);
+        closePipe(stderrPipe);
+    };
+
+    if (feedStdin && ::pipe(stdinPipe) != 0) {
+        throwErrno("pipe(stdin)");
+    }
+    if (captureStdout && ::pipe(stdoutPipe) != 0) {
+        cleanupPipes();
+        throwErrno("pipe(stdout)");
+    }
+    if (::pipe(stderrPipe) != 0) {
+        cleanupPipes();
+        throwErrno("pipe(stderr)");
+    }
+
+    pid_t pid = ::fork();
+    if (pid < 0) {
+        cleanupPipes();
+        throwErrno("fork");
+    }
+
+    if (pid == 0) {
+        if (feedStdin) {
+            ::dup2(stdinPipe[0], STDIN_FILENO);
+        } else {
+            int devnull = ::open("/dev/null", O_RDONLY);
+            if (devnull >= 0) {
+                ::dup2(devnull, STDIN_FILENO);
+                ::close(devnull);
+            }
+        }
+
+        if (captureStdout) {
+            ::dup2(stdoutPipe[1], STDOUT_FILENO);
+        } else {
+            int outFd = ::open(stdoutPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+            if (outFd < 0) {
+                _exit(126);
+            }
+            ::dup2(outFd, STDOUT_FILENO);
+            ::close(outFd);
+        }
+
+        ::dup2(stderrPipe[1], STDERR_FILENO);
+
+        closePipe(stdinPipe);
+        closePipe(stdoutPipe);
+        closePipe(stderrPipe);
+
+        std::vector<char*> cargv;
+        cargv.reserve(argv.size() + 1);
+        for (const auto& arg : argv) {
+            cargv.push_back(const_cast<char*>(arg.c_str()));
+        }
+        cargv.push_back(nullptr);
+
+        ::execvp(cargv[0], cargv.data());
+        _exit(127);
+    }
+
+    // Parent: close child-side ends; keep parent-side ends in the pipe arrays.
+    closeFd(stdinPipe[0]);
+    closeFd(stdoutPipe[1]);
+    closeFd(stderrPipe[1]);
+
+    if (!feedStdin) {
+        closeFd(stdinPipe[1]);
+    }
+    if (!captureStdout) {
+        closeFd(stdoutPipe[0]);
+    }
+
+    ProcessResult result;
+    size_t stdinOffset = 0;
+
+    try {
+        pumpIo(stdinPipe[1], stdinData, stdinOffset,
+                stdoutPipe[0], captureStdout ? &result.stdoutOutput : nullptr,
+                stderrPipe[0], result.stderrOutput);
+    } catch (...) {
+        closePipe(stdinPipe);
+        closePipe(stdoutPipe);
+        closePipe(stderrPipe);
+        int status = 0;
+        ::waitpid(pid, &status, 0);
+        throw;
+    }
+
+    // pumpIo closes all parent ends it was given.
+    int status = 0;
+    if (::waitpid(pid, &status, 0) < 0) {
+        throwErrno("waitpid");
+    }
+    if (WIFEXITED(status)) {
+        result.exitCode = WEXITSTATUS(status);
+    } else if (WIFSIGNALED(status)) {
+        result.exitCode = 128 + WTERMSIG(status);
+    } else {
+        result.exitCode = -1;
+    }
+    return result;
+}
+
+void runProcessOrThrow(const std::vector<std::string>& argv,
+        const std::string& stdinData,
+        const std::string& stdoutPath) {
+    ProcessResult result = runProcess(argv, stdinData, stdoutPath);
+    if (result.exitCode == 0) {
+        return;
+    }
+    std::string message = "command failed (" + std::to_string(result.exitCode) + "): " + joinArgv(argv);
+    if (!result.stderrOutput.empty()) {
+        message += "\n" + result.stderrOutput;
+    } else if (!result.stdoutOutput.empty()) {
+        message += "\n" + result.stdoutOutput;
+    }
+    throw std::runtime_error { message };
+}
+
+} // namespace util

--- a/src/util/Process.h
+++ b/src/util/Process.h
@@ -1,0 +1,34 @@
+#ifndef UTIL_PROCESS_H_
+#define UTIL_PROCESS_H_
+
+#include <string>
+#include <vector>
+
+namespace util {
+
+struct ProcessResult {
+    int exitCode { -1 };
+    std::string stdoutOutput;
+    std::string stderrOutput;
+};
+
+// Run a program with an explicit argv (no shell). argv[0] is resolved via PATH.
+//
+// Modes intentionally cover both call sites:
+// - Compiler: no stdin, capture stderr (and unused stdout) for nasm/gcc errors.
+// - Functional tests: optional stdin bytes; optional stdoutPath redirects child
+//   stdout to a file instead of capturing it.
+// Stdout and stderr are drained concurrently (poll) so dual-stream children cannot deadlock.
+ProcessResult runProcess(const std::vector<std::string>& argv,
+        const std::string& stdinData = {},
+        const std::string& stdoutPath = {});
+
+// Like runProcess, but throws std::runtime_error if exitCode != 0.
+// The exception message includes the command and stderr (or stdout if stderr is empty).
+void runProcessOrThrow(const std::vector<std::string>& argv,
+        const std::string& stdinData = {},
+        const std::string& stdoutPath = {});
+
+} // namespace util
+
+#endif

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -80,16 +80,25 @@ add_executable(codegenTest
         codegenTest/ATandTInstructionSetTests.cpp
         codegenTest/StackMachineTests.cpp
         codegenTest/BasicBlockTests.cpp
+        codegenTest/UnimplementedArrayCodegenTest.cpp
         )
-target_link_libraries(codegenTest PRIVATE GTest::gmock_main codegen)
+target_link_libraries(codegenTest PRIVATE GTest::gmock_main codegen ast)
 add_test(NAME codegenTest COMMAND codegenTest)
 
 
 add_executable(driverTest
         driverTest/ConfigurationParserTest.cpp
+        driverTest/DriverExitCodeTest.cpp
         )
 target_link_libraries(driverTest PRIVATE GTest::gmock_main driver translation_unit scanner util parser testUtil)
 add_test(NAME driverTest COMMAND driverTest)
+
+
+add_executable(utilTest
+        utilTest/ProcessTest.cpp
+        )
+target_link_libraries(utilTest PRIVATE GTest::gmock_main util)
+add_test(NAME utilTest COMMAND utilTest)
 
 
 add_executable(functionalTest

--- a/test/src/codegenTest/UnimplementedArrayCodegenTest.cpp
+++ b/test/src/codegenTest/UnimplementedArrayCodegenTest.cpp
@@ -1,0 +1,54 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "ast/ArrayAccess.h"
+#include "ast/ArrayDeclarator.h"
+#include "ast/Identifier.h"
+#include "ast/IdentifierExpression.h"
+#include "ast/TerminalSymbol.h"
+#include "codegen/CodeGeneratingVisitor.h"
+#include "translation_unit/Context.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using namespace testing;
+using namespace ast;
+using namespace codegen;
+
+translation_unit::Context testContext() {
+    return { "test", 1 };
+}
+
+TEST(CodeGeneratingVisitor, arrayAccessIsNotImplemented) {
+    ArrayAccess access {
+            std::make_unique<IdentifierExpression>("a", testContext()),
+            std::make_unique<IdentifierExpression>("i", testContext())
+    };
+    CodeGeneratingVisitor visitor;
+    try {
+        access.accept(visitor);
+        FAIL() << "expected array access codegen to throw";
+    } catch (const std::runtime_error& error) {
+        EXPECT_THAT(std::string(error.what()), HasSubstr("array access is not implemented"));
+    }
+}
+
+TEST(CodeGeneratingVisitor, arrayDeclaratorIsNotImplemented) {
+    ArrayDeclarator declarator {
+            std::make_unique<Identifier>(TerminalSymbol { "id", "a", testContext() }),
+            std::make_unique<IdentifierExpression>("n", testContext())
+    };
+    CodeGeneratingVisitor visitor;
+    try {
+        declarator.accept(visitor);
+        FAIL() << "expected array declarator codegen to throw";
+    } catch (const std::runtime_error& error) {
+        EXPECT_THAT(std::string(error.what()), HasSubstr("array declarators is not implemented"));
+    }
+}
+
+} // namespace

--- a/test/src/driverTest/DriverExitCodeTest.cpp
+++ b/test/src/driverTest/DriverExitCodeTest.cpp
@@ -1,0 +1,218 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "driver/Compiler.h"
+#include "driver/Configuration.h"
+#include "driver/ConfigurationParser.h"
+#include "driver/Driver.h"
+#include "util/LogManager.h"
+
+#include "ResourceHelpers.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+using namespace testing;
+
+std::filesystem::path writeTempSource(const std::string& name, const std::string& source) {
+    auto dir = std::filesystem::temp_directory_path() / "trans_driver_exit_tests";
+    std::filesystem::create_directories(dir);
+    auto path = dir / name;
+    std::ofstream out { path };
+    out << source;
+    return path;
+}
+
+void removeCompileArtifacts(const std::filesystem::path& sourcePath) {
+    std::filesystem::remove(sourcePath);
+    std::filesystem::remove(sourcePath.string() + ".S");
+    std::filesystem::remove(sourcePath.string() + ".o");
+    std::filesystem::remove(sourcePath.string() + ".out");
+}
+
+// Restores PATH on destruction so failure paths cannot leave a poisoned environment.
+class PathGuard {
+public:
+    explicit PathGuard(const std::string& pathPrefix) {
+        const char* previous = std::getenv("PATH");
+        if (previous == nullptr) {
+            throw std::runtime_error("PATH is not set");
+        }
+        previousPath_ = previous;
+        const std::string combined = pathPrefix + ":" + previousPath_;
+        if (setenv("PATH", combined.c_str(), 1) != 0) {
+            throw std::runtime_error("setenv(PATH) failed");
+        }
+    }
+
+    ~PathGuard() {
+        setenv("PATH", previousPath_.c_str(), 1);
+    }
+
+    PathGuard(const PathGuard&) = delete;
+    PathGuard& operator=(const PathGuard&) = delete;
+
+private:
+    std::string previousPath_;
+};
+
+// Installs a failing `nasm` ahead of the real one on PATH for the lifetime of this object.
+class FakeFailingNasm {
+public:
+    FakeFailingNasm() {
+        // Unique directory so concurrent test processes cannot clash.
+        std::string templatePath =
+                (std::filesystem::temp_directory_path() / "trans_fake_nasm_XXXXXX").string();
+        std::vector<char> mutableTemplate(templatePath.begin(), templatePath.end());
+        mutableTemplate.push_back('\0');
+        char* created = ::mkdtemp(mutableTemplate.data());
+        if (created == nullptr) {
+            throw std::runtime_error("mkdtemp failed for FakeFailingNasm");
+        }
+        binDir_ = created;
+        nasmPath_ = binDir_ / "nasm";
+        {
+            std::ofstream out { nasmPath_ };
+            out << "#!/bin/sh\n"
+                   "echo fake-nasm-failed >&2\n"
+                   "exit 1\n";
+        }
+        std::filesystem::permissions(nasmPath_,
+                std::filesystem::perms::owner_all
+                        | std::filesystem::perms::group_exec
+                        | std::filesystem::perms::others_exec);
+        pathGuard_.emplace(binDir_.string());
+    }
+
+    ~FakeFailingNasm() {
+        pathGuard_.reset();
+        std::error_code ec;
+        std::filesystem::remove_all(binDir_, ec);
+    }
+
+    FakeFailingNasm(const FakeFailingNasm&) = delete;
+    FakeFailingNasm& operator=(const FakeFailingNasm&) = delete;
+
+private:
+    std::filesystem::path binDir_;
+    std::filesystem::path nasmPath_;
+    std::optional<PathGuard> pathGuard_;
+};
+
+// argv strings must outlive ConfigurationParser (it does not copy flags).
+struct ArgvBuffer {
+    std::string executable { "trans" };
+    std::string resourcesFlag;
+    std::vector<std::string> sources;
+    std::vector<char*> pointers;
+
+    explicit ArgvBuffer(std::vector<std::string> sourcePaths) :
+            resourcesFlag { "-r" + getResourcesBaseDir() },
+            sources { std::move(sourcePaths) } {
+        pointers.push_back(executable.data());
+        pointers.push_back(resourcesFlag.data());
+        for (auto& source : sources) {
+            pointers.push_back(source.data());
+        }
+    }
+
+    int argc() const {
+        return static_cast<int>(pointers.size());
+    }
+
+    char** argv() {
+        return pointers.data();
+    }
+};
+
+int runDriver(ArgvBuffer& args, std::string* errorOutput = nullptr) {
+    std::stringstream outputStream;
+    std::stringstream errorStream;
+    int exitCode = 0;
+    LogManager::withOutputStreams(outputStream, errorStream, [&]() {
+        Driver driver {};
+        exitCode = driver.run(ConfigurationParser { args.argc(), args.argv() });
+    });
+    if (errorOutput != nullptr) {
+        *errorOutput = errorStream.str();
+    }
+    return exitCode;
+}
+
+Configuration testConfiguration() {
+    Configuration configuration;
+    configuration.setResourcesBasePath(getResourcesBaseDir());
+    return configuration;
+}
+
+const char* kTrivialMain =
+        "int main() {\n"
+        "    return 0;\n"
+        "}\n";
+
+TEST(Driver, returnsNonZeroWhenSourceIsMissing) {
+    ArgvBuffer args { { "definitely_missing_source_file.src" } };
+    std::string errors;
+    EXPECT_NE(runDriver(args, &errors), 0);
+    EXPECT_THAT(errors, HasSubstr("Error:"));
+}
+
+TEST(Driver, returnsZeroForSuccessfulCompile) {
+    auto sourcePath = writeTempSource("ok_main.src", kTrivialMain);
+    ArgvBuffer args { { sourcePath.string() } };
+    std::string errors;
+    EXPECT_EQ(runDriver(args, &errors), 0) << errors;
+    EXPECT_TRUE(errors.empty());
+    removeCompileArtifacts(sourcePath);
+}
+
+TEST(Driver, returnsNonZeroWhenAnySourceFailsInMultiFileRun) {
+    auto goodPath = writeTempSource("multi_ok.src", kTrivialMain);
+    ArgvBuffer args { { goodPath.string(), "definitely_missing_other.src" } };
+    std::string errors;
+    EXPECT_NE(runDriver(args, &errors), 0);
+    EXPECT_THAT(errors, HasSubstr("Error:"));
+    removeCompileArtifacts(goodPath);
+}
+
+TEST(Compiler, throwsWhenSourceCannotBeOpened) {
+    Compiler compiler { testConfiguration() };
+    EXPECT_THROW(compiler.compile("no_such_compile_input.src"), std::runtime_error);
+}
+
+TEST(Compiler, assembleFailureThrowsFromCompile) {
+    auto sourcePath = writeTempSource("assemble_fail_compile.src", kTrivialMain);
+    FakeFailingNasm fakeNasm;
+    Compiler compiler { testConfiguration() };
+
+    try {
+        compiler.compile(sourcePath.string());
+        FAIL() << "expected compile to throw when nasm fails";
+    } catch (const std::runtime_error& error) {
+        EXPECT_THAT(std::string(error.what()), HasSubstr("command failed"));
+        EXPECT_THAT(std::string(error.what()), AnyOf(HasSubstr("nasm"), HasSubstr("fake-nasm-failed")));
+    }
+
+    removeCompileArtifacts(sourcePath);
+}
+
+TEST(Driver, assembleFailureReturnsNonZero) {
+    auto sourcePath = writeTempSource("assemble_fail_driver.src", kTrivialMain);
+    FakeFailingNasm fakeNasm;
+    ArgvBuffer args { { sourcePath.string() } };
+    std::string errors;
+    EXPECT_NE(runDriver(args, &errors), 0);
+    EXPECT_THAT(errors, HasSubstr("Error:"));
+    removeCompileArtifacts(sourcePath);
+}
+
+} // namespace

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -22,6 +22,7 @@
 #include "ResourceHelpers.h"
 #include "util/Logger.h"
 #include "util/LogManager.h"
+#include "util/Process.h"
 
 using namespace testing;
 
@@ -35,13 +36,6 @@ std::string readFileContents(std::string filename) {
 
     content.assign(std::istreambuf_iterator<char>(inputStream), std::istreambuf_iterator<char>());
     return content;
-}
-
-void callSystem(std::string command) {
-    int returnCode = system(command.c_str());
-    if (returnCode != 0) {
-        throw std::runtime_error { "Unexpected return code: " + std::to_string(returnCode) };
-    }
 }
 
 Program::Program(std::string programName) :
@@ -66,20 +60,23 @@ void Program::compile(bool verbose) {
 
     std::stringstream outputStream;
     std::stringstream errorStream;
+    int exitCode = 0;
 
-    LogManager::withOutputStreams(outputStream, errorStream, [&argv](){
+    LogManager::withOutputStreams(outputStream, errorStream, [&argv, &exitCode](){
         Driver transDriver {};
-        transDriver.run(ConfigurationParser {(int)argv.size()-1, argv.data()});
+        exitCode = transDriver.run(ConfigurationParser {(int)argv.size()-1, argv.data()});
     });
     if (verbose) {
         std::cout << outputStream.str();
     }
 
     compilationErrors = errorStream.str();
-    if (compilationErrors.empty()) {
+    if (exitCode == 0 && compilationErrors.empty()) {
         compiled = true;
     } else {
-        std::cerr << compilationErrors;
+        if (!compilationErrors.empty()) {
+            std::cerr << compilationErrors;
+        }
         compiled = false;
     }
 }
@@ -87,14 +84,15 @@ void Program::compile(bool verbose) {
 void Program::run() {
     assertCompiled();
     remove(outputFile.c_str());
-    callSystem(executableFile + " > " + outputFile);
+    util::runProcessOrThrow({ executableFile }, {}, outputFile);
     executed = true;
 }
 
 void Program::run(std::string input) {
     assertCompiled();
     remove(outputFile.c_str());
-    callSystem("echo '" + input + "' | " + executableFile + " > " + outputFile);
+    // Match prior `echo '...' | prog` behavior: stdin text ends with a newline.
+    util::runProcessOrThrow({ executableFile }, input + "\n", outputFile);
     executed = true;
 }
 

--- a/test/src/parserGeneratorTest/LR1ParserGeneratedTableTests.cpp
+++ b/test/src/parserGeneratorTest/LR1ParserGeneratedTableTests.cpp
@@ -13,6 +13,7 @@
 #include "ResourceHelpers.h"
 
 #include <fstream>
+#include <memory>
 #include <sstream>
 
 using namespace testing;
@@ -31,7 +32,7 @@ void generateAndParseExample(AutomatonKind kind) {
     CompilerComponentsFactory factory { configuration };
     BNFFileReader reader;
     Grammar grammar = reader.readGrammar(getResourcePath(kProductGrammar));
-    LR1Parser parser { new GeneratedParsingTable(&grammar, kind) };
+    LR1Parser parser { std::make_unique<GeneratedParsingTable>(&grammar, kind) };
     auto syntaxTreeBuilder = factory.makeSyntaxTreeBuilder("test", &grammar);
     ASSERT_NO_THROW(
             parser.parse(*factory.makeScannerForSourceFile(getTestResourcePath("programs/example_prog.src")),

--- a/test/src/parserTest/LR1ParserTest.cpp
+++ b/test/src/parserTest/LR1ParserTest.cpp
@@ -29,9 +29,9 @@ TEST(LR1Parser, parsesTestProgram) {
 
     BNFFileReader reader;
     Grammar grammar = reader.readGrammar(getResourcePath("configuration/grammar.bnf"));
-    ParsingTable* parsingTable = new FilePersistedParsingTable(getResourcePath("configuration/parsing_table"), &grammar);
+    auto parsingTable = std::make_unique<FilePersistedParsingTable>(getResourcePath("configuration/parsing_table"), &grammar);
 
-    LR1Parser parser { parsingTable };
+    LR1Parser parser { std::move(parsingTable) };
     auto builder = compilerComponentsFactory.makeSyntaxTreeBuilder("test", &grammar);
     ASSERT_NO_THROW(
             parser.parse(*compilerComponentsFactory.makeScannerForSourceFile(getTestResourcePath("programs/example_prog.src")),

--- a/test/src/utilTest/ProcessTest.cpp
+++ b/test/src/utilTest/ProcessTest.cpp
@@ -1,0 +1,97 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "util/Process.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+using namespace testing;
+using namespace util;
+
+namespace {
+
+TEST(Process, capturesStdoutOfSuccessfulCommand) {
+    ProcessResult result = runProcess({ "/bin/echo", "hello" });
+    EXPECT_EQ(result.exitCode, 0);
+    EXPECT_EQ(result.stdoutOutput, "hello\n");
+    EXPECT_TRUE(result.stderrOutput.empty());
+}
+
+TEST(Process, nonZeroExitIsReported) {
+    ProcessResult result = runProcess({ "/bin/false" });
+    EXPECT_NE(result.exitCode, 0);
+}
+
+TEST(Process, runProcessOrThrowThrowsOnFailure) {
+    EXPECT_THROW(runProcessOrThrow({ "/bin/false" }), std::runtime_error);
+}
+
+TEST(Process, emptyArgvThrows) {
+    EXPECT_THROW(runProcess({}), std::invalid_argument);
+}
+
+TEST(Process, missingExecutableFailsWithoutHanging) {
+    ProcessResult result = runProcess({ "/no/such/trans_process_binary_xyz" });
+    EXPECT_NE(result.exitCode, 0);
+    // execvp failure in the child is reported as 127.
+    EXPECT_EQ(result.exitCode, 127);
+}
+
+TEST(Process, nasmFailureSurfacesStderrInException) {
+    // Garbage input forces a non-zero exit; runProcessOrThrow must include stderr.
+    const auto asmPath = std::filesystem::temp_directory_path() / "trans_process_bad.S";
+    {
+        std::ofstream out { asmPath };
+        out << "this is not valid nasm assembly!!!\n";
+    }
+    ProcessResult failed = runProcess({ "nasm", "-O1", "-f", "elf64", asmPath.string() });
+    EXPECT_NE(failed.exitCode, 0);
+    EXPECT_FALSE(failed.stderrOutput.empty());
+
+    try {
+        runProcessOrThrow({ "nasm", "-O1", "-f", "elf64", asmPath.string() });
+        FAIL() << "expected nasm to fail on garbage assembly";
+    } catch (const std::runtime_error& error) {
+        const std::string message { error.what() };
+        EXPECT_THAT(message, HasSubstr("command failed"));
+        EXPECT_THAT(message, HasSubstr("nasm"));
+        // Do not match version-specific wording; only that stderr was folded in.
+        EXPECT_THAT(message, HasSubstr(failed.stderrOutput.substr(0, std::min<size_t>(32, failed.stderrOutput.size()))));
+    }
+    std::filesystem::remove(asmPath);
+    std::filesystem::remove(std::filesystem::path(asmPath).replace_extension(".o"));
+}
+
+TEST(Process, feedsStdinAndRedirectsStdoutToFile) {
+    const auto outPath = std::filesystem::temp_directory_path() / "trans_process_test_out.txt";
+    std::filesystem::remove(outPath);
+
+    ProcessResult result = runProcess({ "/bin/cat" }, "piped-input\n", outPath.string());
+    EXPECT_EQ(result.exitCode, 0);
+    EXPECT_TRUE(result.stdoutOutput.empty());
+
+    std::ifstream in { outPath };
+    std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(contents, "piped-input\n");
+
+    std::filesystem::remove(outPath);
+}
+
+TEST(Process, drainsStdoutAndStderrWithoutDeadlock) {
+    // Child writes > pipe capacity to both streams; sequential drain would hang.
+    // First dd → stdout; second → stderr via cat 1>&2.
+    ProcessResult result = runProcess({
+            "/bin/sh", "-c",
+            "dd if=/dev/zero bs=200000 count=1 2>/dev/null; "
+            "dd if=/dev/zero bs=200000 count=1 2>/dev/null | /bin/cat 1>&2"
+    });
+    EXPECT_EQ(result.exitCode, 0);
+    EXPECT_EQ(result.stdoutOutput.size(), 200000u);
+    EXPECT_EQ(result.stderrOutput.size(), 200000u);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Add `util::Process` (no shell): concurrent stdout/stderr drain via `poll`, optional stdin and stdout file redirect; used by Compiler assemble/link and functional fixtures.
- `Driver::run` returns non-zero on any compile failure; `main` propagates it. Assemble/link failures throw with tool diagnostics.
- Factory ownership: `unique_ptr` for parsing tables and finite automata through `LR1Parser` / `Scanner`.
- Array access/declarator codegen throws instead of emitting empty IR.
- Tests: process contracts (including dual-stream deadlock and nasm failures), Driver/Compiler exit codes (including fake-nasm PATH), array hard-fail unit tests.

## Test plan
- [x] Local `make test` — full suite green (18 CTest entries)
- [ ] CI `build` green
- [ ] Coveralls coverage status green / no unexpected drop