### PR TITLE
Make the CMake build target-centric and preset-driven

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,60 @@
 cmake_minimum_required(VERSION 3.17)
-project(trans)
+project(trans
+  VERSION 0.1.0
+  DESCRIPTION "Compiler for a C-like programming language"
+  LANGUAGES CXX
+)
 
-include(FetchContent)
 include(CTest)
 
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wno-unused-parameter -Werror -pedantic")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -fprofile-arcs -ftest-coverage")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Parallelism for the day-to-day path lives in the root Makefile (-j$(JOBS)).
 # Do not bake -j into CMAKE_CTEST_ARGUMENTS: coverage must run serial (gcov).
 list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 
-FetchContent_Declare(
-  googletest
-  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
-  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+# --- Shared target defaults (idiomatic: no global CMAKE_CXX_FLAGS* mutation) ---
+
+add_library(trans_src INTERFACE)
+target_include_directories(trans_src INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src>
 )
-FetchContent_MakeAvailable(googletest)
+
+add_library(trans_common INTERFACE)
+target_compile_features(trans_common INTERFACE cxx_std_20)
+target_compile_options(trans_common INTERFACE
+  $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:
+    -Wall;-Wextra;-Wno-unused-parameter;-Werror;-pedantic
+  >
+)
+
+option(TRANS_ENABLE_COVERAGE "Enable gcov/lcov instrumentation (--coverage)" OFF)
+add_library(trans_coverage INTERFACE)
+if(TRANS_ENABLE_COVERAGE)
+  target_compile_options(trans_coverage INTERFACE
+    $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:--coverage>
+  )
+  target_link_options(trans_coverage INTERFACE
+    $<$<COMPILE_LANG_AND_ID:CXX,GNU,Clang,AppleClang>:--coverage>
+  )
+  # Prefer foo.gcno over foo.cpp.gcno for lcov path matching.
+  set(CMAKE_CXX_OUTPUT_EXTENSION_REPLACE ON)
+endif()
+
+# Apply include root + warnings (+ optional coverage) to project targets.
+# PUBLIC so static-lib consumers (trans, tests) inherit includes, -Werror, and
+# --coverage link flags required for instrumented objects.
+function(trans_target_defaults target)
+  target_link_libraries(${target} PUBLIC trans_src trans_common)
+  if(TRANS_ENABLE_COVERAGE)
+    target_link_libraries(${target} PUBLIC trans_coverage)
+  endif()
+endfunction()
 
 add_subdirectory(src/driver)
 add_subdirectory(src/translation_unit)
@@ -40,24 +67,23 @@ add_subdirectory(src/codegen)
 add_subdirectory(src/util)
 
 add_executable(trans src/trans.cpp)
-target_include_directories(trans PRIVATE "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(trans PRIVATE
-  driver
-  translation_unit
-  scanner
-  parser
-  ast
-  semantic_analyzer
-  types
-  codegen
-  util
-)
+trans_target_defaults(trans)
+# driver PUBLIC-pulls the rest of the compile pipeline (ast, backend, util, …).
+target_link_libraries(trans PRIVATE driver)
 
 if(BUILD_TESTING)
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    URL_HASH SHA256=8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  )
+  FetchContent_MakeAvailable(googletest)
   add_subdirectory(test/src)
 endif()
 
-# Coverage: project sources only (Make and Ninja). Prefer Debug (gcov flags).
+# Coverage: project sources only (Make and Ninja). Prefer Debug + TRANS_ENABLE_COVERAGE.
 # Capture both source and object trees so --no-external keeps ${CMAKE_SOURCE_DIR}/src
 # (object-dir-only capture treats those sources as external and yields an empty report).
 # Do not scan _deps/ or test/ — googletest triggers lcov line-table errors.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,97 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 17,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Release (default)",
