### PR TITLE
feat(types): array types and sizeof

### DIFF
--- a/src/ast/ArrayDeclarator.cpp
+++ b/src/ast/ArrayDeclarator.cpp
@@ -20,17 +20,40 @@ void ArrayDeclarator::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
+void ArrayDeclarator::visitBaseDeclarator(AbstractSyntaxTreeVisitor& visitor) {
+    baseDeclarator->accept(visitor);
+}
+
+void ArrayDeclarator::setArraySize(long size) {
+    arraySize = size;
+    arraySizeSet = true;
+}
+
+bool ArrayDeclarator::hasArraySize() const {
+    return arraySizeSet;
+}
+
+long ArrayDeclarator::getArraySize() const {
+    return arraySize;
+}
+
 type::Type ArrayDeclarator::getFundamentalType(std::vector<Pointer> indirection, const type::Type& baseType) {
     type::Type elementType = baseType;
     for (Pointer pointer : indirection) {
         elementType = type::pointer(elementType, pointer.getQualifiers());
     }
+    // Prefer size folded in semantic analysis. Invalid bounds yield a zero-length
+    // array type after a semantic error was already reported (no exception).
     long length = 0;
-    if (!subscriptExpression || !subscriptExpression->evaluateConstant(length) || length < 0) {
-        throw std::runtime_error { "array size is not a non-negative constant expression" };
+    if (arraySizeSet) {
+        length = arraySize;
+    } else if (subscriptExpression && subscriptExpression->evaluateConstant(length) && length >= 0) {
+        // Fallback when getFundamentalType is used without a prior semantic visit.
+    } else {
+        length = 0;
     }
     if (length > static_cast<long>(std::numeric_limits<int>::max())) {
-        throw std::invalid_argument { "array size is too large" };
+        length = 0;
     }
     return baseDeclarator->getFundamentalType({}, type::array(elementType, static_cast<int>(length)));
 }

--- a/src/ast/ArrayDeclarator.cpp
+++ b/src/ast/ArrayDeclarator.cpp
@@ -1,23 +1,38 @@
 #include "ArrayDeclarator.h"
 
-#include "AbstractSyntaxTreeVisitor.h"
+#include <limits>
+#include <stdexcept>
 
+#include "AbstractSyntaxTreeVisitor.h"
 #include "Expression.h"
+#include "types/Type.h"
 
 namespace ast {
 
-ArrayDeclarator::ArrayDeclarator(std::unique_ptr<DirectDeclarator> declarator, std::unique_ptr<Expression> subscriptExpression) :
-		DirectDeclarator(declarator->getName(), declarator->getContext()),
-		subscriptExpression { std::move(subscriptExpression) } {
+ArrayDeclarator::ArrayDeclarator(std::unique_ptr<DirectDeclarator> declarator,
+        std::unique_ptr<Expression> subscriptExpression) :
+        DirectDeclarator(declarator->getName(), declarator->getContext()),
+        subscriptExpression { std::move(subscriptExpression) },
+        baseDeclarator { std::move(declarator) } {
 }
 
 void ArrayDeclarator::accept(AbstractSyntaxTreeVisitor& visitor) {
-	visitor.visit(*this);
+    visitor.visit(*this);
 }
 
-type::Type ArrayDeclarator::getFundamentalType(std::vector<Pointer> indirection, const type::Type& baseType){
-    throw std::runtime_error {"Arrays not implemented yet"};
+type::Type ArrayDeclarator::getFundamentalType(std::vector<Pointer> indirection, const type::Type& baseType) {
+    type::Type elementType = baseType;
+    for (Pointer pointer : indirection) {
+        elementType = type::pointer(elementType, pointer.getQualifiers());
+    }
+    long length = 0;
+    if (!subscriptExpression || !subscriptExpression->evaluateConstant(length) || length < 0) {
+        throw std::runtime_error { "array size is not a non-negative constant expression" };
+    }
+    if (length > static_cast<long>(std::numeric_limits<int>::max())) {
+        throw std::invalid_argument { "array size is too large" };
+    }
+    return baseDeclarator->getFundamentalType({}, type::array(elementType, static_cast<int>(length)));
 }
 
 } // namespace ast
-

--- a/src/ast/ArrayDeclarator.cpp
+++ b/src/ast/ArrayDeclarator.cpp
@@ -45,16 +45,19 @@ type::Type ArrayDeclarator::getFundamentalType(std::vector<Pointer> indirection,
     // Prefer size folded in semantic analysis. Invalid bounds yield a zero-length
     // array type after a semantic error was already reported (no exception).
     long length = 0;
-    if (arraySizeSet) {
-        length = arraySize;
+    if (hasArraySize()) {
+        length = getArraySize();
     } else if (subscriptExpression && subscriptExpression->evaluateConstant(length) && length >= 0) {
         // Fallback when getFundamentalType is used without a prior semantic visit.
     } else {
         length = 0;
     }
     if (length > static_cast<long>(std::numeric_limits<int>::max())) {
+        // Bound already diagnosed (or unvisited); keep a zero-length shell type.
         length = 0;
     }
+    // type::array may throw std::invalid_argument (overflow / incomplete element);
+    // semantic analysis catches that when building declaration types.
     return baseDeclarator->getFundamentalType({}, type::array(elementType, static_cast<int>(length)));
 }
 

--- a/src/ast/ArrayDeclarator.h
+++ b/src/ast/ArrayDeclarator.h
@@ -18,10 +18,17 @@ public:
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
     type::Type getFundamentalType(std::vector<Pointer> indirection, const type::Type& baseType) override;
 
+    void visitBaseDeclarator(AbstractSyntaxTreeVisitor& visitor);
+    void setArraySize(long size);
+    bool hasArraySize() const;
+    long getArraySize() const;
+
     const std::unique_ptr<Expression> subscriptExpression;
 
 private:
     std::unique_ptr<DirectDeclarator> baseDeclarator;
+    long arraySize { 0 };
+    bool arraySizeSet { false };
 };
 
 } // namespace ast

--- a/src/ast/ArrayDeclarator.h
+++ b/src/ast/ArrayDeclarator.h
@@ -19,6 +19,9 @@ public:
     type::Type getFundamentalType(std::vector<Pointer> indirection, const type::Type& baseType) override;
 
     const std::unique_ptr<Expression> subscriptExpression;
+
+private:
+    std::unique_ptr<DirectDeclarator> baseDeclarator;
 };
 
 } // namespace ast

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -340,8 +340,9 @@ void sizeofTypeExpression(AbstractSyntaxTreeBuilderContext& context) {
     auto typeSpec = context.popTypeSpecifier();
     auto sizeofKw = context.popTerminal(); // sizeof
     const type::Type& namedType = typeSpec.getType();
-    // sizeof(void) / incomplete types are invalid; pointers-to-void remain complete.
-    if (namedType.isVoid() || namedType.isFunction()) {
+    // sizeof(void) / bare function types are invalid. Pointers (incl. pointer-to-function
+    // and pointer-to-void) remain complete; pointer-to-function also reports isFunction().
+    if (namedType.isVoid() || (namedType.isFunction() && !namedType.isPointer())) {
         throw std::runtime_error {
                 "invalid application of ‘sizeof’ to incomplete type ‘" + namedType.to_string() + "’" };
     }

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -14,6 +14,7 @@
 #include "Block.h"
 #include "ComparisonExpression.h"
 #include "ConditionalExpression.h"
+#include "Constant.h"
 #include "ConstantExpression.h"
 #include "ExpressionList.h"
 #include "ForLoopHeader.h"
@@ -327,11 +328,20 @@ void unaryExpression(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void sizeofExpression(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "sizeofExpression is not implemented yet" };
+    context.popTerminal(); // sizeof
+    context.pushExpression(std::make_unique<UnaryExpression>(
+            std::make_unique<Operator>("sizeof"), context.popExpression()));
 }
 
 void sizeofTypeExpression(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "sizeofTypeExpression is not implemented yet" };
+    context.popTerminal(); // )
+    context.popTerminal(); // (
+    // type_name left a TypeSpecifier for simple types (int, char, long, pointers via abstract decl later).
+    auto typeSpec = context.popTypeSpecifier();
+    auto sizeofKw = context.popTerminal(); // sizeof
+    const int size = typeSpec.getType().getSize();
+    context.pushExpression(std::make_unique<ConstantExpression>(
+            Constant { std::to_string(size), type::signedInteger(), sizeofKw.context }));
 }
 
 void typeCast(AbstractSyntaxTreeBuilderContext& context) {
@@ -754,18 +764,25 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     nodeCreatorRegistry[s_cast_exp][{ s_unary_exp }] = doNothing;
     nodeCreatorRegistry[s_cast_exp][{ s_open_paren, grammar.symbolId("<type_name>"), s_close_paren, s_cast_exp }] = typeCast;
 
-    // type_name / spec_qualifier_list feed casts and sizeof(type); stub until type names are built.
+    // type_name / spec_qualifier_list for sizeof(type) and casts (casts still stubbed at cast_exp).
     int s_spec_qualifier_list = grammar.symbolId("<spec_qualifier_list>");
     int s_type_name = grammar.symbolId("<type_name>");
-    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier }] = notImplementedYet("type names (casts/sizeof)");
+    int s_abstract_declarator_sym = grammar.symbolId("<abstract_declarator>");
+    // type_specifier already pushed a TypeSpecifier; identity keeps it on the stack.
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier }] = doNothing;
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier, s_spec_qualifier_list }] =
-            notImplementedYet("type names (casts/sizeof)");
-    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier }] = notImplementedYet("type names (casts/sizeof)");
+            notImplementedYet("multi type-specifier type names");
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier }] = notImplementedYet("qualified type names");
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier, s_spec_qualifier_list }] =
-            notImplementedYet("type names (casts/sizeof)");
-    nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list }] = notImplementedYet("type names (casts/sizeof)");
-    nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list, s_abstract_declarator }] =
-            notImplementedYet("type names (casts/sizeof)");
+            notImplementedYet("qualified type names");
+    nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list }] = doNothing;
+    nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list, s_abstract_declarator_sym }] =
+            [](AbstractSyntaxTreeBuilderContext& context) {
+                auto declarator = context.popDeclarator();
+                auto typeSpec = context.popTypeSpecifier();
+                auto combined = declarator->getFundamentalType(typeSpec.getType());
+                context.pushTypeSpecifier(TypeSpecifier { combined, typeSpec.getName() });
+            };
 
     int s_mult_exp = grammar.symbolId("<mult_exp>");
     nodeCreatorRegistry[s_mult_exp][{ s_cast_exp }] = doNothing;

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -344,11 +344,19 @@ void sizeofTypeExpression(AbstractSyntaxTreeBuilderContext& context) {
             Constant { std::to_string(size), type::signedInteger(), sizeofKw.context }));
 }
 
