### PR TITLE
feat(ast): implement goto and named statement labels

### DIFF
--- a/src/ast/AbstractSyntaxTreeVisitor.h
+++ b/src/ast/AbstractSyntaxTreeVisitor.h
@@ -13,6 +13,8 @@
 #include "ast/IfElseStatement.h"
 #include "ast/IfStatement.h"
 #include "ast/JumpStatement.h"
+#include "ast/GotoStatement.h"
+#include "ast/LabeledStatement.h"
 #include "ast/LoopStatement.h"
 #include "ast/Operator.h"
 #include "ast/ReturnStatement.h"
@@ -72,6 +74,8 @@ public:
     virtual void visit(Operator& op) = 0;
 
     virtual void visit(JumpStatement& statement) = 0;
+    virtual void visit(GotoStatement& statement) = 0;
+    virtual void visit(LabeledStatement& statement) = 0;
     virtual void visit(ReturnStatement& statement) = 0;
     virtual void visit(VoidReturnStatement& statement) = 0;
     virtual void visit(IfStatement& statement) = 0;

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -26,12 +26,14 @@ add_library(ast
         FunctionCall.cpp
         FunctionDeclarator.cpp
         FunctionDefinition.cpp
+        GotoStatement.cpp
         Identifier.cpp
         IdentifierExpression.cpp
         IfElseStatement.cpp
         IfStatement.cpp
         InitializedDeclarator.cpp
         JumpStatement.cpp
+        LabeledStatement.cpp
         LogicalAndExpression.cpp
         LogicalExpression.cpp
         LogicalOrExpression.cpp
@@ -84,12 +86,14 @@ add_library(ast
         FunctionCall.h
         FunctionDeclarator.h
         FunctionDefinition.h
+        GotoStatement.h
         Identifier.h
         IdentifierExpression.h
         IfElseStatement.h
         IfStatement.h
         InitializedDeclarator.h
         JumpStatement.h
+        LabeledStatement.h
         LogicalAndExpression.h
         LogicalExpression.h
         LogicalOrExpression.h

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -24,6 +24,8 @@
 #include "IfElseStatement.h"
 #include "IfStatement.h"
 #include "JumpStatement.h"
+#include "GotoStatement.h"
+#include "LabeledStatement.h"
 #include "LogicalAndExpression.h"
 #include "LogicalOrExpression.h"
 #include "LoopStatement.h"
@@ -504,6 +506,20 @@ void whileLoopStatement(AbstractSyntaxTreeBuilderContext& context) {
     context.pushStatement(std::make_unique<LoopStatement>(std::move(loopHeader), std::move(body)));
 }
 
+void namedLabel(AbstractSyntaxTreeBuilderContext& context) {
+    context.popTerminal(); // :
+    auto labelName = context.popTerminal(); // id
+    auto statement = context.popStatement();
+    context.pushStatement(std::make_unique<LabeledStatement>(labelName, std::move(statement)));
+}
+
+void gotoStatement(AbstractSyntaxTreeBuilderContext& context) {
+    context.popTerminal(); // ;
+    auto labelName = context.popTerminal(); // id
+    auto gotoKeyword = context.popTerminal(); // goto
+    context.pushStatement(std::make_unique<GotoStatement>(gotoKeyword, labelName));
+}
+
 void doWhileLoopStatement(AbstractSyntaxTreeBuilderContext& context) {
     // Production: 'do' <stat> 'while' '(' <exp> ')' ';'
     context.popTerminal(); // ;
@@ -851,10 +867,17 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     int s_compound_stat = grammar.symbolId("<compound_stat>");
     int s_jump_stat = grammar.symbolId("<jump_stat>");
     int s_if = grammar.symbolId("if");
+    int s_colon = grammar.symbolId(":");
+    int s_labeled_stat_matched = grammar.symbolId("<labeled_stat_matched>");
+    int s_labeled_stat_unmatched = grammar.symbolId("<labeled_stat_unmatched>");
     nodeCreatorRegistry[s_matched][{s_if, s_open_paren, s_exp, s_close_paren, s_matched, grammar.symbolId("else"), s_matched }] = ifElseStatement;
     nodeCreatorRegistry[s_unmatched][{s_if, s_open_paren, s_exp, s_close_paren, s_stat }] = ifStatement;
     //nodeCreatorRegistry[s_matched][{ grammar.symbolId("switch"), s_open_paren, s_exp, s_close_paren, s_matched }] = switchStatement;
-    //nodeCreatorRegistry[s_matched][{ grammar.symbolId("<labeled_stat_matched>") }] = labeledStatement; // ??
+    nodeCreatorRegistry[s_matched][{ s_labeled_stat_matched }] = doNothing;
+    nodeCreatorRegistry[s_unmatched][{ s_labeled_stat_unmatched }] = doNothing;
+    // s_identifier defined earlier with declarators / primary_exp.
+    nodeCreatorRegistry[s_labeled_stat_matched][{ s_identifier, s_colon, s_matched }] = namedLabel;
+    nodeCreatorRegistry[s_labeled_stat_unmatched][{ s_identifier, s_colon, s_unmatched }] = namedLabel;
     nodeCreatorRegistry[s_matched][{ s_exp_stat }] = doNothing;
     nodeCreatorRegistry[s_matched][{ s_compound_stat }] = doNothing;
     nodeCreatorRegistry[s_matched][{ s_jump_stat }] = doNothing;
@@ -867,7 +890,7 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_stat_list][{ s_stat_list, s_stat }] = addToStatementList;
 
     int s_return = grammar.symbolId("return");
-    //nodeCreatorRegistry[s_jump_stat][{ grammar.symbolId("goto"), s_identifier, s_semicolon }] = gotoStatement;
+    nodeCreatorRegistry[s_jump_stat][{ grammar.symbolId("goto"), s_identifier, s_semicolon }] = gotoStatement;
     nodeCreatorRegistry[s_jump_stat][{ grammar.symbolId("continue"), s_semicolon }] = loopJumpStatement;
     nodeCreatorRegistry[s_jump_stat][{ grammar.symbolId("break"), s_semicolon }] = loopJumpStatement;
     nodeCreatorRegistry[s_jump_stat][{ s_return, s_exp, s_semicolon }] = returnExpressionStatement;

--- a/src/ast/GotoStatement.cpp
+++ b/src/ast/GotoStatement.cpp
@@ -1,0 +1,28 @@
+#include "GotoStatement.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+GotoStatement::GotoStatement(TerminalSymbol gotoKeyword, TerminalSymbol labelName) :
+        gotoKeyword { gotoKeyword },
+        label { labelName } {
+}
+
+void GotoStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+void GotoStatement::setTarget(semantic_analyzer::LabelEntry target) {
+    this->target = std::make_unique<semantic_analyzer::LabelEntry>(target);
+}
+
+semantic_analyzer::LabelEntry* GotoStatement::getTarget() const {
+    return target.get();
+}
+
+const std::string& GotoStatement::getLabelName() const {
+    return label.value;
+}
+
+} // namespace ast

--- a/src/ast/GotoStatement.h
+++ b/src/ast/GotoStatement.h
@@ -1,0 +1,33 @@
+#ifndef GOTOSTATEMENT_H_
+#define GOTOSTATEMENT_H_
+
+#include <memory>
+#include <string>
+
+#include "ast/AbstractSyntaxTreeNode.h"
+#include "ast/TerminalSymbol.h"
+#include "semantic_analyzer/LabelEntry.h"
+
+namespace ast {
+
+class GotoStatement: public AbstractSyntaxTreeNode {
+public:
+    GotoStatement(TerminalSymbol gotoKeyword, TerminalSymbol labelName);
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    void setTarget(semantic_analyzer::LabelEntry target);
+    semantic_analyzer::LabelEntry* getTarget() const;
+
+    const std::string& getLabelName() const;
+
+    TerminalSymbol gotoKeyword;
+    TerminalSymbol label;
+
+private:
+    std::unique_ptr<semantic_analyzer::LabelEntry> target { nullptr };
+};
+
+} // namespace ast
+
+#endif // GOTOSTATEMENT_H_

--- a/src/ast/LabeledStatement.cpp
+++ b/src/ast/LabeledStatement.cpp
@@ -1,0 +1,28 @@
+#include "LabeledStatement.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+LabeledStatement::LabeledStatement(TerminalSymbol labelName, std::unique_ptr<AbstractSyntaxTreeNode> statement) :
+        name { labelName },
+        statement { std::move(statement) } {
+}
+
+void LabeledStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+void LabeledStatement::setLabel(semantic_analyzer::LabelEntry label) {
+    this->label = std::make_unique<semantic_analyzer::LabelEntry>(label);
+}
+
+semantic_analyzer::LabelEntry* LabeledStatement::getLabel() const {
+    return label.get();
+}
+
+const std::string& LabeledStatement::getLabelName() const {
+    return name.value;
+}
+
+} // namespace ast

