### PR TITLE
feat(scanner): C-ish tokens, keywords, and string-literal decode

### DIFF
--- a/resources/configuration/scanner.lex
+++ b/resources/configuration/scanner.lex
@@ -40,6 +40,7 @@
 @closing_brack  ]
 @opening_paren  (
 @closing_paren  )
+@dot            .
 @star           *
 @modulo         %
 @slash          /
@@ -53,25 +54,42 @@
 @bit_not        ~
 @less_than      <
 @more_than      >
+@colon          :
+@question       ?
 @start
 
 :literal_start
 @literal_esc    \
-@literal_end    abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789
+@literal_end
 
 :literal_esc
-@literal_end    abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789'\
+@literal_hex_intro  xX
+@literal_oct_digits 01234567
+@literal_end
+
+# Hex character escapes: '\xNN' (one or more hex digits).
+:literal_hex_intro
+@literal_hex_digits 0123456789abcdefABCDEF
+
+:literal_hex_digits
+@literal_hex_digits 0123456789abcdefABCDEF
+@literal        '
+
+# Octal character escapes: '\0', '\033', etc.
+:literal_oct_digits
+@literal_oct_digits 01234567
+@literal        '
 
 :literal_end
 @literal        '
 
 :"string_start
 @string_esc     \
-@string_start   abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789*/%-+=&^|!<>;:{}()[],'
 @string         "
+@string_start
 
 :"string_esc
-@string_start   abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789*/%-+=&^|!<>;:{}()[],'\
+@string_start
 
 :operator
 @operator       =-+&|<>
@@ -83,11 +101,48 @@
 
 :int_constant   int_const
 @int_constant   0123456789
+@hex_prefix     xX
 @float_constant .
+@float_exp_intro eE
+@int_suffix     uUlL
+@fin
+
+:hex_prefix
+@hex_constant   0123456789abcdefABCDEF
+@fin
+
+:hex_constant   int_const
+@hex_constant   0123456789abcdefABCDEF
+@int_suffix     uUlL
+@fin
+
+# C integer suffixes: u, l, ul, lu, ull, llu, etc.
+:int_suffix     int_const
+@int_suffix     uUlL
 @fin
 
 :float_constant float_const
 @float_constant 0123456789
+@float_exp_intro eE
+@float_suffix   fFlL
+@fin
+
+# C floating exponent: [eE][+-]?digits (e.g. 1.0e9, 1e-3).
+:float_exp_intro
+@float_exp_sign +-
+@float_exp_digits 0123456789
+
+:float_exp_sign
+@float_exp_digits 0123456789
+
+:float_exp_digits float_const
+@float_exp_digits 0123456789
+@float_suffix   fFlL
+@fin
+
+# C floating suffixes: f, F, l, L
+:float_suffix   float_const
+@float_suffix   fFlL
 @fin
 
 :literal        char_const
@@ -103,6 +158,17 @@
 @fin
 
 :closing_paren  )
+@fin
+
+:dot            .
+@dot_dot        .
+@fin
+
+:dot_dot        ..
+@ellipsis       .
+@fin
+
+:ellipsis       ...
 @fin
 
 :star           *
@@ -146,12 +212,16 @@
 :hyphen         -
 @minus_eq       =
 @decrement      -
+@arrow          >
 @fin
 
 :minus_eq       -=
 @fin
 
 :decrement      --
+@fin
+
+:arrow          ->
 @fin
 
 :plus           +
@@ -244,6 +314,12 @@
 :semicolon      ;
 @fin
 