+void typeNameWithAbstractDeclarator(AbstractSyntaxTreeBuilderContext& context) {
+    auto declarator = context.popDeclarator();
+    auto typeSpec = context.popTypeSpecifier();
+    auto combined = declarator->getFundamentalType(typeSpec.getType());
+    context.pushTypeSpecifier(TypeSpecifier { combined, typeSpec.getName() });
+}
+
 void typeCast(AbstractSyntaxTreeBuilderContext& context) {
     context.popTerminal(); // )
     //context.pushExpression(std::make_unique<TypeCast>(context.popTypeName(), context.popExpression()));
     context.popTerminal(); // (
-    throw std::runtime_error { "typeCast is not implemented yet" };
+    // type_name is accepted for sizeof(type); cast expressions still need TypeCast AST wiring.
+    throw std::runtime_error { "type cast expressions are not implemented yet (type names work for sizeof)" };
 }
 
 void arithmeticExpression(AbstractSyntaxTreeBuilderContext& context) {
@@ -777,12 +785,7 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
             notImplementedYet("qualified type names");
     nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list }] = doNothing;
     nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list, s_abstract_declarator_sym }] =
-            [](AbstractSyntaxTreeBuilderContext& context) {
-                auto declarator = context.popDeclarator();
-                auto typeSpec = context.popTypeSpecifier();
-                auto combined = declarator->getFundamentalType(typeSpec.getType());
-                context.pushTypeSpecifier(TypeSpecifier { combined, typeSpec.getName() });
-            };
+            typeNameWithAbstractDeclarator;
 
     int s_mult_exp = grammar.symbolId("<mult_exp>");
     nodeCreatorRegistry[s_mult_exp][{ s_cast_exp }] = doNothing;

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -339,7 +339,13 @@ void sizeofTypeExpression(AbstractSyntaxTreeBuilderContext& context) {
     // type_name left a TypeSpecifier for simple types (int, char, long, pointers via abstract decl later).
     auto typeSpec = context.popTypeSpecifier();
     auto sizeofKw = context.popTerminal(); // sizeof
-    const int size = typeSpec.getType().getSize();
+    const type::Type& namedType = typeSpec.getType();
+    // sizeof(void) / incomplete types are invalid; pointers-to-void remain complete.
+    if (namedType.isVoid() || namedType.isFunction()) {
+        throw std::runtime_error {
+                "invalid application of ‘sizeof’ to incomplete type ‘" + namedType.to_string() + "’" };
+    }
+    const int size = namedType.getSize();
     context.pushExpression(std::make_unique<ConstantExpression>(
             Constant { std::to_string(size), type::signedInteger(), sizeofKw.context }));
 }