--- a/src/ast/LabeledStatement.h
+++ b/src/ast/LabeledStatement.h
@@ -1,0 +1,34 @@
+#ifndef LABELEDSTATEMENT_H_
+#define LABELEDSTATEMENT_H_
+
+#include <memory>
+#include <string>
+
+#include "ast/AbstractSyntaxTreeNode.h"
+#include "ast/TerminalSymbol.h"
+#include "semantic_analyzer/LabelEntry.h"
+
+namespace ast {
+
+// C statement label: id : statement
+class LabeledStatement: public AbstractSyntaxTreeNode {
+public:
+    LabeledStatement(TerminalSymbol labelName, std::unique_ptr<AbstractSyntaxTreeNode> statement);
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    void setLabel(semantic_analyzer::LabelEntry label);
+    semantic_analyzer::LabelEntry* getLabel() const;
+
+    const std::string& getLabelName() const;
+
+    TerminalSymbol name;
+    const std::unique_ptr<AbstractSyntaxTreeNode> statement;
+
+private:
+    std::unique_ptr<semantic_analyzer::LabelEntry> label { nullptr };
+};
+
+} // namespace ast
+
+#endif // LABELEDSTATEMENT_H_

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -432,6 +432,21 @@ void CodeGeneratingVisitor::visit(ast::JumpStatement& statement) {
     instructions.push_back(std::make_unique<Jump>(statement.getJumpTo()->getName()));
 }
 