+:colon          :
+@fin
+
+:question       ?
+@fin
+
 :opening_brace  {
 @fin
 
@@ -258,8 +334,14 @@
 
 :fin
 
-%int char void float
+%int char void float double short long signed unsigned
 %if else
-%while for continue break return
-%input output
+%while for do continue break return
+%struct union enum
+%typedef sizeof
+%switch case default goto
+%const volatile
+%static extern auto register
+%__builtin_offsetof __builtin_types_compatible_p __typeof__ __builtin_va_arg
+%_Generic
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(util
         NullStream.cpp
         Process.cpp
         Process.h
+        StringLiteralDecode.cpp
+        StringLiteralDecode.h
         )
 
 trans_target_defaults(util)

--- a/src/util/StringLiteralDecode.cpp
+++ b/src/util/StringLiteralDecode.cpp
@@ -1,0 +1,112 @@
+#include "StringLiteralDecode.h"
+
+#include <sstream>
+
+namespace util {
+
+std::vector<unsigned char> decodeStringLiteralBytes(const std::string &token) {
+    std::string body = token;
+    if (body.size() >= 2 && body.front() == '"' && body.back() == '"') {
+        body = body.substr(1, body.size() - 2);
+    }
+    std::vector<unsigned char> bytes;
+    for (std::size_t i = 0; i < body.size(); ++i) {
+        if (body[i] == '\\' && i + 1 < body.size()) {
+            ++i;
+            char e = body[i];
+            switch (e) {
+            case 'n':
+                bytes.push_back('\n');
+                break;
+            case 't':
+                bytes.push_back('\t');
+                break;
+            case 'r':
+                bytes.push_back('\r');
+                break;
+            case 'a':
+                bytes.push_back('\a');
+                break;
+            case 'b':
+                bytes.push_back('\b');
+                break;
+            case 'f':
+                bytes.push_back('\f');
+                break;
+            case 'v':
+                bytes.push_back('\v');
+                break;
+            case '\\':
+                bytes.push_back('\\');
+                break;
+            case '"':
+                bytes.push_back('"');
+                break;
+            case '\'':
+                bytes.push_back('\'');
+                break;
+            case '?':
+                bytes.push_back('?');
+                break;
+            case 'x':
+            case 'X': {
+                unsigned value = 0;
+                bool any = false;
+                while (i + 1 < body.size()) {
+                    char d = body[i + 1];
+                    unsigned digit;
+                    if (d >= '0' && d <= '9') {
+                        digit = static_cast<unsigned>(d - '0');
+                    } else if (d >= 'a' && d <= 'f') {
+                        digit = static_cast<unsigned>(d - 'a' + 10);
+                    } else if (d >= 'A' && d <= 'F') {
+                        digit = static_cast<unsigned>(d - 'A' + 10);
+                    } else {
+                        break;
+                    }
+                    any = true;
+                    ++i;
+                    value = (value << 4) | digit;
+                }
+                bytes.push_back(any ? static_cast<unsigned char>(value & 0xffu) : 0);
+                break;
+            }
+            default:
+                if (e >= '0' && e <= '7') {
+                    unsigned value = static_cast<unsigned>(e - '0');
+                    int count = 1;
+                    while (count < 3 && i + 1 < body.size() && body[i + 1] >= '0' && body[i + 1] <= '7') {
+                        ++i;
+                        ++count;
+                        value = (value << 3) | static_cast<unsigned>(body[i] - '0');
+                    }
+                    bytes.push_back(static_cast<unsigned char>(value & 0xffu));
+                } else {
+                    bytes.push_back(static_cast<unsigned char>(e));
+                }
+                break;
+            }
+        } else {
+            bytes.push_back(static_cast<unsigned char>(body[i]));
+        }
+    }
+    bytes.push_back(0);
+    return bytes;
+}
+
+int stringLiteralArrayLength(const std::string &token) { return static_cast<int>(decodeStringLiteralBytes(token).size()); }
+
+std::string toNasmDbDirective(const std::string &token) {
+    const auto bytes = decodeStringLiteralBytes(token);
+    std::ostringstream declaration;
+    declaration << "db ";
+    for (std::size_t i = 0; i < bytes.size(); ++i) {
+        if (i > 0) {
+            declaration << ", ";
+        }
+        declaration << static_cast<unsigned>(bytes[i]);
+    }
+    return declaration.str();
+}
+
+} // namespace util

--- a/src/util/StringLiteralDecode.h
+++ b/src/util/StringLiteralDecode.h
@@ -1,0 +1,21 @@
+#ifndef UTIL_STRINGLITERALDECODE_H_
+#define UTIL_STRINGLITERALDECODE_H_
+
+#include <string>
+#include <vector>
+
+namespace util {
+
+// Decode a C string token ("...") into the bytes it stores in a char array,
+// including the trailing NUL. Handles simple escapes, hex \xNN, and octal \nnn.
+std::vector<unsigned char> decodeStringLiteralBytes(const std::string &token);
+
+// Byte length including trailing NUL (char x[] = "XXXXXX" has length 7).
+int stringLiteralArrayLength(const std::string &token);
+
+// Format decoded bytes as a NASM "db ..." directive (includes trailing NUL).
+std::string toNasmDbDirective(const std::string &token);
+
+} // namespace util
+
+#endif // UTIL_STRINGLITERALDECODE_H_

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -50,6 +50,7 @@ add_test(NAME parserTest COMMAND parserTest)
 
 add_executable(scannerTest
         scannerTest/ScannerTest.cpp
+        scannerTest/ScannerTokensTest.cpp
         scannerTest/FiniteAutomatonTest.cpp
         scannerTest/LexFileScannerReaderTest.cpp
         scannerTest/StateTest.cpp
@@ -103,6 +104,7 @@ add_test(NAME driverTest COMMAND driverTest)
 
 add_executable(utilTest
         utilTest/ProcessTest.cpp
+        utilTest/StringLiteralDecodeTest.cpp
         )
 target_link_libraries(utilTest PRIVATE GTest::gmock_main util)
 add_test(NAME utilTest COMMAND utilTest)

--- a/test/src/scannerTest/ScannerTokensTest.cpp
+++ b/test/src/scannerTest/ScannerTokensTest.cpp
@@ -1,0 +1,184 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "scanner/LexFileScannerReader.h"
+#include "scanner/Scanner.h"
+#include "scanner/Token.h"
+
+#include "ResourceHelpers.h"
+
+#include <cerrno>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <sys/stat.h>
+#include <utility>
+#include <vector>
+
+using namespace testing;
+using namespace scanner;
+
+namespace {
+
+std::string writeTempSource(const std::string &name, const std::string &contents) {
+    // test/programs/tmp is gitignored; create if needed (same path layout as SourceProgram).
+    const std::string dir = getTestResourcePath("programs/tmp/");
+    if (mkdir(dir.c_str(), 0777) == -1 && errno != 17) {
+        throw std::runtime_error("Could not create " + dir);
+    }
+    const std::string path = dir + name + ".src";
+    std::ofstream out(path);
+    if (!out) {
+        throw std::runtime_error("Could not write " + path);
+    }
+    out << contents;
+    return path;
+}
+
+std::vector<Token> scanAll(const std::string &path) {
+    LexFileScannerReader reader;
+    Scanner scanner{path, reader.fromConfiguration(getResourcePath("configuration/scanner.lex"))};
+    std::vector<Token> out;
+    for (int i = 0; i < 200; ++i) {
+        Token t = scanner.nextToken();
+        if (t.id == Token::END) {
+            break;
+        }
+        out.push_back(t);
+    }
+    return out;
+}
+
+TEST(ScannerTokens, keywordsAreDistinctFromIdentifiers) {
+    auto path = writeTempSource("scan_kw", "const volatile static extern typedef sizeof struct union enum "
+                                           "short long signed unsigned double do switch case default goto "
+                                           "int x;\n");
+    auto toks = scanAll(path);
+    auto has = [&](const std::string &id) {
+        for (const auto &t : toks) {
+            if (t.id == id && t.lexeme == id) {
+                return true;
+            }
+        }
+        return false;
+    };
+    EXPECT_TRUE(has("const"));
+    EXPECT_TRUE(has("volatile"));
+    EXPECT_TRUE(has("static"));
+    EXPECT_TRUE(has("extern"));
+    EXPECT_TRUE(has("typedef"));
+    EXPECT_TRUE(has("sizeof"));
+    EXPECT_TRUE(has("struct"));
+    EXPECT_TRUE(has("union"));
+    EXPECT_TRUE(has("enum"));
+    EXPECT_TRUE(has("short"));
+    EXPECT_TRUE(has("long"));
+    EXPECT_TRUE(has("signed"));
+    EXPECT_TRUE(has("unsigned"));
+    EXPECT_TRUE(has("double"));
+    EXPECT_TRUE(has("do"));
+    EXPECT_TRUE(has("switch"));
+    EXPECT_TRUE(has("case"));
+    EXPECT_TRUE(has("default"));
+    EXPECT_TRUE(has("goto"));
+    // Non-keyword still id
+    bool sawX = false;
+    for (const auto &t : toks) {
+        if (t.lexeme == "x") {
+            EXPECT_EQ(t.id, "id");
+            sawX = true;
+        }
+    }
+    EXPECT_TRUE(sawX);
+}
+
+TEST(ScannerTokens, punctuatorsDotArrowQuestionColonEllipsis) {
+    auto path = writeTempSource("scan_punct", "a.b a->b c ? d : e f(...);\n");
+    auto toks = scanAll(path);
+    std::vector<std::string> ids;
+    for (const auto &t : toks) {
+        ids.push_back(t.id);
+    }
+    EXPECT_THAT(ids, Contains("."));
+    EXPECT_THAT(ids, Contains("->"));
+    EXPECT_THAT(ids, Contains("?"));
+    EXPECT_THAT(ids, Contains(":"));
+    EXPECT_THAT(ids, Contains("..."));
+}
+
+TEST(ScannerTokens, hexIntegerConstant) {
+    auto path = writeTempSource("scan_hex", "int x = 0x2A;\n");
+    auto toks = scanAll(path);
+    bool found = false;
+    for (const auto &t : toks) {
+        if (t.id == "int_const" && (t.lexeme == "0x2A" || t.lexeme == "0x2a")) {
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found) << "expected hex int_const token";
+}
+
+TEST(ScannerTokens, floatWithExponentAndSuffix) {
+    auto path = writeTempSource("scan_float", "float f = 1.5e2f; double d = 1e-3;\n");
+    auto toks = scanAll(path);
+    bool foundFloat = false;
+    bool foundExp = false;
+    for (const auto &t : toks) {
+        if (t.id == "float_const") {
+            if (t.lexeme.find("1.5") != std::string::npos || t.lexeme.find('f') != std::string::npos || t.lexeme.find('F') != std::string::npos) {
+                foundFloat = true;
+            }
+            if (t.lexeme.find('e') != std::string::npos || t.lexeme.find('E') != std::string::npos) {
+                foundExp = true;
+            }
+        }
+    }
+    EXPECT_TRUE(foundFloat);
+    EXPECT_TRUE(foundExp);
+}
+
+TEST(ScannerTokens, charHexAndOctalEscapesLexAsCharConst) {
+    auto path = writeTempSource("scan_charesc", "char a = '\\x41'; char b = '\\101';\n");
+    auto toks = scanAll(path);
+    int charConsts = 0;
+    for (const auto &t : toks) {
+        if (t.id == "char_const") {
+            ++charConsts;
+            EXPECT_THAT(t.lexeme, AnyOf(HasSubstr("\\x41"), HasSubstr("\\101"), Eq("'\\x41'"), Eq("'\\101'")));
+        }
+    }
+    EXPECT_GE(charConsts, 2);
+}
+
+TEST(ScannerTokens, stringWithEscapesIsOneToken) {
+    auto path = writeTempSource("scan_str", "char *p = \"a\\n\\t\";\n");
+    auto toks = scanAll(path);
+    bool found = false;
+    for (const auto &t : toks) {
+        if (t.id == "string") {
+            found = true;
+            EXPECT_THAT(t.lexeme, HasSubstr("\\n"));
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST(ScannerTokens, stillScansExistingKeywords) {
+    auto path = writeTempSource("scan_old_kw", "int main(void) { if (1) while (0) return 0; }\n");
+    auto toks = scanAll(path);
+    auto has = [&](const std::string &id) {
+        for (const auto &t : toks) {
+            if (t.id == id) {
+                return true;
+            }
+        }
+        return false;
+    };
+    EXPECT_TRUE(has("int"));
+    EXPECT_TRUE(has("if"));
+    EXPECT_TRUE(has("while"));
+    EXPECT_TRUE(has("return"));
+    EXPECT_TRUE(has("void"));
+}
+
+} // namespace

--- a/test/src/utilTest/StringLiteralDecodeTest.cpp
+++ b/test/src/utilTest/StringLiteralDecodeTest.cpp
@@ -1,0 +1,66 @@
+#include "gtest/gtest.h"
+
+#include "util/StringLiteralDecode.h"
+
+using util::decodeStringLiteralBytes;
+using util::stringLiteralArrayLength;
+using util::toNasmDbDirective;
+
+TEST(StringLiteralDecode, plainStringIncludesTrailingNul) {
+    auto bytes = decodeStringLiteralBytes("\"hello\"");
+    ASSERT_EQ(bytes.size(), 6u);
+    EXPECT_EQ(bytes[0], 'h');
+    EXPECT_EQ(bytes[4], 'o');
+    EXPECT_EQ(bytes[5], 0);
+    EXPECT_EQ(stringLiteralArrayLength("\"hello\""), 6);
+}
+
+TEST(StringLiteralDecode, simpleEscapes) {
+    auto bytes = decodeStringLiteralBytes("\"a\\n\\t\\\\\\\"\"");
+    // a, \n, \t, \, ", NUL
+    ASSERT_EQ(bytes.size(), 6u);
+    EXPECT_EQ(bytes[0], 'a');
+    EXPECT_EQ(bytes[1], '\n');
+    EXPECT_EQ(bytes[2], '\t');
+    EXPECT_EQ(bytes[3], '\\');
+    EXPECT_EQ(bytes[4], '"');
+    EXPECT_EQ(bytes[5], 0);
+}
+
+TEST(StringLiteralDecode, hexEscape) {
+    auto bytes = decodeStringLiteralBytes("\"\\x41\\x00\\xFF\"");
+    // \x41='A', \x00=0, \xFF=255, plus trailing NUL from decoder
+    ASSERT_EQ(bytes.size(), 4u);
+    EXPECT_EQ(bytes[0], 0x41);
+    EXPECT_EQ(bytes[1], 0x00);
+    EXPECT_EQ(bytes[2], 0xFF);
+    EXPECT_EQ(bytes[3], 0);
+}
+
+TEST(StringLiteralDecode, octalEscape) {
+    auto bytes = decodeStringLiteralBytes("\"\\101\\0\"");
+    // \101='A', \0=0, trailing NUL
+    ASSERT_EQ(bytes.size(), 3u);
+    EXPECT_EQ(bytes[0], 'A');
+    EXPECT_EQ(bytes[1], 0);
+    EXPECT_EQ(bytes[2], 0);
+}
+
+TEST(StringLiteralDecode, incompleteArrayLengthXPattern) {
+    // char x[] = "XXXXXX" has size 7 including NUL
+    EXPECT_EQ(stringLiteralArrayLength("\"XXXXXX\""), 7);
+}
+
+TEST(StringLiteralDecode, nasmDbDirective) {
+    EXPECT_EQ(toNasmDbDirective("\"AB\""), "db 65, 66, 0");
+    EXPECT_EQ(toNasmDbDirective("\"\\n\""), "db 10, 0");
+}
+
+TEST(StringLiteralDecode, unquotedBodyStillDecodes) {
+    // Callers may pass body without quotes in some paths; treat as raw body.
+    auto bytes = decodeStringLiteralBytes("hi");
+    ASSERT_EQ(bytes.size(), 3u);
+    EXPECT_EQ(bytes[0], 'h');
+    EXPECT_EQ(bytes[1], 'i');
+    EXPECT_EQ(bytes[2], 0);
+}


### PR DESCRIPTION
## Summary
- Expand `scanner.lex` with C punctuation (`.`, `->`, `?`, `:`, `...`), hex integers, float exponents/suffixes, hex/octal char escapes, and a fuller keyword set (`const`/`volatile`/storage/types/`sizeof`/control/struct-enum/builtins).
- Add `util::StringLiteralDecode` (+ unit tests) for shared string/escape decoding used by later frontend/codegen work.
- Add `ScannerTokensTest` to pin the new lexemes via the existing lex-file automaton.

This is **phase A** of landing `feature/finish-for-git` in slices: lexical substrate only. No grammar/table, Type, AST, or host-preprocess changes.

## Test plan
- [x] `ctest -R 'scannerTest|utilTest'` 
- [x] Full `ctest` (including functional shards)
- [ ] CI green

## Out of scope (later slices)
- Attribute/asm/pragma filtering in `Scanner.cpp`
- Typedef/enum registries
- Grammar `block_item` / arrays / structs
- Wiring decode into ConstantExpression / string codegen