--- a/src/ast/UnaryExpression.cpp
+++ b/src/ast/UnaryExpression.cpp
@@ -18,7 +18,19 @@ bool UnaryExpression::isLval() const {
     return getOperator()->getLexeme() == "*";
 }
 
+void UnaryExpression::setSizeofValue(int bytes) {
+    sizeofValue = bytes;
+}
+
+int UnaryExpression::getSizeofValue() const {
+    return sizeofValue;
+}
+
 bool UnaryExpression::evaluateConstant(long& value) const {
+    if (getOperator()->getLexeme() == "sizeof" && sizeofValue >= 0) {
+        value = sizeofValue;
+        return true;
+    }
     long operand = 0;
     if (!_operand->evaluateConstant(operand)) {
         return false;

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -25,11 +25,15 @@ public:
     void setLvalueSymbol(semantic_analyzer::ValueEntry lvalueSymbol);
     semantic_analyzer::ValueEntry* getLvalueSymbol() const override;
 
+    void setSizeofValue(int bytes);
+    int getSizeofValue() const;
+
 private:
     std::unique_ptr<semantic_analyzer::LabelEntry> truthyLabel { nullptr };
     std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
 
     std::unique_ptr<semantic_analyzer::ValueEntry> lvalueSymbol { nullptr };
+    int sizeofValue { -1 };
 };
 
 } // namespace ast

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -137,6 +137,13 @@ void CodeGeneratingVisitor::visit(ast::PrefixExpression& expression) {
 }
 
 void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
