### PR TITLE
feat(ast): implement conditional expression (ternary ?:)

### DIFF
--- a/src/ast/AbstractSyntaxTreeVisitor.h
+++ b/src/ast/AbstractSyntaxTreeVisitor.h
@@ -28,6 +28,7 @@
 #include "ast/ExpressionList.h"
 #include "ast/LogicalAndExpression.h"
 #include "ast/LogicalOrExpression.h"
+#include "ast/ConditionalExpression.h"
 #include "ast/PostfixExpression.h"
 #include "ast/PrefixExpression.h"
 #include "ast/ShiftExpression.h"
@@ -63,6 +64,7 @@ public:
     virtual void visit(BitwiseExpression& expression) = 0;
     virtual void visit(LogicalAndExpression& expression) = 0;
     virtual void visit(LogicalOrExpression& expression) = 0;
+    virtual void visit(ConditionalExpression& expression) = 0;
     virtual void visit(AssignmentExpression& expression) = 0;
     virtual void visit(ExpressionList& expression) = 0;
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(ast
         BitwiseExpression.cpp
         Block.cpp
         ComparisonExpression.cpp
+        ConditionalExpression.cpp
         Constant.cpp
         ConstantExpression.cpp
         ContextualSyntaxNodeBuilder.cpp
@@ -65,6 +66,7 @@ add_library(ast
         BitwiseExpression.h
         Block.h
         ComparisonExpression.h
+        ConditionalExpression.h
         Constant.h
         ConstantExpression.h
         ContextualSyntaxNodeBuilder.h

--- a/src/ast/ConditionalExpression.cpp
+++ b/src/ast/ConditionalExpression.cpp
@@ -1,0 +1,71 @@
+#include "ConditionalExpression.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+ConditionalExpression::ConditionalExpression(std::unique_ptr<Expression> condition,
+        std::unique_ptr<Expression> trueExpression,
+        std::unique_ptr<Expression> falseExpression) :
+        condition { std::move(condition) },
+        trueExpression { std::move(trueExpression) },
+        falseExpression { std::move(falseExpression) } {
+}
+
+void ConditionalExpression::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+void ConditionalExpression::visitCondition(AbstractSyntaxTreeVisitor& visitor) {
+    condition->accept(visitor);
+}
+
+void ConditionalExpression::visitTrueExpression(AbstractSyntaxTreeVisitor& visitor) {
+    trueExpression->accept(visitor);
+}
+
+void ConditionalExpression::visitFalseExpression(AbstractSyntaxTreeVisitor& visitor) {
+    falseExpression->accept(visitor);
+}
+
+semantic_analyzer::ValueEntry* ConditionalExpression::conditionSymbol() const {
+    return condition->getResultSymbol();
+}
+
+semantic_analyzer::ValueEntry* ConditionalExpression::trueSymbol() const {
+    return trueExpression->getResultSymbol();
+}
+
+semantic_analyzer::ValueEntry* ConditionalExpression::falseSymbol() const {
+    return falseExpression->getResultSymbol();
+}
+
+translation_unit::Context ConditionalExpression::getContext() const {
+    return condition->getContext();
+}
+
+void ConditionalExpression::setFalsyLabel(semantic_analyzer::LabelEntry label) {
+    falsyLabel = std::make_unique<semantic_analyzer::LabelEntry>(label);
+}
+
+semantic_analyzer::LabelEntry* ConditionalExpression::getFalsyLabel() const {
+    return falsyLabel.get();
+}
+
+void ConditionalExpression::setExitLabel(semantic_analyzer::LabelEntry label) {
+    exitLabel = std::make_unique<semantic_analyzer::LabelEntry>(label);
+}
+
+semantic_analyzer::LabelEntry* ConditionalExpression::getExitLabel() const {
+    return exitLabel.get();
+}
+
+bool ConditionalExpression::evaluateConstant(long& value) const {
+    long condValue;
+    if (!condition->evaluateConstant(condValue)) {
+        return false;
+    }
+    return condValue ? trueExpression->evaluateConstant(value) : falseExpression->evaluateConstant(value);
+}
+
+} // namespace ast

