### PR TITLE
feat(ast): implement do-while loops

### DIFF
--- a/src/ast/AbstractSyntaxTreeVisitor.h
+++ b/src/ast/AbstractSyntaxTreeVisitor.h
@@ -23,6 +23,7 @@
 #include "ast/TypeCast.h"
 #include "ast/UnaryExpression.h"
 #include "ast/WhileLoopHeader.h"
+#include "ast/DoWhileLoopHeader.h"
 #include "ast/ArithmeticExpression.h"
 #include "ast/BitwiseExpression.h"
 #include "ast/ExpressionList.h"
@@ -79,6 +80,7 @@ public:
 
     virtual void visit(ForLoopHeader& loopHeader) = 0;
     virtual void visit(WhileLoopHeader& loopHeader) = 0;
+    virtual void visit(DoWhileLoopHeader& loopHeader) = 0;
 
     virtual void visit(Pointer& pointer) = 0;
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(ast
         DeclarationSpecifiers.cpp
         Declarator.cpp
         DirectDeclarator.cpp
+        DoWhileLoopHeader.cpp
         DoubleOperandExpression.cpp
         Expression.cpp
         ExpressionList.cpp
@@ -74,6 +75,7 @@ add_library(ast
         DeclarationSpecifiers.h
         Declarator.h
         DirectDeclarator.h
+        DoWhileLoopHeader.h
         DoubleOperandExpression.h
         Expression.h
         ExpressionList.h

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -37,6 +37,7 @@
 #include "TypeCast.h"
 #include "UnaryExpression.h"
 #include "WhileLoopHeader.h"
+#include "DoWhileLoopHeader.h"
 
 #include "ast/StringLiteralExpression.h"
 #include "types/Type.h"
@@ -503,6 +504,19 @@ void whileLoopStatement(AbstractSyntaxTreeBuilderContext& context) {
     context.pushStatement(std::make_unique<LoopStatement>(std::move(loopHeader), std::move(body)));
 }
 
+void doWhileLoopStatement(AbstractSyntaxTreeBuilderContext& context) {
+    // Production: 'do' <stat> 'while' '(' <exp> ')' ';'
+    context.popTerminal(); // ;
+    context.popTerminal(); // )
+    context.popTerminal(); // (
+    context.popTerminal(); // while
+    context.popTerminal(); // do
+    auto clause = context.popExpression();
+    auto body = context.popStatement();
+    auto loopHeader = std::make_unique<DoWhileLoopHeader>(std::move(clause));
+    context.pushStatement(std::make_unique<LoopStatement>(std::move(loopHeader), std::move(body)));
+}
+
 void statementList(AbstractSyntaxTreeBuilderContext& context) {
     context.newStatementList(context.popStatement());
 }
@@ -895,9 +909,14 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_unmatched][{ s_iteration_stat_unmatched }] = doNothing;
 
     int s_while = grammar.symbolId("while");
+    int s_do = grammar.symbolId("do");
     int s_for = grammar.symbolId("for");
     nodeCreatorRegistry[s_iteration_stat_matched][{ s_while, s_open_paren, s_exp, s_close_paren, s_matched }] = whileLoopStatement;
     nodeCreatorRegistry[s_iteration_stat_unmatched][{ s_while, s_open_paren, s_exp, s_close_paren, s_unmatched }] = whileLoopStatement;
+    nodeCreatorRegistry[s_iteration_stat_matched][{ s_do, s_matched, s_while, s_open_paren, s_exp, s_close_paren, s_semicolon }] =
+            doWhileLoopStatement;
+    nodeCreatorRegistry[s_iteration_stat_unmatched][{ s_do, s_unmatched, s_while, s_open_paren, s_exp, s_close_paren, s_semicolon }] =
+            doWhileLoopStatement;
 
     // for-init: none / expression / declaration. Decl form has one fewer terminal because
     // <decl> already consumes its terminating ';'.

--- a/src/ast/DoWhileLoopHeader.cpp
+++ b/src/ast/DoWhileLoopHeader.cpp
@@ -1,0 +1,15 @@
+#include "DoWhileLoopHeader.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+DoWhileLoopHeader::DoWhileLoopHeader(std::unique_ptr<Expression> clause) :
+        clause { std::move(clause) } {
+}
+
+void DoWhileLoopHeader::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+} // namespace ast

