### PR TITLE
feat(ast): implement switch, case, and default

### DIFF
--- a/src/ast/AbstractSyntaxTreeVisitor.h
+++ b/src/ast/AbstractSyntaxTreeVisitor.h
@@ -15,6 +15,9 @@
 #include "ast/JumpStatement.h"
 #include "ast/GotoStatement.h"
 #include "ast/LabeledStatement.h"
+#include "ast/SwitchStatement.h"
+#include "ast/CaseLabel.h"
+#include "ast/DefaultLabel.h"
 #include "ast/LoopStatement.h"
 #include "ast/Operator.h"
 #include "ast/ReturnStatement.h"
@@ -76,6 +79,9 @@ public:
     virtual void visit(JumpStatement& statement) = 0;
     virtual void visit(GotoStatement& statement) = 0;
     virtual void visit(LabeledStatement& statement) = 0;
+    virtual void visit(SwitchStatement& statement) = 0;
+    virtual void visit(CaseLabel& statement) = 0;
+    virtual void visit(DefaultLabel& statement) = 0;
     virtual void visit(ReturnStatement& statement) = 0;
     virtual void visit(VoidReturnStatement& statement) = 0;
     virtual void visit(IfStatement& statement) = 0;

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -50,6 +50,9 @@ add_library(ast
         SingleOperandExpression.cpp
         StorageSpecifier.cpp
         StringLiteralExpression.cpp
+        SwitchStatement.cpp
+        CaseLabel.cpp
+        DefaultLabel.cpp
         TerminalSymbol.cpp
         TranslationUnitContextAware.cpp
         TypeCast.cpp
@@ -110,6 +113,9 @@ add_library(ast
         SingleOperandExpression.h
         StorageSpecifier.h
         StringLiteralExpression.h
+        SwitchStatement.h
+        CaseLabel.h
+        DefaultLabel.h
         TerminalSymbol.h
         TranslationUnitContextAware.h
         TypeCast.h

--- a/src/ast/CaseLabel.cpp
+++ b/src/ast/CaseLabel.cpp
@@ -1,0 +1,32 @@
+#include "CaseLabel.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+CaseLabel::CaseLabel(std::unique_ptr<Expression> caseExpression, std::unique_ptr<AbstractSyntaxTreeNode> statement) :
+        caseExpression { std::move(caseExpression) },
+        statement { std::move(statement) } {
+}
+
+void CaseLabel::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+void CaseLabel::setLabel(semantic_analyzer::LabelEntry label) {
+    this->label = std::make_unique<semantic_analyzer::LabelEntry>(label);
+}
+
+semantic_analyzer::LabelEntry* CaseLabel::getLabel() const {
+    return label.get();
+}
+
+void CaseLabel::setCaseValue(long value) {
+    caseValue = value;
+}
+
+long CaseLabel::getCaseValue() const {
+    return caseValue;
+}
+
+} // namespace ast

--- a/src/ast/CaseLabel.h
+++ b/src/ast/CaseLabel.h
@@ -1,0 +1,35 @@
+#ifndef CASELABEL_H_
+#define CASELABEL_H_
+
+#include <memory>
+
+#include "semantic_analyzer/LabelEntry.h"
+#include "ast/AbstractSyntaxTreeNode.h"
+#include "ast/Expression.h"
+
+namespace ast {
+
+class CaseLabel: public AbstractSyntaxTreeNode {
+public:
+    CaseLabel(std::unique_ptr<Expression> caseExpression, std::unique_ptr<AbstractSyntaxTreeNode> statement);
+    virtual ~CaseLabel() = default;
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    void setLabel(semantic_analyzer::LabelEntry label);
+    semantic_analyzer::LabelEntry* getLabel() const;
+
+    void setCaseValue(long value);
+    long getCaseValue() const;
+
+    const std::unique_ptr<Expression> caseExpression;
+    const std::unique_ptr<AbstractSyntaxTreeNode> statement;
+
+private:
+    std::unique_ptr<semantic_analyzer::LabelEntry> label { nullptr };
+    long caseValue { 0 };
+};
+
+} // namespace ast
+
+#endif // CASELABEL_H_

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -533,9 +533,9 @@ void caseLabel(AbstractSyntaxTreeBuilderContext& context) {
 
 void defaultLabel(AbstractSyntaxTreeBuilderContext& context) {
     context.popTerminal(); // :
-    context.popTerminal(); // default
+    auto defaultKeyword = context.popTerminal(); // default
     auto statement = context.popStatement();
-    context.pushStatement(std::make_unique<DefaultLabel>(std::move(statement)));
+    context.pushStatement(std::make_unique<DefaultLabel>(defaultKeyword, std::move(statement)));
 }
 
 void gotoStatement(AbstractSyntaxTreeBuilderContext& context) {

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -26,6 +26,9 @@
 #include "JumpStatement.h"
 #include "GotoStatement.h"
 #include "LabeledStatement.h"
+#include "SwitchStatement.h"
+#include "CaseLabel.h"
+#include "DefaultLabel.h"
 #include "LogicalAndExpression.h"
 #include "LogicalOrExpression.h"
 #include "LoopStatement.h"
@@ -513,6 +516,28 @@ void namedLabel(AbstractSyntaxTreeBuilderContext& context) {
     context.pushStatement(std::make_unique<LabeledStatement>(labelName, std::move(statement)));
 }
 
+void switchStatement(AbstractSyntaxTreeBuilderContext& context) {
+    context.popTerminal(); // )
+    context.popTerminal(); // (
+    context.popTerminal(); // switch
+    auto body = context.popStatement();
+    context.pushStatement(std::make_unique<SwitchStatement>(context.popExpression(), std::move(body)));
+}
+
+void caseLabel(AbstractSyntaxTreeBuilderContext& context) {
+    context.popTerminal(); // :
+    context.popTerminal(); // case
+    auto statement = context.popStatement();
+    context.pushStatement(std::make_unique<CaseLabel>(context.popExpression(), std::move(statement)));
+}
+
+void defaultLabel(AbstractSyntaxTreeBuilderContext& context) {
+    context.popTerminal(); // :
+    context.popTerminal(); // default
+    auto statement = context.popStatement();
+    context.pushStatement(std::make_unique<DefaultLabel>(std::move(statement)));
+}
+
 void gotoStatement(AbstractSyntaxTreeBuilderContext& context) {
     context.popTerminal(); // ;
     auto labelName = context.popTerminal(); // id
@@ -872,10 +897,18 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     int s_labeled_stat_unmatched = grammar.symbolId("<labeled_stat_unmatched>");
     nodeCreatorRegistry[s_matched][{s_if, s_open_paren, s_exp, s_close_paren, s_matched, grammar.symbolId("else"), s_matched }] = ifElseStatement;
     nodeCreatorRegistry[s_unmatched][{s_if, s_open_paren, s_exp, s_close_paren, s_stat }] = ifStatement;
-    //nodeCreatorRegistry[s_matched][{ grammar.symbolId("switch"), s_open_paren, s_exp, s_close_paren, s_matched }] = switchStatement;
+    int s_switch = grammar.symbolId("switch");
+    nodeCreatorRegistry[s_matched][{ s_switch, s_open_paren, s_exp, s_close_paren, s_matched }] = switchStatement;
+    nodeCreatorRegistry[s_unmatched][{ s_switch, s_open_paren, s_exp, s_close_paren, s_unmatched }] = switchStatement;
     nodeCreatorRegistry[s_matched][{ s_labeled_stat_matched }] = doNothing;
     nodeCreatorRegistry[s_unmatched][{ s_labeled_stat_unmatched }] = doNothing;
+    int s_case = grammar.symbolId("case");
+    int s_default = grammar.symbolId("default");
     // s_identifier defined earlier with declarators / primary_exp.
+    nodeCreatorRegistry[s_labeled_stat_matched][{ s_case, grammar.symbolId("<const_exp>"), s_colon, s_matched }] = caseLabel;
+    nodeCreatorRegistry[s_labeled_stat_unmatched][{ s_case, grammar.symbolId("<const_exp>"), s_colon, s_unmatched }] = caseLabel;
+    nodeCreatorRegistry[s_labeled_stat_matched][{ s_default, s_colon, s_matched }] = defaultLabel;
+    nodeCreatorRegistry[s_labeled_stat_unmatched][{ s_default, s_colon, s_unmatched }] = defaultLabel;
     nodeCreatorRegistry[s_labeled_stat_matched][{ s_identifier, s_colon, s_matched }] = namedLabel;
     nodeCreatorRegistry[s_labeled_stat_unmatched][{ s_identifier, s_colon, s_unmatched }] = namedLabel;
     nodeCreatorRegistry[s_matched][{ s_exp_stat }] = doNothing;

--- a/src/ast/DefaultLabel.cpp
+++ b/src/ast/DefaultLabel.cpp
@@ -1,0 +1,23 @@
+#include "DefaultLabel.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+DefaultLabel::DefaultLabel(std::unique_ptr<AbstractSyntaxTreeNode> statement) :
+        statement { std::move(statement) } {
+}
+
+void DefaultLabel::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+void DefaultLabel::setLabel(semantic_analyzer::LabelEntry label) {
+    this->label = std::make_unique<semantic_analyzer::LabelEntry>(label);
+}
+
+semantic_analyzer::LabelEntry* DefaultLabel::getLabel() const {
+    return label.get();
+}
+
+} // namespace ast

--- a/src/ast/DefaultLabel.cpp
+++ b/src/ast/DefaultLabel.cpp
@@ -4,7 +4,8 @@
 
 namespace ast {
 
-DefaultLabel::DefaultLabel(std::unique_ptr<AbstractSyntaxTreeNode> statement) :
+DefaultLabel::DefaultLabel(TerminalSymbol defaultKeyword, std::unique_ptr<AbstractSyntaxTreeNode> statement) :
+        defaultKeyword { std::move(defaultKeyword) },
         statement { std::move(statement) } {
 }
 

--- a/src/ast/DefaultLabel.h
+++ b/src/ast/DefaultLabel.h
@@ -5,12 +5,13 @@
 
 #include "semantic_analyzer/LabelEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
+#include "ast/TerminalSymbol.h"
 
 namespace ast {
 
 class DefaultLabel: public AbstractSyntaxTreeNode {
 public:
-    DefaultLabel(std::unique_ptr<AbstractSyntaxTreeNode> statement);
+    DefaultLabel(TerminalSymbol defaultKeyword, std::unique_ptr<AbstractSyntaxTreeNode> statement);
     virtual ~DefaultLabel() = default;
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
@@ -18,6 +19,7 @@ public:
     void setLabel(semantic_analyzer::LabelEntry label);
     semantic_analyzer::LabelEntry* getLabel() const;
 
+    const TerminalSymbol defaultKeyword;
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
 private:

--- a/src/ast/DefaultLabel.h
+++ b/src/ast/DefaultLabel.h
@@ -1,0 +1,29 @@
+#ifndef DEFAULTLABEL_H_
+#define DEFAULTLABEL_H_
+
+#include <memory>
+
+#include "semantic_analyzer/LabelEntry.h"
+#include "ast/AbstractSyntaxTreeNode.h"
+
+namespace ast {
+
+class DefaultLabel: public AbstractSyntaxTreeNode {
+public:
+    DefaultLabel(std::unique_ptr<AbstractSyntaxTreeNode> statement);
+    virtual ~DefaultLabel() = default;
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    void setLabel(semantic_analyzer::LabelEntry label);
+    semantic_analyzer::LabelEntry* getLabel() const;
+
+    const std::unique_ptr<AbstractSyntaxTreeNode> statement;
+
+private:
+    std::unique_ptr<semantic_analyzer::LabelEntry> label { nullptr };
+};
+
+} // namespace ast
+
+#endif // DEFAULTLABEL_H_

--- a/src/ast/SwitchStatement.cpp
+++ b/src/ast/SwitchStatement.cpp
@@ -1,0 +1,50 @@
+#include "SwitchStatement.h"
+
+#include "AbstractSyntaxTreeVisitor.h"
+#include "CaseLabel.h"
+#include "DefaultLabel.h"
+
+namespace ast {
+
+SwitchStatement::SwitchStatement(std::unique_ptr<Expression> expression, std::unique_ptr<AbstractSyntaxTreeNode> body) :
+        expression { std::move(expression) },
+        body { std::move(body) } {
+}
+
+void SwitchStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+void SwitchStatement::setExitLabel(semantic_analyzer::LabelEntry exitLabel) {
+    this->exitLabel = std::make_unique<semantic_analyzer::LabelEntry>(exitLabel);
+}
+
+semantic_analyzer::LabelEntry* SwitchStatement::getExitLabel() const {
+    return exitLabel.get();
+}
+
+void SwitchStatement::setCaseTemp(semantic_analyzer::ValueEntry temp) {
+    this->caseTemp = std::make_unique<semantic_analyzer::ValueEntry>(temp);
+}
+
+semantic_analyzer::ValueEntry* SwitchStatement::getCaseTemp() const {
+    return caseTemp.get();
+}
+
+void SwitchStatement::addCase(CaseLabel* caseLabel) {
+    cases.push_back(caseLabel);
+}
+
+const std::vector<CaseLabel*>& SwitchStatement::getCases() const {
+    return cases;
+}
+
+void SwitchStatement::setDefaultLabel(DefaultLabel* defaultLabel) {
+    defaultLabelNode = defaultLabel;
+}
+
+DefaultLabel* SwitchStatement::getDefaultLabel() const {
+    return defaultLabelNode;
+}
+
+} // namespace ast

--- a/src/ast/SwitchStatement.h
+++ b/src/ast/SwitchStatement.h
@@ -1,0 +1,48 @@
+#ifndef SWITCHSTATEMENT_H_
+#define SWITCHSTATEMENT_H_
+
+#include <memory>
+#include <vector>
+
+#include "semantic_analyzer/LabelEntry.h"
+#include "semantic_analyzer/ValueEntry.h"
+#include "ast/AbstractSyntaxTreeNode.h"
+#include "ast/Expression.h"
+
+namespace ast {
+
+class CaseLabel;
+class DefaultLabel;
+
+class SwitchStatement: public AbstractSyntaxTreeNode {
+public:
+    SwitchStatement(std::unique_ptr<Expression> expression, std::unique_ptr<AbstractSyntaxTreeNode> body);
+    virtual ~SwitchStatement() = default;
+
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+
+    void setExitLabel(semantic_analyzer::LabelEntry exitLabel);
+    semantic_analyzer::LabelEntry* getExitLabel() const;
+
+    void setCaseTemp(semantic_analyzer::ValueEntry temp);
+    semantic_analyzer::ValueEntry* getCaseTemp() const;
+
+    void addCase(CaseLabel* caseLabel);
+    const std::vector<CaseLabel*>& getCases() const;
+
+    void setDefaultLabel(DefaultLabel* defaultLabel);
+    DefaultLabel* getDefaultLabel() const;
+
+    const std::unique_ptr<Expression> expression;
+    const std::unique_ptr<AbstractSyntaxTreeNode> body;
+
+private:
+    std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
+    std::unique_ptr<semantic_analyzer::ValueEntry> caseTemp { nullptr };
+    std::vector<CaseLabel*> cases;
+    DefaultLabel* defaultLabelNode { nullptr };
+};
+
+} // namespace ast
+
+#endif // SWITCHSTATEMENT_H_

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -432,6 +432,39 @@ void CodeGeneratingVisitor::visit(ast::JumpStatement& statement) {
     instructions.push_back(std::make_unique<Jump>(statement.getJumpTo()->getName()));
 }
 
+void CodeGeneratingVisitor::visit(ast::SwitchStatement& statement) {
+    statement.expression->accept(*this);
+
+    auto switchResult = statement.expression->getResultSymbol()->getName();
+    auto caseTemp = statement.getCaseTemp()->getName();
+
+    for (auto* caseLabel : statement.getCases()) {
+        instructions.push_back(std::make_unique<AssignConstant>(
+                std::to_string(caseLabel->getCaseValue()), caseTemp));
+        instructions.push_back(std::make_unique<ValueCompare>(switchResult, caseTemp));
+        instructions.push_back(std::make_unique<Jump>(caseLabel->getLabel()->getName(), JumpCondition::IF_EQUAL));
+    }
+
+    if (statement.getDefaultLabel()) {
+        instructions.push_back(std::make_unique<Jump>(statement.getDefaultLabel()->getLabel()->getName()));
+    } else {
+        instructions.push_back(std::make_unique<Jump>(statement.getExitLabel()->getName()));
+    }
+
+    statement.body->accept(*this);
+    instructions.push_back(std::make_unique<Label>(statement.getExitLabel()->getName()));
+}
+
+void CodeGeneratingVisitor::visit(ast::CaseLabel& statement) {
+    instructions.push_back(std::make_unique<Label>(statement.getLabel()->getName()));
+    statement.statement->accept(*this);
+}
+
+void CodeGeneratingVisitor::visit(ast::DefaultLabel& statement) {
+    instructions.push_back(std::make_unique<Label>(statement.getLabel()->getName()));
+    statement.statement->accept(*this);
+}
+
 void CodeGeneratingVisitor::visit(ast::GotoStatement& statement) {
     if (!statement.getTarget()) {
         throw std::runtime_error { "GotoStatement has no target label" };

--- a/src/codegen/CodeGeneratingVisitor.h
+++ b/src/codegen/CodeGeneratingVisitor.h
@@ -44,6 +44,9 @@ public:
     void visit(ast::JumpStatement& statement) override;
     void visit(ast::GotoStatement& statement) override;
     void visit(ast::LabeledStatement& statement) override;
+    void visit(ast::SwitchStatement& statement) override;
+    void visit(ast::CaseLabel& statement) override;
+    void visit(ast::DefaultLabel& statement) override;
     void visit(ast::ReturnStatement& statement) override;
     void visit(ast::VoidReturnStatement& statement) override;
     void visit(ast::IfStatement& statement) override;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -505,17 +505,21 @@ void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::DefaultLabel& statement) {
+    // Always attach a label for codegen, even when the label is illegal / duplicate.
+    statement.setLabel(symbolTable.newLabel());
+
     if (switchStack.empty()) {
-        semanticError("default label not within a switch statement", EXTERNAL_CONTEXT);
+        semanticError("default label not within a switch statement", statement.defaultKeyword.context);
         statement.statement->accept(*this);
         return;
     }
 
     if (switchStack.back()->getDefaultLabel()) {
-        semanticError("multiple default labels in switch", EXTERNAL_CONTEXT);
+        // Keep the first default for codegen; ignore subsequent ones as targets.
+        semanticError("multiple default labels in switch", statement.defaultKeyword.context);
+    } else {
+        switchStack.back()->setDefaultLabel(&statement);
     }
-    statement.setLabel(symbolTable.newLabel());
-    switchStack.back()->setDefaultLabel(&statement);
 
     statement.statement->accept(*this);
 }

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -503,6 +503,13 @@ void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
         return;
     }
     statement.setCaseValue(value);
+    for (const auto* existing : switchStack.back()->getCases()) {
+        if (existing->getCaseValue() == value) {
+            semanticError("duplicate case value", statement.caseExpression->getContext());
+            statement.statement->accept(*this);
+            return;
+        }
+    }
     switchStack.back()->addCase(&statement);
 
     statement.statement->accept(*this);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -486,6 +486,9 @@ void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
+    // Always attach a codegen label so the node is well-formed even when illegal.
+    statement.setLabel(symbolTable.newLabel());
+
     if (switchStack.empty()) {
         semanticError("case label not within a switch statement", statement.caseExpression->getContext());
         statement.statement->accept(*this);
@@ -496,9 +499,10 @@ void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
     long value = 0;
     if (!statement.caseExpression->evaluateConstant(value)) {
         semanticError("case label is not a constant expression", statement.caseExpression->getContext());
+        statement.statement->accept(*this);
+        return;
     }
     statement.setCaseValue(value);
-    statement.setLabel(symbolTable.newLabel());
     switchStack.back()->addCase(&statement);
 
     statement.statement->accept(*this);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -442,17 +442,82 @@ void SemanticAnalysisVisitor::visit(ast::Operator&) {
 
 void SemanticAnalysisVisitor::visit(ast::JumpStatement& statement) {
     if (loopStack.empty()) {
-        semanticError("`" + statement.jumpKeyword.type + "` statement not in loop", statement.jumpKeyword.context);
+        semanticError("`" + statement.jumpKeyword.type + "` statement not in loop or switch",
+                statement.jumpKeyword.context);
         return;
     }
     const auto& loop = loopStack.back();
     if (statement.jumpKeyword.type == "break") {
         statement.setJumpTo(*loop.exit);
     } else if (statement.jumpKeyword.type == "continue") {
+        if (!loop.cont) {
+            semanticError("`continue` statement not in loop", statement.jumpKeyword.context);
+            return;
+        }
         statement.setJumpTo(*loop.cont);
     } else {
         semanticError("unsupported jump statement `" + statement.jumpKeyword.type + "`", statement.jumpKeyword.context);
     }
+}
+
+void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
+    statement.expression->accept(*this);
+    if (statement.expression->hasResultSymbol()) {
+        rejectFunctionValue(statement.expression->getResultSymbol()->getType(),
+                statement.expression->getContext());
+    }
+
+    auto exitLabel = symbolTable.newLabel();
+    statement.setExitLabel(exitLabel);
+    statement.setCaseTemp(symbolTable.createTemporarySymbol(type::signedInteger()));
+
+    LabelEntry* continueLabel = nullptr;
+    if (!loopStack.empty()) {
+        continueLabel = loopStack.back().cont;
+    }
+    // break → switch exit; continue only if nested in a loop (cont may be null).
+    loopStack.push_back({ nullptr, continueLabel, statement.getExitLabel() });
+    switchStack.push_back(&statement);
+
+    statement.body->accept(*this);
+
+    switchStack.pop_back();
+    loopStack.pop_back();
+}
+
+void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
+    if (switchStack.empty()) {
+        semanticError("case label not within a switch statement", statement.caseExpression->getContext());
+        statement.statement->accept(*this);
+        return;
+    }
+
+    statement.caseExpression->accept(*this);
+    long value = 0;
+    if (!statement.caseExpression->evaluateConstant(value)) {
+        semanticError("case label is not a constant expression", statement.caseExpression->getContext());
+    }
+    statement.setCaseValue(value);
+    statement.setLabel(symbolTable.newLabel());
+    switchStack.back()->addCase(&statement);
+
+    statement.statement->accept(*this);
+}
+
+void SemanticAnalysisVisitor::visit(ast::DefaultLabel& statement) {
+    if (switchStack.empty()) {
+        semanticError("default label not within a switch statement", EXTERNAL_CONTEXT);
+        statement.statement->accept(*this);
+        return;
+    }
+
+    if (switchStack.back()->getDefaultLabel()) {
+        semanticError("multiple default labels in switch", EXTERNAL_CONTEXT);
+    }
+    statement.setLabel(symbolTable.newLabel());
+    switchStack.back()->setDefaultLabel(&statement);
+
+    statement.statement->accept(*this);
 }
 
 void SemanticAnalysisVisitor::visit(ast::GotoStatement& statement) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -45,6 +45,9 @@ public:
     void visit(ast::JumpStatement& statement) override;
     void visit(ast::GotoStatement& statement) override;
     void visit(ast::LabeledStatement& statement) override;
+    void visit(ast::SwitchStatement& statement) override;
+    void visit(ast::CaseLabel& statement) override;
+    void visit(ast::DefaultLabel& statement) override;
     void visit(ast::ReturnStatement& statement) override;
     void visit(ast::VoidReturnStatement& statement) override;
     void visit(ast::IfStatement& statement) override;
@@ -87,6 +90,7 @@ private:
         LabelEntry* exit;
     };
     std::vector<LoopContext> loopStack;
+    std::vector<ast::SwitchStatement*> switchStack;
 
     // Named labels (goto targets) within the current function.
     std::map<std::string, LabelEntry> namedLabels;

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -248,6 +248,29 @@ void SemanticXmlOutputVisitor::visit(ast::JumpStatement& statement) {
     createLeafNode("jump", statement.jumpKeyword.type);
 }
 
+void SemanticXmlOutputVisitor::visit(ast::SwitchStatement& statement) {
+    const std::string nodeId { "switch" };
+    openXmlNode(nodeId);
+    statement.expression->accept(*this);
+    statement.body->accept(*this);
+    closeXmlNode(nodeId);
+}
+
+void SemanticXmlOutputVisitor::visit(ast::CaseLabel& statement) {
+    const std::string nodeId { "case" };
+    openXmlNode(nodeId);
+    statement.caseExpression->accept(*this);
+    statement.statement->accept(*this);
+    closeXmlNode(nodeId);
+}
+
+void SemanticXmlOutputVisitor::visit(ast::DefaultLabel& statement) {
+    const std::string nodeId { "default" };
+    openXmlNode(nodeId);
+    statement.statement->accept(*this);
+    closeXmlNode(nodeId);
+}
+
 void SemanticXmlOutputVisitor::visit(ast::GotoStatement& statement) {
     ident();
     createLeafNode("goto", statement.getLabelName());

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.h
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.h
@@ -43,6 +43,9 @@ public:
     void visit(ast::JumpStatement& statement) override;
     void visit(ast::GotoStatement& statement) override;
     void visit(ast::LabeledStatement& statement) override;
+    void visit(ast::SwitchStatement& statement) override;
+    void visit(ast::CaseLabel& statement) override;
+    void visit(ast::DefaultLabel& statement) override;
     void visit(ast::ReturnStatement& statement) override;
     void visit(ast::VoidReturnStatement& statement) override;
     void visit(ast::IfStatement& statement) override;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -125,6 +125,7 @@ add_executable(functionalTest
         functionalTest/WhileLoopTest.cpp
         functionalTest/DoWhileTest.cpp
         functionalTest/GotoTest.cpp
+        functionalTest/SwitchTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/functionalTest/SwitchTest.cpp
+++ b/test/src/functionalTest/SwitchTest.cpp
@@ -164,4 +164,51 @@ TEST(Compiler, continueInsideSwitchIsError) {
     program.assertCompilationErrors("`continue` statement not in loop");
 }
 
+TEST(Compiler, switchDuplicateCaseIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1;
+            switch (a) {
+                case 1:
+                    printf("%d", 1);
+                    break;
+                case 1:
+                    printf("%d", 2);
+                    break;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("duplicate case value");
+}
+
+// continue in a loop that contains a switch still targets the loop.
+TEST(Compiler, continueInLoopAroundSwitch) {
+    SourceProgram program{R"prg(
+        int main() {
+            int i;
+            int sum;
+            i = 0;
+            sum = 0;
+            while (i < 3) {
+                i = i + 1;
+                switch (i) {
+                    case 2:
+                        continue;
+                    default:
+                        sum = sum + i;
+                        break;
+                }
+            }
+            printf("%d", sum);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    // i=1 sum=1; i=2 continue; i=3 sum=4
+    program.runAndExpect("4");
+}
+
 } // namespace

--- a/test/src/functionalTest/SwitchTest.cpp
+++ b/test/src/functionalTest/SwitchTest.cpp
@@ -147,4 +147,21 @@ TEST(Compiler, switchMultipleDefaultIsError) {
     program.assertCompilationErrors("multiple default labels");
 }
 
+// continue is only valid in a loop, not in a bare switch (cont is null on switch frame).
+TEST(Compiler, continueInsideSwitchIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1;
+            switch (a) {
+                case 1:
+                    continue;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("`continue` statement not in loop");
+}
+
 } // namespace

--- a/test/src/functionalTest/SwitchTest.cpp
+++ b/test/src/functionalTest/SwitchTest.cpp
@@ -1,0 +1,130 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, switchBasicCases) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            scanf("%ld", &a);
+            switch (a) {
+                case 1:
+                    printf("%d", 10);
+                    break;
+                case 2:
+                    printf("%d", 20);
+                    break;
+                case 3:
+                    printf("%d", 30);
+                    break;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1", "10");
+    program.runAndExpect("2", "20");
+    program.runAndExpect("3", "30");
+}
+
+TEST(Compiler, switchDefault) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            scanf("%ld", &a);
+            switch (a) {
+                case 1:
+                    printf("%d", 1);
+                    break;
+                default:
+                    printf("%d", 0);
+                    break;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1", "1");
+    program.runAndExpect("0", "0");
+    program.runAndExpect("99", "0");
+}
+
+TEST(Compiler, switchFallThrough) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            int s;
+            s = 0;
+            scanf("%ld", &a);
+            switch (a) {
+                case 1:
+                    s = s + 1;
+                case 2:
+                    s = s + 2;
+                    break;
+                case 3:
+                    s = s + 4;
+                    break;
+            }
+            printf("%d", s);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1", "3");
+    program.runAndExpect("2", "2");
+    program.runAndExpect("3", "4");
+}
+
+TEST(Compiler, switchNoMatchNoDefault) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            scanf("%ld", &a);
+            switch (a) {
+                case 1:
+                    printf("%d", 1);
+                    break;
+            }
+            printf("%d", 9);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2", "9");
+    program.runAndExpect("1", "19");
+}
+
+TEST(Compiler, switchBreakExits) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1;
+            switch (a) {
+                case 1:
+                    printf("%d", 1);
+                    break;
+                    printf("%d", 2);
+                default:
+                    printf("%d", 3);
+            }
+            printf("%d", 4);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("14");
+}
+
+TEST(Compiler, switchCaseOutsideIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            case 1:
+                return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("case label not within a switch");
+}
+
+} // namespace

--- a/test/src/functionalTest/SwitchTest.cpp
+++ b/test/src/functionalTest/SwitchTest.cpp
@@ -127,4 +127,24 @@ TEST(Compiler, switchCaseOutsideIsError) {
     program.assertCompilationErrors("case label not within a switch");
 }
 
+TEST(Compiler, switchMultipleDefaultIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a = 1;
+            switch (a) {
+                default:
+                    printf("%d", 1);
+                    break;
+                default:
+                    printf("%d", 2);
+                    break;
+            }
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("multiple default labels");
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- `switch` / `case` / `default` (grammar already present).
- Semantic: register cases, fold case constants, switch exit for `break`.
- Codegen: compare chain then body with fall-through labels.
- Functional tests: multi-case, default, fall-through, no-match, break, error.

## Stack
PR 4/6 — stacks on #66 (goto) → #65 → #64.

## Test plan
- [x] Full local `ctest`
- [x] SwitchTest
- [ ] CI green