--- a/src/ast/ConditionalExpression.h
+++ b/src/ast/ConditionalExpression.h
@@ -1,0 +1,52 @@
+#ifndef CONDITIONALEXPRESSION_H_
+#define CONDITIONALEXPRESSION_H_
+
+#include <memory>
+
+#include "Expression.h"
+#include "semantic_analyzer/LabelEntry.h"
+
+namespace ast {
+
+// cond ? thenExpr : elseExpr
+class ConditionalExpression: public Expression {
+public:
+    ConditionalExpression(std::unique_ptr<Expression> condition,
+            std::unique_ptr<Expression> trueExpression,
+            std::unique_ptr<Expression> falseExpression);
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    void visitCondition(AbstractSyntaxTreeVisitor& visitor);
+    void visitTrueExpression(AbstractSyntaxTreeVisitor& visitor);
+    void visitFalseExpression(AbstractSyntaxTreeVisitor& visitor);
+
+    Expression* getCondition() const { return condition.get(); }
+    Expression* getTrueExpression() const { return trueExpression.get(); }
+    Expression* getFalseExpression() const { return falseExpression.get(); }
+
+    semantic_analyzer::ValueEntry* conditionSymbol() const;
+    semantic_analyzer::ValueEntry* trueSymbol() const;
+    semantic_analyzer::ValueEntry* falseSymbol() const;
+
+    translation_unit::Context getContext() const override;
+
+    void setFalsyLabel(semantic_analyzer::LabelEntry label);
+    semantic_analyzer::LabelEntry* getFalsyLabel() const;
+    void setExitLabel(semantic_analyzer::LabelEntry label);
+    semantic_analyzer::LabelEntry* getExitLabel() const;
+
+    bool evaluateConstant(long& value) const override;
+
+private:
+    std::unique_ptr<Expression> condition;
+    std::unique_ptr<Expression> trueExpression;
+    std::unique_ptr<Expression> falseExpression;
+
+    std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
+    std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
+};
+
+} // namespace ast
+
+#endif // CONDITIONALEXPRESSION_H_

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -13,6 +13,7 @@
 #include "BitwiseExpression.h"
 #include "Block.h"
 #include "ComparisonExpression.h"
+#include "ConditionalExpression.h"
 #include "ConstantExpression.h"
 #include "ExpressionList.h"
 #include "ForLoopHeader.h"
@@ -377,7 +378,15 @@ void logicalOrExpression(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void conditionalExpression(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "conditionalExpression is not implemented yet" };
+    // Production: <logical_or_exp> '?' <exp> ':' <conditional_exp>
+    // Expressions reduce LIFO: false arm, true arm, then condition; then '?' / ':'.
+    context.popTerminal(); // :
+    context.popTerminal(); // ?
+    auto falseExpression = context.popExpression();
+    auto trueExpression = context.popExpression();
+    auto condition = context.popExpression();
+    context.pushExpression(std::make_unique<ConditionalExpression>(
+            std::move(condition), std::move(trueExpression), std::move(falseExpression)));
 }
 
 void assignmentExpression(AbstractSyntaxTreeBuilderContext& context) {

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -310,6 +310,24 @@ void CodeGeneratingVisitor::visit(ast::LogicalOrExpression& expression) {
     instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
 }
 
+void CodeGeneratingVisitor::visit(ast::ConditionalExpression& expression) {
+    expression.visitCondition(*this);
+    instructions.push_back(std::make_unique<ZeroCompare>(expression.conditionSymbol()->getName()));
+    instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
+
+    expression.visitTrueExpression(*this);
+    instructions.push_back(std::make_unique<Assign>(
+            expression.trueSymbol()->getName(), expression.getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName()));
+
+    instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
+    expression.visitFalseExpression(*this);
+    instructions.push_back(std::make_unique<Assign>(
+            expression.falseSymbol()->getName(), expression.getResultSymbol()->getName()));
+
+    instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
+}
+
 void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);

--- a/src/codegen/CodeGeneratingVisitor.h
+++ b/src/codegen/CodeGeneratingVisitor.h
@@ -35,6 +35,7 @@ public:
     void visit(ast::BitwiseExpression& expression) override;
     void visit(ast::LogicalAndExpression& expression) override;
     void visit(ast::LogicalOrExpression& expression) override;
+    void visit(ast::ConditionalExpression& expression) override;
     void visit(ast::AssignmentExpression& expression) override;
     void visit(ast::ExpressionList& expression) override;
 

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -377,6 +377,34 @@ void SemanticAnalysisVisitor::visit(ast::LogicalOrExpression& expression) {
     expression.setExitLabel(symbolTable.newLabel());
 }
 