--- a/src/ast/DoWhileLoopHeader.h
+++ b/src/ast/DoWhileLoopHeader.h
@@ -1,0 +1,25 @@
+#ifndef DOWHILELOOPHEADER_H_
+#define DOWHILELOOPHEADER_H_
+
+#include <memory>
+
+#include "ast/LoopHeader.h"
+
+namespace ast {
+
+class DoWhileLoopHeader: public LoopHeader {
+public:
+    explicit DoWhileLoopHeader(std::unique_ptr<Expression> clause);
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    // Body runs before the condition; continue jumps to the test, not the body entry.
+    bool bodyBeforeTest() const override { return true; }
+    bool continueTargetsEntry() const override { return false; }
+
+    const std::unique_ptr<Expression> clause;
+};
+
+} // namespace ast
+
+#endif // DOWHILELOOPHEADER_H_

--- a/src/ast/LoopHeader.h
+++ b/src/ast/LoopHeader.h
@@ -22,6 +22,11 @@ public:
     // C99 for-with-declaration scopes the header declaration over the loop body.
     virtual bool opensBlockScope() const { return false; }
 
+    // do-while: body before condition. while/for: test before body.
+    virtual bool bodyBeforeTest() const { return false; }
+    // while (and for without increment): continue → entry. do-while: continue → test.
+    virtual bool continueTargetsEntry() const { return !increment; }
+
     static const std::string ID;
 
     const std::unique_ptr<Expression> increment;

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -465,6 +465,16 @@ void CodeGeneratingVisitor::visit(ast::IfElseStatement& statement) {
 }
 
 void CodeGeneratingVisitor::visit(ast::LoopStatement& loop) {
+    if (loop.header->bodyBeforeTest()) {
+        // do { body } while (cond); — header visit emits the trailing test + branch.
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopEntry()->getName()));
+        loop.body->accept(*this);
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopContinue()->getName()));
+        loop.header->accept(*this);
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopExit()->getName()));
+        return;
+    }
+
     loop.header->accept(*this);
     loop.body->accept(*this);
     // continue target: for-loops place a label before the increment; while reuses entry.