+void CodeGeneratingVisitor::visit(ast::GotoStatement& statement) {
+    if (!statement.getTarget()) {
+        throw std::runtime_error { "GotoStatement has no target label" };
+    }
+    instructions.push_back(std::make_unique<Jump>(statement.getTarget()->getName()));
+}
+
+void CodeGeneratingVisitor::visit(ast::LabeledStatement& statement) {
+    if (!statement.getLabel()) {
+        throw std::runtime_error { "LabeledStatement has no label" };
+    }
+    instructions.push_back(std::make_unique<Label>(statement.getLabel()->getName()));
+    statement.statement->accept(*this);
+}
+
 void CodeGeneratingVisitor::visit(ast::ReturnStatement& statement) {
     statement.returnExpression->accept(*this);
     instructions.push_back(std::make_unique<Return>(statement.returnExpression->getResultSymbol()->getName()));

--- a/src/codegen/CodeGeneratingVisitor.h
+++ b/src/codegen/CodeGeneratingVisitor.h
@@ -42,6 +42,8 @@ public:
     void visit(ast::Operator& op) override;
 
     void visit(ast::JumpStatement& statement) override;
+    void visit(ast::GotoStatement& statement) override;
+    void visit(ast::LabeledStatement& statement) override;
     void visit(ast::ReturnStatement& statement) override;
     void visit(ast::VoidReturnStatement& statement) override;
     void visit(ast::IfStatement& statement) override;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -455,6 +455,21 @@ void SemanticAnalysisVisitor::visit(ast::JumpStatement& statement) {
     }
 }
 
+void SemanticAnalysisVisitor::visit(ast::GotoStatement& statement) {
+    pendingGotos.push_back(&statement);
+}
+
+void SemanticAnalysisVisitor::visit(ast::LabeledStatement& statement) {
+    if (namedLabels.find(statement.getLabelName()) != namedLabels.end()) {
+        semanticError("duplicate label `" + statement.getLabelName() + "`", statement.name.context);
+    } else {
+        auto label = symbolTable.newLabel();
+        namedLabels.insert({ statement.getLabelName(), label });
+        statement.setLabel(label);
+    }
+    statement.statement->accept(*this);
+}
+
 void SemanticAnalysisVisitor::visit(ast::ReturnStatement& statement) {
     statement.returnExpression->accept(*this);
     if (statement.returnExpression->hasResultSymbol()) {
@@ -598,8 +613,21 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
     }
     function.setSymbol(symbolTable.findFunction(function.getName()));
     symbolTable.startFunction(function.getName(), argumentNames);
+    namedLabels.clear();
+    pendingGotos.clear();
     // Parameters and outermost body declarations share one scope (C); do not enterBlockScope.
     function.visitBodyChildren(*this);
+    for (auto* gotoStmt : pendingGotos) {
+        auto it = namedLabels.find(gotoStmt->getLabelName());
+        if (it == namedLabels.end()) {
+            semanticError("label `" + gotoStmt->getLabelName() + "` used but not defined",
+                    gotoStmt->label.context);
+        } else {
+            gotoStmt->setTarget(it->second);
+        }
+    }
+    namedLabels.clear();
+    pendingGotos.clear();
     function.setArguments(symbolTable.getCurrentScopeArguments());
     function.setLocalVariables(symbolTable.getCurrentScopeSymbols());
     symbolTable.endFunction();

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -460,12 +460,14 @@ void SemanticAnalysisVisitor::visit(ast::GotoStatement& statement) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::LabeledStatement& statement) {
+    // Always attach a codegen label so the statement node is well-formed even when
+    // the name is a duplicate (goto targets keep the first definition only).
+    auto label = symbolTable.newLabel();
+    statement.setLabel(label);
     if (namedLabels.find(statement.getLabelName()) != namedLabels.end()) {
         semanticError("duplicate label `" + statement.getLabelName() + "`", statement.name.context);
     } else {
-        auto label = symbolTable.newLabel();
         namedLabels.insert({ statement.getLabelName(), label });
-        statement.setLabel(label);
     }
     statement.statement->accept(*this);
 }

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -1,6 +1,7 @@
 #ifndef SEMANTICANALYSISVISITOR_H_
 #define SEMANTICANALYSISVISITOR_H_
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -42,6 +43,8 @@ public:
     void visit(ast::Operator& op) override;
 
     void visit(ast::JumpStatement& statement) override;
