### PR TITLE
feat(types): named structure member layout

### DIFF
--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -47,6 +47,22 @@ Type array(const Type& elementType, int elementCount) {
     return a;
 }
 
+Type structure(const std::vector<std::pair<std::string, Type>>& members) {
+    Type s { std::vector<Qualifier> {} };
+    s._members = std::make_shared<std::vector<Type::Member>>();
+    int offset = 0;
+    for (const auto& [name, memberType] : members) {
+        Type::Member m;
+        m.name = name;
+        m.type = std::make_shared<Type>(memberType);
+        m.offset = offset;
+        s._members->push_back(m);
+        offset += memberType.getSize();
+    }
+    s._size = offset;
+    return s;
+}
+
 Type signedCharacter(const std::vector<Qualifier>& qualifiers) {
     return primitive(Primitive::signedCharacter(), qualifiers);
 }
@@ -115,7 +131,7 @@ int Type::getSize() const {
     if (isPointer()) {
         return POINTER_SIZE;
     }
-    if (isArray()) {
+    if (isArray() || isStructure()) {
         return _size;
     }
     if (isPrimitive()) {
@@ -160,10 +176,6 @@ bool Type::isFunction() const {
 
 Function Type::getFunction() const {
     return *_function;
-}
-
-bool Type::isStructure() const {
-    return false;
 }
 
 Type Type::dereference() const {
@@ -211,9 +223,42 @@ std::string Type::to_string() const {
         }
         return str.str();
     }
+    if (isStructure()) {
+        return "struct";
+    }
     return "unknown type";
 }
 
+
+bool Type::isStructure() const {
+    return _members != nullptr;
+}
+
+bool Type::memberOffset(const std::string& memberName, int& offsetBytes) const {
+    if (!isStructure()) {
+        return false;
+    }
+    for (const auto& m : *_members) {
+        if (m.name == memberName) {
+            offsetBytes = m.offset;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Type::memberType(const std::string& memberName, Type& outType) const {
+    if (!isStructure()) {
+        return false;
+    }
+    for (const auto& m : *_members) {
+        if (m.name == memberName) {
+            outType = *m.type;
+            return true;
+        }
+    }
+    return false;
+}
 
 bool Type::isArray() const {
     // Pointer-to-array copies element payload via pointer(); peel indirection first.

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -49,12 +49,17 @@ Type array(const Type& elementType, int elementCount) {
 
 namespace {
 
-int alignUp(int offset, int alignment) {
+long long alignUp(long long offset, int alignment) {
     if (alignment <= 1) {
         return offset;
     }
-    const int rem = offset % alignment;
+    const long long rem = offset % alignment;
     return rem == 0 ? offset : offset + (alignment - rem);
+}
+
+bool isIncompleteMemberType(const Type& memberType) {
+    // Match array(): bare function/void incomplete; pointer-to-function is complete.
+    return memberType.isVoid() || (memberType.isFunction() && !memberType.isPointer());
 }
 
 } // namespace
@@ -62,23 +67,41 @@ int alignUp(int offset, int alignment) {
 Type structure(const std::vector<std::pair<std::string, Type>>& members) {
     Type s { std::vector<Qualifier> {} };
     s._members = std::make_shared<std::vector<Type::Member>>();
-    int offset = 0;
+    long long offset = 0;
     int maxAlign = 1;
     for (const auto& [name, memberType] : members) {
+        if (isIncompleteMemberType(memberType)) {
+            throw std::invalid_argument { "structure member has incomplete type" };
+        }
+        for (const auto& existing : *s._members) {
+            if (existing.name == name) {
+                throw std::invalid_argument { "duplicate structure member name" };
+            }
+        }
         const int align = memberType.getAlignment();
         if (align > maxAlign) {
             maxAlign = align;
         }
         offset = alignUp(offset, align);
+        if (offset > static_cast<long long>(std::numeric_limits<int>::max())) {
+            throw std::invalid_argument { "structure size is too large" };
+        }
         Type::Member m;
         m.name = name;
         m.type = std::make_shared<Type>(memberType);
-        m.offset = offset;
+        m.offset = static_cast<int>(offset);
         s._members->push_back(m);
         offset += memberType.getSize();
+        if (offset > static_cast<long long>(std::numeric_limits<int>::max())) {
+            throw std::invalid_argument { "structure size is too large" };
+        }
     }
     // Trailing padding so array-of-struct stride matches SysV layout.
-    s._size = alignUp(offset, maxAlign);
+    offset = alignUp(offset, maxAlign);
+    if (offset > static_cast<long long>(std::numeric_limits<int>::max())) {
+        throw std::invalid_argument { "structure size is too large" };
+    }
+    s._size = static_cast<int>(offset);
     return s;
 }
 

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -47,11 +47,29 @@ Type array(const Type& elementType, int elementCount) {
     return a;
 }
 
+namespace {
+
+int alignUp(int offset, int alignment) {
+    if (alignment <= 1) {
+        return offset;
+    }
+    const int rem = offset % alignment;
+    return rem == 0 ? offset : offset + (alignment - rem);
+}
+
+} // namespace
+
 Type structure(const std::vector<std::pair<std::string, Type>>& members) {
     Type s { std::vector<Qualifier> {} };
     s._members = std::make_shared<std::vector<Type::Member>>();
     int offset = 0;
+    int maxAlign = 1;
     for (const auto& [name, memberType] : members) {
+        const int align = memberType.getAlignment();
+        if (align > maxAlign) {
+            maxAlign = align;
+        }
+        offset = alignUp(offset, align);
         Type::Member m;
         m.name = name;
         m.type = std::make_shared<Type>(memberType);
@@ -59,7 +77,8 @@ Type structure(const std::vector<std::pair<std::string, Type>>& members) {
         s._members->push_back(m);
         offset += memberType.getSize();
     }
-    s._size = offset;
+    // Trailing padding so array-of-struct stride matches SysV layout.
+    s._size = alignUp(offset, maxAlign);
     return s;
 }
 
@@ -139,6 +158,30 @@ int Type::getSize() const {
     }
 
     return _size;
+}
+
+int Type::getAlignment() const {
+    if (isPointer()) {
+        return POINTER_SIZE;
+    }
+    if (isArray()) {
+        return getElementType().getAlignment();
+    }
+    if (isStructure()) {
+        int maxAlign = 1;
+        for (const auto& m : *_members) {
+            const int a = m.type->getAlignment();
+            if (a > maxAlign) {
+                maxAlign = a;
+            }
+        }
+        return maxAlign;
+    }
+    if (isPrimitive()) {
+        // Natural alignment equals size for the primitives we model (1/4/8/16).
+        return _primitive->getSize();
+    }
+    return 1;
 }
 
 bool Type::canAssignFrom(const Type& other) const {
@@ -231,7 +274,8 @@ std::string Type::to_string() const {
 
 
 bool Type::isStructure() const {
-    return _members != nullptr;
+    // Pointer-to-struct copies member payload via pointer(); peel indirection first.
+    return !isPointer() && _members != nullptr;
 }
 
 bool Type::memberOffset(const std::string& memberName, int& offsetBytes) const {

--- a/src/types/Type.h
+++ b/src/types/Type.h
@@ -33,6 +33,8 @@ public:
     friend Type array(const Type& elementType, int elementCount);
 
     int getSize() const;
+    // Natural alignment in bytes (SysV/amd64 stand-in: size for primitives, max for aggregates).
+    int getAlignment() const;
     bool canAssignFrom(const Type& other) const;
 
     bool isVoid() const;

--- a/src/types/Type.h
+++ b/src/types/Type.h
@@ -4,10 +4,11 @@
 #include "Primitive.h"
 #include "Function.h"
 
-#include <string>
-#include <vector>
-#include <optional>
 #include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace type {
 
@@ -17,11 +18,18 @@ enum class Qualifier {
 
 class Type {
 public:
+    struct Member {
+        std::string name;
+        // Stored by value via shared_ptr to keep Type copyable.
+        std::shared_ptr<Type> type;
+        int offset { 0 };
+    };
+
     friend Type voidType();
     friend Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifiers);
     friend Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers);
     friend Type function(const Type& returnType, const std::vector<Type>& arguments);
-    friend Type structure(const std::vector<Type>& members);
+    friend Type structure(const std::vector<std::pair<std::string, Type>>& members);
     friend Type array(const Type& elementType, int elementCount);
 
     int getSize() const;
@@ -37,6 +45,9 @@ public:
     bool isArray() const;
     Type getElementType() const;
     int getArraySize() const;
+
+    bool memberOffset(const std::string& memberName, int& offsetBytes) const;
+    bool memberType(const std::string& memberName, Type& outType) const;
 
     bool isConst() const;
     bool isVolatile() const;
@@ -60,13 +71,14 @@ private:
     int _indirection {0};
     std::shared_ptr<Type> _elementType;
     int _arrayCount { -1 };
+    std::shared_ptr<std::vector<Member>> _members;
 };
 
 Type voidType();
 Type primitive(const Primitive& primitive, const std::vector<Qualifier>& qualifiers = {});
 Type pointer(const Type& pointsTo, const std::vector<Qualifier>& qualifiers = {});
 Type function(const Type& returnType, const std::vector<Type>& arguments = {});
-Type structure(const std::vector<Type>& members = {});
+Type structure(const std::vector<std::pair<std::string, Type>>& members = {});
 Type array(const Type& elementType, int elementCount);
 
 Type signedCharacter(const std::vector<Qualifier>& qualifiers = {});

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -318,6 +318,50 @@ TEST(Type, structureLayoutAlignsMixedMembers) {
     EXPECT_THAT(off, Eq(4));
 }
 
+TEST(Type, structureTrailingPadAndArrayStride) {
+    // int then char needs trailing pad to align 4 → size 8; array stride multiplies that.
+    using namespace type;
+    auto s = structure({
+        {"i", signedInteger()},
+        {"c", signedCharacter()},
+    });
+    ASSERT_THAT(s.isStructure(), IsTrue());
+    EXPECT_THAT(s.getSize(), Eq(8));
+    int off = -1;
+    EXPECT_THAT(s.memberOffset("i", off), IsTrue());
+    EXPECT_THAT(off, Eq(0));
+    EXPECT_THAT(s.memberOffset("c", off), IsTrue());
+    EXPECT_THAT(off, Eq(4));
+    EXPECT_THAT(array(s, 2).getSize(), Eq(16));
+}
+
+TEST(Type, structureRejectsIncompleteMembers) {
+    using namespace type;
+    EXPECT_THROW(structure({{"v", voidType()}}), std::invalid_argument);
+    EXPECT_THROW(structure({{"f", function(signedInteger(), {})}}), std::invalid_argument);
+}
+
+TEST(Type, structureAllowsFunctionPointerMembers) {
+    using namespace type;
+    auto s = structure({{"fp", pointer(function(signedInteger(), {}))}});
+    EXPECT_THAT(s.isStructure(), IsTrue());
+    EXPECT_THAT(s.getSize(), Eq(8));
+}
+
+TEST(Type, structureRejectsDuplicateMemberNames) {
+    using namespace type;
+    EXPECT_THROW(
+            structure({{"x", signedInteger()}, {"x", signedCharacter()}}),
+            std::invalid_argument);
+}
+
+TEST(Type, structureRejectsSizeOverflow) {
+    using namespace type;
+    // Each member fits in int; sum of two exceeds INT_MAX.
+    auto huge = array(signedCharacter(), 1073741824); // 2^30
+    EXPECT_THROW(structure({{"a", huge}, {"b", huge}}), std::invalid_argument);
+}
+
 TEST(Type, pointerToStructureIsPointerNotStructure) {
     using namespace type;
     auto s = structure({{"x", signedInteger()}});

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -278,24 +278,58 @@ TEST(Type, getElementTypeOnNonArrayThrows) {
     EXPECT_THROW(signedInteger().getArraySize(), std::runtime_error);
 }
 
-} // namespace
-
-
 TEST(Type, structureMembersHaveOffsetsAndSize) {
     using namespace type;
     auto s = structure({
         {"x", signedInteger()},
         {"y", signedInteger()},
     });
-    ASSERT_TRUE(s.isStructure());
-    EXPECT_EQ(s.getSize(), 8);
+    ASSERT_THAT(s.isStructure(), IsTrue());
+    EXPECT_THAT(s.getSize(), Eq(8));
     int off = -1;
-    EXPECT_TRUE(s.memberOffset("x", off));
-    EXPECT_EQ(off, 0);
-    EXPECT_TRUE(s.memberOffset("y", off));
-    EXPECT_EQ(off, 4);
+    EXPECT_THAT(s.memberOffset("x", off), IsTrue());
+    EXPECT_THAT(off, Eq(0));
+    EXPECT_THAT(s.memberOffset("y", off), IsTrue());
+    EXPECT_THAT(off, Eq(4));
     Type mt = voidType();
-    EXPECT_TRUE(s.memberType("x", mt));
-    EXPECT_TRUE(mt.isPrimitive());
-    EXPECT_FALSE(s.memberOffset("z", off));
+    EXPECT_THAT(s.memberType("x", mt), IsTrue());
+    EXPECT_THAT(mt.isPrimitive(), IsTrue());
+    EXPECT_THAT(mt.getSize(), Eq(4));
+    EXPECT_THAT(mt.getPrimitive().isSigned(), IsTrue());
+    Type mty = voidType();
+    EXPECT_THAT(s.memberType("y", mty), IsTrue());
+    EXPECT_THAT(mty.getSize(), Eq(4));
+    EXPECT_THAT(s.memberOffset("z", off), IsFalse());
 }
+
+TEST(Type, structureLayoutAlignsMixedMembers) {
+    // SysV/amd64-style: char then int → offsets 0/4, size 8 (not packed 0/1/size 5).
+    using namespace type;
+    auto s = structure({
+        {"c", signedCharacter()},
+        {"i", signedInteger()},
+    });
+    ASSERT_THAT(s.isStructure(), IsTrue());
+    EXPECT_THAT(s.getSize(), Eq(8));
+    int off = -1;
+    EXPECT_THAT(s.memberOffset("c", off), IsTrue());
+    EXPECT_THAT(off, Eq(0));
+    EXPECT_THAT(s.memberOffset("i", off), IsTrue());
+    EXPECT_THAT(off, Eq(4));
+}
+
+TEST(Type, pointerToStructureIsPointerNotStructure) {
+    using namespace type;
+    auto s = structure({{"x", signedInteger()}});
+    auto p = pointer(s);
+    EXPECT_THAT(p.isPointer(), IsTrue());
+    EXPECT_THAT(p.isStructure(), IsFalse());
+    int off = -1;
+    EXPECT_THAT(p.memberOffset("x", off), IsFalse());
+    auto peeled = p.dereference();
+    EXPECT_THAT(peeled.isStructure(), IsTrue());
+    EXPECT_THAT(peeled.memberOffset("x", off), IsTrue());
+    EXPECT_THAT(off, Eq(0));
+}
+
+} // namespace

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -280,3 +280,22 @@ TEST(Type, getElementTypeOnNonArrayThrows) {
 
 } // namespace
 
+
+TEST(Type, structureMembersHaveOffsetsAndSize) {
+    using namespace type;
+    auto s = structure({
+        {"x", signedInteger()},
+        {"y", signedInteger()},
+    });
+    ASSERT_TRUE(s.isStructure());
+    EXPECT_EQ(s.getSize(), 8);
+    int off = -1;
+    EXPECT_TRUE(s.memberOffset("x", off));
+    EXPECT_EQ(off, 0);
+    EXPECT_TRUE(s.memberOffset("y", off));
+    EXPECT_EQ(off, 4);
+    Type mt = voidType();
+    EXPECT_TRUE(s.memberType("x", mt));
+    EXPECT_TRUE(mt.isPrimitive());
+    EXPECT_FALSE(s.memberOffset("z", off));
+}


### PR DESCRIPTION
## Summary
- `type::structure({{name, type}, …})` with `memberOffset` / `memberType` and layout size.
- Layout uses natural alignment + trailing pad (SysV-style stand-in).
- Rejects incomplete/duplicate members and oversized layouts; peels pointer-to-struct.
- Unit tests for two-int layout, mixed members, trailing pad / array stride, factory guards.

## Not yet
grammar/CSNB for `struct S { … }`, `.` / `->` member access, or field IR (`FieldAddress`).

## Stack
PR 6/6 foundation — base is **master** (arrays/sizeof #68 merged).

## Test plan
- [x] Full local `ctest`
- [x] Type structure unit tests
- [ ] CI green