+void SemanticAnalysisVisitor::visit(ast::ConditionalExpression& expression) {
+    expression.visitCondition(*this);
+    expression.visitTrueExpression(*this);
+    expression.visitFalseExpression(*this);
+
+    if (!expression.getCondition()->hasResultSymbol()
+            || !expression.getTrueExpression()->hasResultSymbol()
+            || !expression.getFalseExpression()->hasResultSymbol()) {
+        return;
+    }
+
+    rejectFunctionValue(expression.conditionSymbol()->getType(), expression.getContext());
+    rejectFunctionValue(expression.trueSymbol()->getType(), expression.getContext());
+    rejectFunctionValue(expression.falseSymbol()->getType(), expression.getContext());
+
+    typeCheck(
+            expression.trueSymbol()->getType(),
+            expression.falseSymbol()->getType(),
+            expression.getContext());
+
+    // Result type follows the true arm after typeCheck (same policy as other binary ops).
+    const type::Type resultType = expression.trueSymbol()->getType();
+    expression.setType(resultType);
+    expression.setResultSymbol(symbolTable.createTemporarySymbol(resultType));
+    expression.setFalsyLabel(symbolTable.newLabel());
+    expression.setExitLabel(symbolTable.newLabel());
+}
+
 void SemanticAnalysisVisitor::visit(ast::AssignmentExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -35,6 +35,7 @@ public:
     void visit(ast::BitwiseExpression& expression) override;
     void visit(ast::LogicalAndExpression& expression) override;
     void visit(ast::LogicalOrExpression& expression) override;
+    void visit(ast::ConditionalExpression& expression) override;
     void visit(ast::AssignmentExpression& expression) override;
     void visit(ast::ExpressionList& expression) override;
 

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -212,6 +212,15 @@ void SemanticXmlOutputVisitor::visit(ast::LogicalOrExpression& expression) {
     closeXmlNode(nodeId);
 }
 
+void SemanticXmlOutputVisitor::visit(ast::ConditionalExpression& expression) {
+    const std::string nodeId { "conditional" };
+    openXmlNode(nodeId);
+    expression.visitCondition(*this);
+    expression.visitTrueExpression(*this);
+    expression.visitFalseExpression(*this);
+    closeXmlNode(nodeId);
+}
+
 void SemanticXmlOutputVisitor::visit(ast::AssignmentExpression& expression) {
     const std::string nodeId { "assignment" };
     openXmlNode(nodeId);

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.h
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.h
@@ -34,6 +34,7 @@ public:
     void visit(ast::BitwiseExpression& expression) override;
     void visit(ast::LogicalAndExpression& expression) override;
     void visit(ast::LogicalOrExpression& expression) override;
+    void visit(ast::ConditionalExpression& expression) override;
     void visit(ast::AssignmentExpression& expression) override;
     void visit(ast::ExpressionList& expression) override;
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -115,6 +115,7 @@ add_executable(functionalTest
         functionalTest/TestFixtures.cpp
         functionalTest/CompilerInitTest.cpp
         functionalTest/ConditionalTest.cpp
+        functionalTest/TernaryTest.cpp
         functionalTest/BasicMathTest.cpp
         functionalTest/IncrementsDecrementsTest.cpp
         functionalTest/PointersTest.cpp

--- a/test/src/functionalTest/TernaryTest.cpp
+++ b/test/src/functionalTest/TernaryTest.cpp
@@ -1,0 +1,121 @@
+#include "TestFixtures.h"
+
+namespace {
+
+// Proves conditionalExpression is required: master throws until implemented.
+TEST(Compiler, ternaryBasicTrue) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1 ? 10 : 20;
+            printf("%d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("10");
+}
+
+TEST(Compiler, ternaryBasicFalse) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 0 ? 10 : 20;
+            printf("%d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20");
+}
+
+TEST(Compiler, ternaryWithVariables) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x;
+            int y;
+            int z;
+            x = 5;
+            y = 3;
+            z = (x > y) ? x : y;
+            printf("%d", z);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5");
+}
+
+TEST(Compiler, ternaryNested) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1 ? (0 ? 1 : 2) : 3;
+            printf("%d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2");
+}
+
+TEST(Compiler, ternaryInExpression) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 2 + (1 ? 3 : 4);
+            printf("%d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5");
+}
+
+TEST(Compiler, ternaryOnlyOneArmEvaluated) {
+    // Side effects: only the selected arm must run (via assignment to out).
+    SourceProgram program{R"prg(
+        int main() {
+            int out;
+            int unused;
+            out = 0;
+            unused = 1 ? (out = 7) : (out = 9);
+            printf("%d %d", out, unused);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7 7");
+}
+
+// Global init folds constant ternary via evaluateConstant.
+TEST(Compiler, ternaryConstantGlobalInit) {
+    SourceProgram program{R"prg(
+        int g = 1 ? 4 : 5;
+
+        int main() {
+            printf("%d", g);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("4");
+}
+
+// Selected arm's false path must not execute either.
+TEST(Compiler, ternaryFalseArmOnly) {
+    SourceProgram program{R"prg(
+        int main() {
+            int out;
+            int unused;
+            out = 0;
+            unused = 0 ? (out = 7) : (out = 9);
+            printf("%d %d", out, unused);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9 9");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Implement `cond ? then : else` via new `ConditionalExpression` AST node (grammar production already existed; CSNB threw).
- Semantic analysis: type-check arms, result temp + falsy/exit labels; constant folding for global init.
- Codegen: branch on condition, evaluate only the taken arm at runtime, join on exit label.
- Functional tests: true/false, variables, nesting, expression context, side-effect arms, constant global init.

## Stack
PR 1/6 of finish-for-git extraction (ternary → do-while → goto → switch → recursive Type → structs).

## Test plan
- [x] Full local `ctest`
- [x] Ternary functional suite
- [ ] CI green