+    void visit(ast::GotoStatement& statement) override;
+    void visit(ast::LabeledStatement& statement) override;
     void visit(ast::ReturnStatement& statement) override;
     void visit(ast::VoidReturnStatement& statement) override;
     void visit(ast::IfStatement& statement) override;
@@ -84,6 +87,10 @@ private:
         LabelEntry* exit;
     };
     std::vector<LoopContext> loopStack;
+
+    // Named labels (goto targets) within the current function.
+    std::map<std::string, LabelEntry> namedLabels;
+    std::vector<ast::GotoStatement*> pendingGotos;
 
     bool containsSemanticErrors { false };
     std::ostream* errorStream;

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -248,6 +248,19 @@ void SemanticXmlOutputVisitor::visit(ast::JumpStatement& statement) {
     createLeafNode("jump", statement.jumpKeyword.type);
 }
 
+void SemanticXmlOutputVisitor::visit(ast::GotoStatement& statement) {
+    ident();
+    createLeafNode("goto", statement.getLabelName());
+}
+
+void SemanticXmlOutputVisitor::visit(ast::LabeledStatement& statement) {
+    const std::string nodeId { "label" };
+    openXmlNode(nodeId);
+    createLeafNode("name", statement.getLabelName());
+    statement.statement->accept(*this);
+    closeXmlNode(nodeId);
+}
+
 void SemanticXmlOutputVisitor::visit(ast::ReturnStatement& statement) {
     const std::string nodeId { "return" };
     openXmlNode(nodeId);

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.h
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.h
@@ -41,6 +41,8 @@ public:
     void visit(ast::Operator& op) override;
 
     void visit(ast::JumpStatement& statement) override;
+    void visit(ast::GotoStatement& statement) override;
+    void visit(ast::LabeledStatement& statement) override;
     void visit(ast::ReturnStatement& statement) override;
     void visit(ast::VoidReturnStatement& statement) override;
     void visit(ast::IfStatement& statement) override;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -124,6 +124,7 @@ add_executable(functionalTest
         functionalTest/ForLoopTest.cpp
         functionalTest/WhileLoopTest.cpp
         functionalTest/DoWhileTest.cpp
+        functionalTest/GotoTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/functionalTest/GotoTest.cpp
+++ b/test/src/functionalTest/GotoTest.cpp
@@ -1,0 +1,78 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, gotoForward) {
+    SourceProgram program{R"prg(
+        int main() {
+            goto skip;
+            printf("%d", 1);
+        skip:
+            printf("%d", 2);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2");
+}
+
+TEST(Compiler, gotoBackward) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            n = 0;
+        loop:
+            n = n + 1;
+            if (n < 3) {
+                goto loop;
+            }
+            printf("%d", n);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, gotoSkipsOver) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 0;
+            goto end;
+            a = 1;
+        end:
+            printf("%d", a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("0");
+}
+
+TEST(Compiler, gotoUndefinedLabelIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            goto missing;
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("label `missing` used but not defined");
+}
+
+TEST(Compiler, gotoDuplicateLabelIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+        lab:
+            printf("%d", 1);
+        lab:
+            printf("%d", 2);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("duplicate label");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Named labels (`id: statement`) and `goto id;` (grammar already present).
- Per-function label map; resolve pending gotos after the body (forward refs OK).
- Semantic errors: undefined label, duplicate label.
- Functional tests for forward/backward goto and error cases.

## Stack
PR 3/6 — stacks on #65 (do-while) → #64 (ternary).

## Test plan
- [x] Full local `ctest`
- [x] GotoTest functional suite
- [ ] CI green