+    if (expression.getOperator()->getLexeme() == "sizeof") {
+        // Operand is unevaluated at runtime; emit the folded size constant.
+        instructions.push_back(std::make_unique<AssignConstant>(
+                std::to_string(expression.getSizeofValue()), expression.getResultSymbol()->getName()));
+        return;
+    }
+
     expression.visitOperand(*this);
 
     switch (expression.getOperator()->getLexeme().front()) {
@@ -576,8 +583,10 @@ void CodeGeneratingVisitor::visit(ast::FunctionDeclarator& declarator) {
 }
 
 void CodeGeneratingVisitor::visit(ast::ArrayDeclarator& declaration) {
-    declaration.subscriptExpression->accept(*this);
-    throw std::runtime_error { "code generation for array declarators is not implemented" };
+    // Sized arrays are typed in semantic analysis; no IR is emitted for the declarator itself.
+    if (declaration.subscriptExpression) {
+        declaration.subscriptExpression->accept(*this);
+    }
 }
 
 void CodeGeneratingVisitor::visit(ast::FormalArgument& parameter) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -240,9 +240,10 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             return;
         }
         const type::Type& operandType = expression.operandType();
-        // Mirror sizeof(type): void and function types are incomplete for sizeof.
-        // Pointers (including pointer-to-function) remain complete.
-        if (operandType.isVoid() || operandType.isFunction()) {
+        // Mirror sizeof(type): void and bare function types are incomplete for sizeof.
+        // Pointers (including pointer-to-function) remain complete; those types also
+        // report isFunction() because pointer() copies the function payload.
+        if (operandType.isVoid() || (operandType.isFunction() && !operandType.isPointer())) {
             semanticError(
                     "invalid application of ‘sizeof’ to incomplete type ‘" + operandType.to_string() + "’",
                     expression.getContext());

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -224,13 +224,25 @@ void SemanticAnalysisVisitor::visit(ast::PrefixExpression& expression) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
+    const auto& lexeme = expression.getOperator()->getLexeme();
+    if (lexeme == "sizeof") {
+        expression.visitOperand(*this);
+        if (!expression.hasOperandSymbol()) {
+            expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+            return;
+        }
+        expression.setSizeofValue(expression.operandType().getSize());
+        expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+        return;
+    }
+
     expression.visitOperand(*this);
     if (!expression.hasOperandSymbol()) {
         return;
     }
     rejectFunctionValue(expression.operandType(), expression.getContext());
 
-    switch (expression.getOperator()->getLexeme().front()) {
+    switch (lexeme.front()) {
     case '&':
         expression.setResultSymbol(symbolTable.createTemporarySymbol(type::pointer(expression.operandType())));
         break;
@@ -646,8 +658,10 @@ void SemanticAnalysisVisitor::visit(ast::Identifier&) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::ArrayDeclarator& declaration) {
-    declaration.subscriptExpression->accept(*this);
-    throw std::runtime_error { "not implemented" };
+    // Fold/size array bounds via the subscript expression; type is built in getFundamentalType.
+    if (declaration.subscriptExpression) {
+        declaration.subscriptExpression->accept(*this);
+    }
 }
 
 void SemanticAnalysisVisitor::visit(ast::FunctionDeclarator& declarator) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <limits>
 #include <stdexcept>
 #include <string>
 
@@ -658,9 +659,23 @@ void SemanticAnalysisVisitor::visit(ast::Identifier&) {
 }
 
 void SemanticAnalysisVisitor::visit(ast::ArrayDeclarator& declaration) {
-    // Fold/size array bounds via the subscript expression; type is built in getFundamentalType.
+    declaration.visitBaseDeclarator(*this);
     if (declaration.subscriptExpression) {
         declaration.subscriptExpression->accept(*this);
+        long length = 0;
+        if (!declaration.subscriptExpression->evaluateConstant(length) || length < 0) {
+            semanticError("array size is not a non-negative constant expression",
+                    declaration.getContext());
+            declaration.setArraySize(0);
+        } else if (length > static_cast<long>(std::numeric_limits<int>::max())) {
+            semanticError("array size is too large", declaration.getContext());
+            declaration.setArraySize(0);
+        } else {
+            declaration.setArraySize(length);
+        }
+    } else {
+        // Incomplete array T a[] — treat as zero-length for now.
+        declaration.setArraySize(0);
     }
 }
 

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -61,7 +61,14 @@ void SemanticAnalysisVisitor::visit(ast::Declaration& declaration) {
 
     auto baseType = declaration.getDeclarationSpecifiers().getTypeSpecifiers().at(0).getType();
     for (const auto& declarator : declaration.getDeclarators()) {
-        auto type = declarator->getFundamentalType(baseType);
+        type::Type type { type::voidType() };
+        try {
+            type = declarator->getFundamentalType(baseType);
+        } catch (const std::invalid_argument& ex) {
+            // array size overflow, array of incomplete type, etc.
+            semanticError(ex.what(), declarator->getContext());
+            continue;
+        }
         if (type.isVoid()) {
             semanticError("variable `" + declarator->getName() + "` declared void", declarator->getContext());
         } else if (symbolTable.isAtFileScope() && symbolTable.hasFunction(declarator->getName())) {
@@ -710,7 +717,14 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDeclarator& declarator) {
 void SemanticAnalysisVisitor::visit(ast::FormalArgument& argument) {
     argument.visitSpecifiers(*this);
     argument.visitDeclarator(*this);
-    if (argument.getType().isVoid()) {
+    type::Type type { type::voidType() };
+    try {
+        type = argument.getType();
+    } catch (const std::invalid_argument& ex) {
+        semanticError(ex.what(), argument.getDeclarationContext());
+        return;
+    }
+    if (type.isVoid()) {
         semanticError("function argument ‘" + argument.getName() + "’ declared void", argument.getDeclarationContext());
     }
 }

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -239,7 +239,17 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
             return;
         }
-        expression.setSizeofValue(expression.operandType().getSize());
+        const type::Type& operandType = expression.operandType();
+        // Mirror sizeof(type): void and function types are incomplete for sizeof.
+        // Pointers (including pointer-to-function) remain complete.
+        if (operandType.isVoid() || operandType.isFunction()) {
+            semanticError(
+                    "invalid application of ‘sizeof’ to incomplete type ‘" + operandType.to_string() + "’",
+                    expression.getContext());
+            expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+            return;
+        }
+        expression.setSizeofValue(operandType.getSize());
         expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
         return;
     }
@@ -692,7 +702,12 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDeclarator& declarator) {
     argumentNames.clear();
     std::vector<type::Type> arguments;
     for (auto& argumentDeclaration : declarator.getFormalArguments()) {
-        arguments.push_back(argumentDeclaration.getType());
+        try {
+            arguments.push_back(argumentDeclaration.getType());
+        } catch (const std::invalid_argument&) {
+            // visit(FormalArgument) already diagnosed; placeholder so analysis can finish.
+            arguments.push_back(type::voidType());
+        }
         argumentNames.push_back(argumentDeclaration.getName());
     }
 

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -30,8 +30,9 @@ Type array(const Type& elementType, int elementCount) {
     if (elementCount < 0) {
         throw std::invalid_argument { "array size must be non-negative" };
     }
-    // Element must be a complete object type (not void/function). Nested arrays are ok.
-    if (elementType.isVoid() || elementType.isFunction()) {
+    // Element must be a complete object type. Bare function/void are incomplete;
+    // pointer-to-function is complete (isFunction() is also true on those types).
+    if (elementType.isVoid() || (elementType.isFunction() && !elementType.isPointer())) {
         throw std::invalid_argument { "array of incomplete type" };
     }
     const long long product =
@@ -196,7 +197,19 @@ std::string Type::to_string() const {
         return _function->to_string();
     }
     if (isArray()) {
-        return getElementType().to_string() + "[" + std::to_string(_arrayCount) + "]";
+        // Emit dimensions outside-in so int a[2][3] prints "int[2][3]", not "int[3][2]".
+        std::vector<int> dims;
+        Type t { *this };
+        while (t.isArray()) {
+            dims.push_back(t.getArraySize());
+            t = t.getElementType();
+        }
+        std::stringstream str;
+        str << t.to_string();
+        for (int dim : dims) {
+            str << "[" << dim << "]";
+        }
+        return str.str();
     }
     return "unknown type";
 }

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -1,5 +1,6 @@
 #include "Type.h"
 
+#include <limits>
 #include <stdexcept>
 #include <sstream>
 
@@ -29,10 +30,19 @@ Type array(const Type& elementType, int elementCount) {
     if (elementCount < 0) {
         throw std::invalid_argument { "array size must be non-negative" };
     }
+    // Element must be a complete object type (not void/function). Nested arrays are ok.
+    if (elementType.isVoid() || elementType.isFunction()) {
+        throw std::invalid_argument { "array of incomplete type" };
+    }
+    const long long product =
+            static_cast<long long>(elementType.getSize()) * static_cast<long long>(elementCount);
+    if (product > static_cast<long long>(std::numeric_limits<int>::max())) {
+        throw std::invalid_argument { "array size is too large" };
+    }
     Type a { std::vector<Qualifier> {} };
     a._elementType = std::make_shared<Type>(elementType);
     a._arrayCount = elementCount;
-    a._size = elementType.getSize() * elementCount;
+    a._size = static_cast<int>(product);
     return a;
 }
 
@@ -193,7 +203,8 @@ std::string Type::to_string() const {
 
 
 bool Type::isArray() const {
-    return _elementType != nullptr && _arrayCount >= 0;
+    // Pointer-to-array copies element payload via pointer(); peel indirection first.
+    return !isPointer() && _elementType != nullptr && _arrayCount >= 0;
 }
 
 Type Type::getElementType() const {

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -25,6 +25,17 @@ Type function(const Type& returnType, const std::vector<Type>& arguments) {
     return Type{returnType, arguments};
 }
 
+Type array(const Type& elementType, int elementCount) {
+    if (elementCount < 0) {
+        throw std::invalid_argument { "array size must be non-negative" };
+    }
+    Type a { std::vector<Qualifier> {} };
+    a._elementType = std::make_shared<Type>(elementType);
+    a._arrayCount = elementCount;
+    a._size = elementType.getSize() * elementCount;
+    return a;
+}
+
 Type signedCharacter(const std::vector<Qualifier>& qualifiers) {
     return primitive(Primitive::signedCharacter(), qualifiers);
 }
@@ -93,6 +104,9 @@ int Type::getSize() const {
     if (isPointer()) {
         return POINTER_SIZE;
     }
+    if (isArray()) {
+        return _size;
+    }
     if (isPrimitive()) {
         return _primitive->getSize();
     }
@@ -106,7 +120,7 @@ bool Type::canAssignFrom(const Type& other) const {
 }
 
 bool Type::isVoid() const {
-    return !isPrimitive() && !isFunction() && !isPointer() && !isStructure();
+    return !isPrimitive() && !isFunction() && !isPointer() && !isStructure() && !isArray();
 }
 
 bool Type::isPrimitive() const {
@@ -171,8 +185,29 @@ std::string Type::to_string() const {
     if (isFunction()) {
         return _function->to_string();
     }
+    if (isArray()) {
+        return getElementType().to_string() + "[" + std::to_string(_arrayCount) + "]";
+    }
     return "unknown type";
 }
 
-} // namespace type
 
+bool Type::isArray() const {
+    return _elementType != nullptr && _arrayCount >= 0;
+}
+
+Type Type::getElementType() const {
+    if (!isArray()) {
+        throw std::runtime_error{"not an array type"};
+    }
+    return *_elementType;
+}
+
+int Type::getArraySize() const {
+    if (!isArray()) {
+        throw std::runtime_error{"not an array type"};
+    }
+    return _arrayCount;
+}
+
+} // namespace type

--- a/src/types/Type.h
+++ b/src/types/Type.h
@@ -22,6 +22,7 @@ public:
     friend Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers);
     friend Type function(const Type& returnType, const std::vector<Type>& arguments);
     friend Type structure(const std::vector<Type>& members);
+    friend Type array(const Type& elementType, int elementCount);
 
     int getSize() const;
     bool canAssignFrom(const Type& other) const;
@@ -33,6 +34,9 @@ public:
     bool isFunction() const;
     Function getFunction() const;
     bool isStructure() const;
+    bool isArray() const;
+    Type getElementType() const;
+    int getArraySize() const;
 
     bool isConst() const;
     bool isVolatile() const;
@@ -54,6 +58,8 @@ private:
     bool _volatile {false};
 
     int _indirection {0};
+    std::shared_ptr<Type> _elementType;
+    int _arrayCount { -1 };
 };
 
 Type voidType();
@@ -61,6 +67,7 @@ Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifi
 Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers = {});
 Type function(const Type& returnType, const std::vector<Type>& arguments = {});
 Type structure(const std::vector<Type>& members = {});
+Type array(const Type& elementType, int elementCount);
 
 Type signedCharacter(const std::vector<Qualifier>& qualifiers = {});
 Type unsignedCharacter(const std::vector<Qualifier>& qualifiers = {});

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -126,6 +126,7 @@ add_executable(functionalTest
         functionalTest/DoWhileTest.cpp
         functionalTest/GotoTest.cpp
         functionalTest/SwitchTest.cpp
+        functionalTest/SizeofTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/codegenTest/UnimplementedArrayCodegenTest.cpp
+++ b/test/src/codegenTest/UnimplementedArrayCodegenTest.cpp
@@ -37,18 +37,15 @@ TEST(CodeGeneratingVisitor, arrayAccessIsNotImplemented) {
     }
 }
 
-TEST(CodeGeneratingVisitor, arrayDeclaratorIsNotImplemented) {
+TEST(CodeGeneratingVisitor, arrayDeclaratorIsNoOp) {
+    // Sized arrays are typed in semantic analysis; declarator codegen emits no IR.
     ArrayDeclarator declarator {
             std::make_unique<Identifier>(TerminalSymbol { "id", "a", testContext() }),
             std::make_unique<IdentifierExpression>("n", testContext())
     };
     CodeGeneratingVisitor visitor;
-    try {
-        declarator.accept(visitor);
-        FAIL() << "expected array declarator codegen to throw";
-    } catch (const std::runtime_error& error) {
-        EXPECT_THAT(std::string(error.what()), HasSubstr("array declarators is not implemented"));
-    }
+    EXPECT_NO_THROW(declarator.accept(visitor));
+    EXPECT_THAT(visitor.getQuadruples().size(), Eq(0u));
 }
 
 } // namespace

--- a/test/src/functionalTest/SemanticErrorsTest.cpp
+++ b/test/src/functionalTest/SemanticErrorsTest.cpp
@@ -187,17 +187,7 @@ INSTANTIATE_TEST_SUITE_P(Compiler, SemanticErrorCatalog,
     )prg",
                                  "abstract array declarator is not implemented yet",
                              },
-                             // Sized arrays parse (const_exp identity), then fail in semantic analysis.
-                             SemanticErrorCase{
-                                 "sizedArrayNotImplemented",
-                                 R"prg(
-        int main() {
-            int a[3];
-            return 0;
-        }
-    )prg",
-                                 "not implemented",
-                             },
+                             // Abstract array declarator remains unsupported (separate from sized arrays).
                              SemanticErrorCase{
                                  "floatingConstant",
                                  R"prg(

--- a/test/src/functionalTest/SizeofTest.cpp
+++ b/test/src/functionalTest/SizeofTest.cpp
@@ -197,4 +197,38 @@ TEST(Compiler, negativeArraySizeIsSemanticError) {
     program.assertCompilationErrors("array size is not a non-negative constant expression");
 }
 
+TEST(Compiler, sizeofFunctionDesignatorIsError) {
+    // sizeof on a function (not a pointer-to-function) is invalid; must not fold to 0.
+    SourceProgram program{R"prg(
+        int f() {
+            return 1;
+        }
+
+        int main() {
+            printf("%d", sizeof f);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("sizeof");
+}
+
+TEST(Compiler, voidArrayParameterReportsSemanticErrorWithoutAbort) {
+    // Recovery: FormalArgument diagnoses incomplete array element; FunctionDeclarator
+    // must not rethrow when rebuilding argument types.
+    SourceProgram program{R"prg(
+        int f(void a[3]) {
+            return 0;
+        }
+
+        int main() {
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array of incomplete type");
+    // Prefer the semantic-analysis path (context:line: error:), not an uncaught exception dump.
+    program.assertCompilationErrors("error:");
+}
+
 } // namespace

--- a/test/src/functionalTest/SizeofTest.cpp
+++ b/test/src/functionalTest/SizeofTest.cpp
@@ -76,4 +76,17 @@ TEST(Compiler, sizedArrayDeclarationAccepted) {
     program.runAndExpect("1");
 }
 
+TEST(Compiler, nonConstantArraySizeIsSemanticError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int n;
+            n = 3;
+            int a[n];
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array size is not a non-negative constant expression");
+}
+
 } // namespace

--- a/test/src/functionalTest/SizeofTest.cpp
+++ b/test/src/functionalTest/SizeofTest.cpp
@@ -213,6 +213,31 @@ TEST(Compiler, sizeofFunctionDesignatorIsError) {
     program.assertCompilationErrors("sizeof");
 }
 
+TEST(Compiler, sizeofPointerToFunction) {
+    // Pointer-to-function is complete; must not be rejected as bare function.
+    SourceProgram program{R"prg(
+        int main() {
+            int (*f)();
+            printf("%d", sizeof f);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8");
+}
+
+TEST(Compiler, sizeofArrayOfFunctionPointers) {
+    SourceProgram program{R"prg(
+        int main() {
+            int (*a[3])();
+            printf("%d", sizeof a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("24");
+}
+
 TEST(Compiler, voidArrayParameterReportsSemanticErrorWithoutAbort) {
     // Recovery: FormalArgument diagnoses incomplete array element; FunctionDeclarator
     // must not rethrow when rebuilding argument types.

--- a/test/src/functionalTest/SizeofTest.cpp
+++ b/test/src/functionalTest/SizeofTest.cpp
@@ -89,4 +89,112 @@ TEST(Compiler, nonConstantArraySizeIsSemanticError) {
     program.assertCompilationErrors("array size is not a non-negative constant expression");
 }
 
+TEST(Compiler, sizeofArrayOfPointers) {
+    // int *a[3] — array of pointers; also exercises pointer-qualified array elements.
+    SourceProgram program{R"prg(
+        int main() {
+            int *a[3];
+            printf("%d", sizeof a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("24");
+}
+
+TEST(Compiler, sizeofAsArrayBound) {
+    // sizeof expr folded as a constant bound — covers UnaryExpression::evaluateConstant for sizeof.
+    SourceProgram program{R"prg(
+        int main() {
+            int a[sizeof(int)];
+            printf("%d", sizeof a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("16");
+}
+
+TEST(Compiler, multidimensionalArraySizeof) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2][3];
+            printf("%d", sizeof a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("24");
+}
+
+TEST(Compiler, voidArrayIsSemanticError) {
+    SourceProgram program{R"prg(
+        int main() {
+            void a[3];
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array of incomplete type");
+}
+
+TEST(Compiler, voidArrayParameterIsSemanticError) {
+    SourceProgram program{R"prg(
+        int f(void a[3]) {
+            return 0;
+        }
+
+        int main() {
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array of incomplete type");
+}
+
+TEST(Compiler, arrayByteSizeOverflowIsSemanticError) {
+    // element size 4 * 536870913 overflows signed 32-bit object size (INT_MAX).
+    SourceProgram program{R"prg(
+        int main() {
+            int a[536870913];
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array size is too large");
+}
+
+TEST(Compiler, arrayCountExceedsIntMaxIsSemanticError) {
+    SourceProgram program{R"prg(
+        int main() {
+            char a[2147483648];
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array size is too large");
+}
+
+TEST(Compiler, sizeofVoidTypeIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d", sizeof(void));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("sizeof");
+}
+
+TEST(Compiler, negativeArraySizeIsSemanticError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[-1];
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("array size is not a non-negative constant expression");
+}
+
 } // namespace

--- a/test/src/functionalTest/SizeofTest.cpp
+++ b/test/src/functionalTest/SizeofTest.cpp
@@ -1,0 +1,79 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, sizeofTypeInt) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d", sizeof(int));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("4");
+}
+
+TEST(Compiler, sizeofTypeChar) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d", sizeof(char));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1");
+}
+
+TEST(Compiler, sizeofTypePointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d", sizeof(int*));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8");
+}
+
+TEST(Compiler, sizeofExpressionVariable) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x;
+            char c;
+            int *p;
+            printf("%d %d %d", sizeof x, sizeof c, sizeof p);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("4 1 8");
+}
+
+TEST(Compiler, sizeofSizedArray) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            printf("%d", sizeof a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("12");
+}
+
+TEST(Compiler, sizedArrayDeclarationAccepted) {
+    // Declaration alone must type-check; no element access required.
+    SourceProgram program{R"prg(
+        int main() {
+            int a[4];
+            int b;
+            b = 1;
+            printf("%d", b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1");
+}
+
+} // namespace

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -223,6 +223,27 @@ TEST(Type, arrayOfIntHasElementTypeAndSize) {
     EXPECT_THAT(a.to_string(), Eq("int[3]"));
 }
 
+TEST(Type, nestedArrayToStringOutsideIn) {
+    using namespace type;
+    // int a[2][3] — outer count 2, element int[3]
+    auto a = array(array(signedInteger(), 3), 2);
+    EXPECT_THAT(a.getSize(), Eq(24));
+    EXPECT_THAT(a.to_string(), Eq("int[2][3]"));
+}
+
+TEST(Type, arrayOfFunctionPointersIsComplete) {
+    using namespace type;
+    auto fp = pointer(function(signedInteger(), {}));
+    auto a = array(fp, 3);
+    EXPECT_THAT(a.isArray(), IsTrue());
+    EXPECT_THAT(a.getSize(), Eq(24));
+}
+
+TEST(Type, arrayRejectsBareFunctionElement) {
+    using namespace type;
+    EXPECT_THROW(array(function(signedInteger(), {}), 2), std::invalid_argument);
+}
+
 TEST(Type, pointerToArrayIsPointerNotArray) {
     using namespace type;
     auto a = array(signedInteger(), 3);

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -3,6 +3,8 @@
 
 #include "types/Type.h"
 
+#include <stdexcept>
+
 namespace {
 
 using namespace testing;
@@ -208,6 +210,51 @@ TEST(Type, functionReturningIntAcceptingIntAndPointerToPointerToUnsignedLong) {
     EXPECT_THAT(t.getFunction().getArguments().size(), Eq(2));
 
     EXPECT_THAT(t.to_string(), Eq("int(int, unsigned long**)"));
+}
+
+TEST(Type, arrayOfIntHasElementTypeAndSize) {
+    using namespace type;
+    auto a = array(signedInteger(), 3);
+    ASSERT_THAT(a.isArray(), IsTrue());
+    EXPECT_THAT(a.isPointer(), IsFalse());
+    EXPECT_THAT(a.getSize(), Eq(12));
+    EXPECT_THAT(a.getArraySize(), Eq(3));
+    EXPECT_THAT(a.getElementType().getSize(), Eq(4));
+    EXPECT_THAT(a.to_string(), Eq("int[3]"));
+}
+
+TEST(Type, pointerToArrayIsPointerNotArray) {
+    using namespace type;
+    auto a = array(signedInteger(), 3);
+    auto p = pointer(a);
+    EXPECT_THAT(p.isPointer(), IsTrue());
+    EXPECT_THAT(p.isArray(), IsFalse());
+    EXPECT_THAT(p.getSize(), Eq(8));
+    auto peeled = p.dereference();
+    EXPECT_THAT(peeled.isArray(), IsTrue());
+    EXPECT_THAT(peeled.getArraySize(), Eq(3));
+}
+
+TEST(Type, arrayRejectsNegativeCount) {
+    using namespace type;
+    EXPECT_THROW(array(signedInteger(), -1), std::invalid_argument);
+}
+
+TEST(Type, arrayRejectsSizeOverflow) {
+    using namespace type;
+    // 4 * 536870913 > INT_MAX
+    EXPECT_THROW(array(signedInteger(), 536870913), std::invalid_argument);
+}
+
+TEST(Type, arrayRejectsVoidElement) {
+    using namespace type;
+    EXPECT_THROW(array(voidType(), 3), std::invalid_argument);
+}
+
+TEST(Type, getElementTypeOnNonArrayThrows) {
+    using namespace type;
+    EXPECT_THROW(signedInteger().getElementType(), std::runtime_error);
+    EXPECT_THROW(signedInteger().getArraySize(), std::runtime_error);
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- `type::array(T, n)` with recursive element type and `getSize()`.
- Sized array declarators type-check; array access still not implemented.
- `sizeof expr` and `sizeof(type)` for primitives and pointers.
- Functional SizeofTest; catalog no longer expects sized arrays to fail early.

## Review follow-ups
- Reject array size overflow (`element_size * count` / count > INT_MAX).
- Reject array of incomplete type (`void a[3]`, void parameters).
- `isArray()` false for pointer-to-array.
- Diagnose `sizeof(void)`.
- Extra functional coverage (array-of-pointers, sizeof as bound, multi-dim, error paths) to address Coveralls regression.

## Known limitations (intentional this slice)
- **Stack storage:** locals still get one machine-word frame slot. Multi-element arrays are not multi-word allocated yet.
- **Array access / indexing IR:** not implemented.

## Stack
PR 5/6 — base is **master**. Tip is #69.

## Test plan
- [x] Full local `ctest`
- [x] SizeofTest + Type unit tests
- [ ] CI green