+      "description": "Optimized build without tests instrumentation",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "TRANS_ENABLE_COVERAGE": "OFF"
+      }
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Debug symbols; no gcov (use coverage preset for instrumentation)",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "TRANS_ENABLE_COVERAGE": "OFF"
+      }
+    },
+    {
+      "name": "coverage",
+      "displayName": "Debug + coverage",
+      "description": "Debug with gcov; matches make configure (BUILD_TYPE=Debug)",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "TRANS_ENABLE_COVERAGE": "ON"
+      }
+    },
+    {
+      "name": "ci",
+      "displayName": "CI",
+      "description": "Same as coverage; intended for GitHub Actions / local CI parity",
+      "inherits": "coverage"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage"
+    },
+    {
+      "name": "ci",
+      "configurePreset": "ci"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "ci",
+      "configurePreset": "ci",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "jobs": 1
+      }
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ BUILD_DIR  ?= build
 BUILD_TYPE ?= Debug
 # Parallelism for the inner build (outer `make -j` only parallelizes this Makefile).
 JOBS       ?= $(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+# Match historical Debug+gcov behaviour; override with COVERAGE=ON|OFF.
+COVERAGE   ?= $(if $(filter Debug,$(BUILD_TYPE)),ON,OFF)
 
 # Extra args for ctest, e.g. make test ARGS='-R parser -V'
 ARGS       ?=
@@ -16,7 +18,9 @@ ARGS       ?=
 all: build
 
 configure:
-	cmake -S . -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
+	cmake -S . -B $(BUILD_DIR) \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DTRANS_ENABLE_COVERAGE=$(COVERAGE)
 	ln -sfn $(BUILD_DIR)/compile_commands.json compile_commands.json
 
 # Configure automatically if the build tree is missing.
@@ -53,9 +57,11 @@ help:
 	@echo "  make clean            Clean build outputs"
 	@echo "  make scrub            Clean build outputs and gcov artifacts"
 	@echo ""
-	@echo "Variables: BUILD_DIR=$(BUILD_DIR) BUILD_TYPE=$(BUILD_TYPE) JOBS=$(JOBS)"
+	@echo "Variables: BUILD_DIR=$(BUILD_DIR) BUILD_TYPE=$(BUILD_TYPE) JOBS=$(JOBS) COVERAGE=$(COVERAGE)"
 	@echo "  make test ARGS='-R parser -V'   # filter / verbose ctest"
 	@echo "  make test ARGS='-L functional'  # functional shards only"
 	@echo "  make test JOBS=1               # serial ctest"
 	@echo "  make BUILD_TYPE=Release configure"
+	@echo "  make COVERAGE=OFF configure    # Debug without gcov"
 	@echo "  cmake -S . -B build -DFUNCTIONAL_TEST_SHARDS=16  # more functional shards"
+	@echo "  cmake --preset coverage        # same knobs as make configure (see CMakePresets.json)"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ make test         # build and run tests (ctest -j by default)
 make test ARGS='-R parser -V'   # filter / verbose ctest
 make test ARGS='-L functional'  # functional shards only
 make test JOBS=1  # serial ctest
-make coverage     # serial tests + build/coverage/lcov.info (needs lcov; use Debug)
+make coverage     # serial tests + build/coverage/lcov.info (needs lcov; Debug enables gcov by default)
 make help         # list targets
 ```
 
@@ -61,11 +61,22 @@ cmake -S . -B build -DFUNCTIONAL_TEST_SHARDS=16
 Equivalent CMake commands (no root Makefile):
 
 ```shell
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DTRANS_ENABLE_COVERAGE=ON
 cmake --build build -j$(nproc)
 cd build && ctest --output-on-failure -j$(nproc)   # day-to-day
 cd build && ctest --output-on-failure -j1            # before lcov / coverage
 ```
+
+Or with presets (`CMakePresets.json`):
+
+```shell
+cmake --preset coverage    # Debug + gcov (same knobs as make configure)
+cmake --build --preset coverage
+ctest --preset coverage
+# also: default (Release), debug, ci (coverage + serial tests)
+```
+
+`TRANS_ENABLE_COVERAGE` is an explicit option (not tied to the Debug config name). The root `Makefile` turns it on automatically when `BUILD_TYPE=Debug` (override with `make COVERAGE=OFF configure`).
 
 ## History
 I started this project in my third year at the University as an assignment for Translation Methods course in Autumn of 2008.

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -113,5 +113,5 @@ add_library(ast
         LoggingSyntaxTreeVisitor.cpp
     )
 
-target_include_directories(ast PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(ast)
 target_link_libraries(ast PUBLIC parser types semantic_analyzer)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(codegen
+# Target is "backend" (compiler backend: IR + assembly). Not "codegen" — that
+# name is reserved by CMake (CMP0171). Source tree stays src/codegen/.
+add_library(backend
         quadruples/Add.cpp
         quadruples/AddressOf.cpp
         quadruples/And.cpp
@@ -91,5 +93,5 @@ add_library(codegen
         Value.h
         Assembly.h)
 
-target_include_directories(codegen PUBLIC "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(codegen PUBLIC ast)
+trans_target_defaults(backend)
+target_link_libraries(backend PUBLIC ast)

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -604,7 +604,8 @@ Address StackMachine::spillSlotAddress(const Value& symbol) const {
 }
 
 void StackMachine::registerFrameHome(const std::string& name, Address address) {
-    auto inserted = frameHomes.emplace(name, std::move(address)).second;
+    [[maybe_unused]] const bool inserted =
+            frameHomes.emplace(name, std::move(address)).second;
     assert(inserted && "duplicate frame home registration");
 }
 

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -10,5 +10,5 @@ add_library(driver
         ConfigurationParser.h
         Driver.h)
 
-target_include_directories(driver PUBLIC "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(driver PUBLIC ast codegen util)
+trans_target_defaults(driver)
+target_link_libraries(driver PUBLIC ast backend util)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -50,5 +50,5 @@ add_library(parser
         TokenStream.h
         XmlOutputVisitor.h)
 
-target_include_directories(parser PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(parser)
 target_link_libraries(parser PUBLIC scanner util)

--- a/src/scanner/CMakeLists.txt
+++ b/src/scanner/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(scanner
         Token.cpp
         )
 
-target_include_directories(scanner PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(scanner)
 target_link_libraries(scanner PUBLIC translation_unit)

--- a/src/semantic_analyzer/CMakeLists.txt
+++ b/src/semantic_analyzer/CMakeLists.txt
@@ -16,5 +16,5 @@ add_library(semantic_analyzer
         ValueEntry.h
         ValueScope.h)
 
-target_include_directories(semantic_analyzer PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(semantic_analyzer)
 target_link_libraries(semantic_analyzer PUBLIC translation_unit types ast)

--- a/src/translation_unit/CMakeLists.txt
+++ b/src/translation_unit/CMakeLists.txt
@@ -4,4 +4,4 @@ add_library(translation_unit
         Context.h
         TranslationUnit.h)
 
-target_include_directories(translation_unit PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(translation_unit)

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -7,4 +7,4 @@ add_library(types
         Function.cpp
         )
 
-target_include_directories(types PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(types)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(util
         Process.h
         )
 
-target_include_directories(util PUBLIC "${CMAKE_SOURCE_DIR}/src")
+trans_target_defaults(util)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -1,5 +1,12 @@
 add_library(testUtil util/ResourceHelpers.cpp util/ResourceHelpers.h)
-target_include_directories(testUtil PUBLIC util)
+target_include_directories(testUtil PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/util>
+)
+# Warnings/coverage for test helpers; include path stays test-local (not trans_src).
+target_link_libraries(testUtil PUBLIC trans_common)
+if(TRANS_ENABLE_COVERAGE)
+  target_link_libraries(testUtil PUBLIC trans_coverage)
+endif()
 
 add_executable(astTest
         astTest/DeclarationSpecifiersTest.cpp
@@ -82,7 +89,7 @@ add_executable(codegenTest
         codegenTest/BasicBlockTests.cpp
         codegenTest/UnimplementedArrayCodegenTest.cpp
         )
-target_link_libraries(codegenTest PRIVATE GTest::gmock_main codegen ast)
+target_link_libraries(codegenTest PRIVATE GTest::gmock_main backend ast)
 add_test(NAME codegenTest COMMAND codegenTest)
 
 


### PR DESCRIPTION
## Summary
- Replace global `CMAKE_CXX_FLAGS*` mutation with INTERFACE targets (`trans_src`, `trans_common`, `trans_coverage`) and `trans_target_defaults()`
- Fetch GoogleTest only when `BUILD_TESTING` is on, with `URL_HASH` pin
- Add `TRANS_ENABLE_COVERAGE` option (Makefile maps Debug → ON); add `CMakePresets.json` (`default` / `debug` / `coverage` / `ci`)
- Rename CMake library target `codegen` → `backend` (CMP0171 reserved name; source tree stays `src/codegen/`)
- Link `trans` through `driver` only; set `project(... VERSION 0.1.0 ...)`
- Fix Release+`-Werror` unused variable when `assert` is compiled out (`StackMachine::registerFrameHome`)

## Test plan
- [x] `cmake --preset coverage` (or Debug + `TRANS_ENABLE_COVERAGE=ON`) build
- [x] Full `ctest` (18 tests) green
- [x] `BUILD_TESTING=OFF` builds `trans` without fetching googletest
- [x] Release build succeeds (assert-only variable fixed)
- [ ] CI: build + test + coverage upload