@@ -498,6 +508,13 @@ void CodeGeneratingVisitor::visit(ast::WhileLoopHeader& loopHeader) {
     loopHeader.clause->accept(*this);
     instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
     instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
+}
+
+void CodeGeneratingVisitor::visit(ast::DoWhileLoopHeader& loopHeader) {
+    // Invoked after the body and continue label (see visit(LoopStatement)).
+    loopHeader.clause->accept(*this);
+    instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopEntry()->getName(), JumpCondition::IF_NOT_EQUAL));
 }
 
 void CodeGeneratingVisitor::visit(ast::Pointer&) {

--- a/src/codegen/CodeGeneratingVisitor.h
+++ b/src/codegen/CodeGeneratingVisitor.h
@@ -50,6 +50,7 @@ public:
 
     void visit(ast::ForLoopHeader& loopHeader) override;
     void visit(ast::WhileLoopHeader& loopHeader) override;
+    void visit(ast::DoWhileLoopHeader& loopHeader) override;
 
     void visit(ast::Pointer& pointer) override;
 

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -496,10 +496,11 @@ void SemanticAnalysisVisitor::visit(ast::LoopStatement& loop) {
         symbolTable.enterBlockScope();
     }
     loop.header->accept(*this);
-    // while/for-without-increment: continue → entry; for-with-increment: separate continue label.
+    // for-with-increment: continue before increment. while: continue → entry.
+    // do-while: header preassigns continue (before the test); leave it alone.
     if (loop.header->increment) {
         loop.header->setLoopContinue(symbolTable.newLabel());
-    } else {
+    } else if (loop.header->continueTargetsEntry()) {
         loop.header->setLoopContinue(*loop.header->getLoopEntry());
     }
     loopStack.push_back({ loop.header->getLoopEntry(), loop.header->getLoopContinue(), loop.header->getLoopExit() });
@@ -529,6 +530,15 @@ void SemanticAnalysisVisitor::visit(ast::WhileLoopHeader& loopHeader) {
     loopHeader.clause->accept(*this);
 
     loopHeader.setLoopEntry(symbolTable.newLabel());
+    loopHeader.setLoopExit(symbolTable.newLabel());
+}
+
+void SemanticAnalysisVisitor::visit(ast::DoWhileLoopHeader& loopHeader) {
+    loopHeader.clause->accept(*this);
+
+    loopHeader.setLoopEntry(symbolTable.newLabel());
+    // continue jumps here (re-test), not to the body entry.
+    loopHeader.setLoopContinue(symbolTable.newLabel());
     loopHeader.setLoopExit(symbolTable.newLabel());
 }
 

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -50,6 +50,7 @@ public:
 
     void visit(ast::ForLoopHeader& loopHeader) override;
     void visit(ast::WhileLoopHeader& loopHeader) override;
+    void visit(ast::DoWhileLoopHeader& loopHeader) override;
 
     void visit(ast::Pointer& pointer) override;
 

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -308,6 +308,13 @@ void SemanticXmlOutputVisitor::visit(ast::WhileLoopHeader& loopHeader) {
     closeXmlNode(nodeId);
 }
 
+void SemanticXmlOutputVisitor::visit(ast::DoWhileLoopHeader& loopHeader) {
+    const std::string nodeId { "doWhileLoopHeader" };
+    openXmlNode(nodeId);
+    loopHeader.clause->accept(*this);
+    closeXmlNode(nodeId);
+}
+
 void SemanticXmlOutputVisitor::visit(ast::Pointer& pointer) {
     ident();
     createLeafNode("pointer", "1");

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.h
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.h
@@ -49,6 +49,7 @@ public:
 
     void visit(ast::ForLoopHeader& loopHeader) override;
     void visit(ast::WhileLoopHeader& loopHeader) override;
+    void visit(ast::DoWhileLoopHeader& loopHeader) override;
 
     void visit(ast::Pointer& pointer) override;
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -123,6 +123,7 @@ add_executable(functionalTest
         functionalTest/InputOutputTest.cpp
         functionalTest/ForLoopTest.cpp
         functionalTest/WhileLoopTest.cpp
+        functionalTest/DoWhileTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/functionalTest/DoWhileTest.cpp
+++ b/test/src/functionalTest/DoWhileTest.cpp
@@ -1,0 +1,80 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, doWhileRunsAtLeastOnce) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            n = 0;
+            do {
+                printf("%d", 7);
+                n = n + 1;
+            } while (0);
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("71");
+}
+
+TEST(Compiler, doWhileMultipleIterations) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            n = 0;
+            do {
+                n = n + 1;
+            } while (n < 3);
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, doWhileBreak) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            n = 0;
+            do {
+                n = n + 1;
+                if (n == 2) {
+                    break;
+                }
+            } while (1);
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2");
+}
+
+TEST(Compiler, doWhileContinue) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            int sum;
+            n = 0;
+            sum = 0;
+            do {
+                n = n + 1;
+                if (n == 2) {
+                    continue;
+                }
+                sum = sum + n;
+            } while (n < 4);
+            printf("%d", sum);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    // n=1 sum=1; n=2 continue; n=3 sum=4; n=4 sum=8
+    program.runAndExpect("8");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Implement `do { … } while (cond);` (grammar already present; CSNB had no creator).
- `DoWhileLoopHeader` + `LoopHeader::bodyBeforeTest` / `continueTargetsEntry` so continue hits the test, not the body entry.
- Codegen: body first, then header emits condition + branch back.
- Functional tests: at-least-once, multi-iter, break, continue.

## Stack
PR 2/6 — stacks on #64 (ternary).

## Test plan
- [x] Full local `ctest`
- [x] DoWhile functional suite
- [ ] CI green