### PR TITLE
feat(codegen): array index access and multi-word array locals

### DIFF
--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -7,7 +7,8 @@ namespace ast {
 
 ArrayAccess::ArrayAccess(std::unique_ptr<Expression> postfixExpression, std::unique_ptr<Expression> subscriptExpression) :
         DoubleOperandExpression(std::move(postfixExpression), std::move(subscriptExpression), std::unique_ptr<Operator> { new Operator("[]") }) {
-    lval = this->leftOperand->isLval();
+    // Element access is always an lvalue when the base is addressable (array or pointer).
+    lval = true;
 }
 
 void ArrayAccess::accept(AbstractSyntaxTreeVisitor& visitor) {
@@ -20,6 +21,26 @@ void ArrayAccess::setLvalue(semantic_analyzer::ValueEntry lvalue) {
 
 semantic_analyzer::ValueEntry* ArrayAccess::getLvalue() const {
     return lvalue.get();
+}
+
+semantic_analyzer::ValueEntry* ArrayAccess::getLvalueSymbol() const {
+    return getLvalue();
+}
+
+void ArrayAccess::setElementSize(int sizeInBytes) {
+    elementSize = sizeInBytes;
+}
+
+int ArrayAccess::getElementSize() const {
+    return elementSize;
+}
+
+void ArrayAccess::setBaseIsArray(bool value) {
+    baseIsArrayFlag = value;
+}
+
+bool ArrayAccess::baseIsArray() const {
+    return baseIsArrayFlag;
 }
 
 } // namespace ast

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -15,9 +15,17 @@ public:
 
     void setLvalue(semantic_analyzer::ValueEntry lvalue);
     semantic_analyzer::ValueEntry* getLvalue() const;
+    semantic_analyzer::ValueEntry* getLvalueSymbol() const override;
+
+    void setElementSize(int sizeInBytes);
+    int getElementSize() const;
+    void setBaseIsArray(bool value);
+    bool baseIsArray() const;
 
 private:
     std::unique_ptr<semantic_analyzer::ValueEntry> lvalue { nullptr };
+    int elementSize { 0 };
+    bool baseIsArrayFlag { false };
 };
 
 } // namespace ast

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -52,6 +52,11 @@ void AssemblyGenerator::generateCodeFor(const Dereference& dereference) {
     stackMachine->dereference(dereference.getOperand(), dereference.getLvalue(), dereference.getResult());
 }
 
+void AssemblyGenerator::generateCodeFor(const IndexAddress& indexAddress) {
+    stackMachine->indexAddress(indexAddress.getBase(), indexAddress.getIndex(), indexAddress.getElementSizeBytes(),
+            indexAddress.getResult(), indexAddress.baseIsArray());
+}
+
 void AssemblyGenerator::generateCodeFor(const UnaryMinus& unaryMinus) {
     stackMachine->unaryMinus(unaryMinus.getOperand(), unaryMinus.getResult());
 }

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -13,6 +13,7 @@
 #include "quadruples/ValueCompare.h"
 #include "quadruples/AddressOf.h"
 #include "quadruples/Dereference.h"
+#include "quadruples/IndexAddress.h"
 #include "quadruples/UnaryMinus.h"
 #include "quadruples/UnaryNot.h"
 #include "quadruples/Assign.h"
@@ -54,6 +55,7 @@ public:
     void generateCodeFor(const ZeroCompare& zeroCompare);
     void generateCodeFor(const AddressOf& addressOf);
     void generateCodeFor(const Dereference& dereference);
+    void generateCodeFor(const IndexAddress& indexAddress);
     void generateCodeFor(const UnaryMinus& unaryMinus);
     void generateCodeFor(const UnaryNot& unaryNot);
     void generateCodeFor(const Assign& assign);

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(backend
         quadruples/DoubleOperandQuadruple.cpp
         quadruples/EndProcedure.cpp
         quadruples/Inc.cpp
+        quadruples/IndexAddress.cpp
         quadruples/Jump.cpp
         quadruples/Label.cpp
         quadruples/LvalueAssign.cpp
@@ -58,6 +59,7 @@ add_library(backend
         quadruples/DoubleOperandQuadruple.h
         quadruples/EndProcedure.h
         quadruples/Inc.h
+        quadruples/IndexAddress.h
         quadruples/Jump.h
         quadruples/Label.h
         quadruples/LvalueAssign.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -11,6 +11,7 @@
 #include "quadruples/Retrieve.h"
 #include "quadruples/AssignConstant.h"
 #include "quadruples/Inc.h"
+#include "quadruples/IndexAddress.h"
 #include "quadruples/Dec.h"
 #include "quadruples/AddressOf.h"
 #include "quadruples/Dereference.h"
@@ -70,7 +71,20 @@ void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
 void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     arrayAccess.visitLeftOperand(*this);
     arrayAccess.visitRightOperand(*this);
-    throw std::runtime_error { "code generation for array access is not implemented" };
+    if (!arrayAccess.getLvalue() || !arrayAccess.getResultSymbol()) {
+        return;
+    }
+    instructions.push_back(std::make_unique<IndexAddress>(
+            arrayAccess.leftOperandSymbol()->getName(),
+            arrayAccess.rightOperandSymbol()->getName(),
+            arrayAccess.getElementSize(),
+            arrayAccess.getLvalue()->getName(),
+            arrayAccess.baseIsArray()));
+    // Load the element for rvalue uses; stores go through LvalueAssign on the address temp.
+    instructions.push_back(std::make_unique<Dereference>(
+            arrayAccess.getLvalue()->getName(),
+            arrayAccess.getLvalue()->getName(),
+            arrayAccess.getResultSymbol()->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
@@ -148,7 +162,14 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
 
     switch (expression.getOperator()->getLexeme().front()) {
     case '&':
-        instructions.push_back(std::make_unique<AddressOf>(expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+        // &a[i] / &*p: address is already computed in the operand's lvalue temp.
+        if (auto* lvalue = expression.operandLvalueSymbol()) {
+            instructions.push_back(std::make_unique<Assign>(
+                    lvalue->getName(), expression.getResultSymbol()->getName()));
+        } else {
+            instructions.push_back(std::make_unique<AddressOf>(
+                    expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+        }
         break;
     case '*':
         instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName(),

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -424,8 +424,13 @@ void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
         ));
     } else if (assignmentOperator->getLexeme() == "=") {
         if (expression.leftOperandLvalueSymbol()) {
-            instructions.push_back(std::make_unique<LvalueAssign>(
+            // Convert into the LHS value temp (correct store width) then write through the address.
+            instructions.push_back(std::make_unique<Assign>(
                         expression.rightOperandSymbol()->getName(),
+                        resultName
+            ));
+            instructions.push_back(std::make_unique<LvalueAssign>(
+                        resultName,
                         expression.leftOperandLvalueSymbol()->getName()
             ));
         } else {

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -1,6 +1,7 @@
 #include "StackMachine.h"
 
 #include <cassert>
+#include <cctype>
 #include <stdexcept>
 
 #include "InstructionSet.h"
@@ -35,19 +36,32 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
     assembly << instructionSet->push(registers->getBasePointer());
     assembly << instructionSet->mov(registers->getStackPointer(), registers->getBasePointer());
 
+    auto wordSlots = [](const Value& v) {
+        const int size = v.getSizeInBytes();
+        if (size <= 0) {
+            return 1;
+        }
+        return (size + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
+    };
+    // Highest exclusive word index among multi-word locals (index is a word offset).
+    int nextLocalWord = 0;
     for (auto& value : values) {
         scopeValues.insert({value.getName(), value});
+        const int end = value.getIndex() + wordSlots(value);
+        if (end > nextLocalWord) {
+            nextLocalWord = end;
+        }
     }
     std::size_t integerArgumentRegisterIndex{0};
-    std::size_t localIndex{scopeValues.size()};
+    int localIndex{nextLocalWord};
     int argumentIndex{0};
     for (auto& argument : arguments) {
         if (argument.getType() == Type::INTEGRAL && integerArgumentRegisterIndex < registers->getIntegerArgumentRegisters().size()) {
-            Value registerArgument{argument.getName(), static_cast<int>(localIndex), argument.getType(), argument.getSizeInBytes()};
+            Value registerArgument{argument.getName(), localIndex, argument.getType(), argument.getSizeInBytes()};
             scopeValues.insert({argument.getName(), registerArgument});
             registers->getIntegerArgumentRegisters()[integerArgumentRegisterIndex]->assign(&resolve(argument.getName()));
             ++integerArgumentRegisterIndex;
-            ++localIndex;
+            localIndex += wordSlots(registerArgument);
         } else {
             Value stackArgument{argument.getName(), argumentIndex, argument.getType(), argument.getSizeInBytes()};
             scopeValues.insert({argument.getName(), stackArgument});
@@ -58,7 +72,8 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
         }
     }
     int savedRegistersStack = registers->getCalleeSavedRegisters().size() * MACHINE_WORD_SIZE;
-    localVariableStackSize = (scopeValues.size() - argumentIndex) * MACHINE_WORD_SIZE;
+    // Spill region covers multi-word locals and register-passed args (not stack args).
+    localVariableStackSize = localIndex * MACHINE_WORD_SIZE;
     int stackSize = savedRegistersStack + localVariableStackSize;
     if (stackSize % STACK_ALIGNMENT) {
         assembly << instructionSet->sub(registers->getStackPointer(), localVariableStackSize + MACHINE_WORD_SIZE);
@@ -202,13 +217,102 @@ void StackMachine::addressOf(std::string operandName, std::string resultName) {
     bindResult(resultRegister, resolve(resultName));
 }
 
+void StackMachine::indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+        bool baseIsArray) {
+    auto& base = resolve(baseName);
+    auto& index = resolve(indexName);
+
+    // One-operand imul writes RDX:RAX. Scale index first, then form base in another reg.
+    Register& mulReg = registers->getMultiplicationRegister();
+    Register& rdx = registers->getRemainderRegister();
+    storeRegisterValue(mulReg);
+    storeRegisterValue(rdx);
+
+    if (elementSizeBytes != 1) {
+        assignRegisterToSymbol(mulReg, index);
+        Register& sizeReg = get64BitRegisterExcluding(mulReg);
+        if (&sizeReg == &rdx) {
+            // Prefer a third register if get64BitRegisterExcluding only avoids mulReg.
+            storeRegisterValue(rdx);
+        }
+        Register& scaleReg = get64BitRegisterExcluding(mulReg);
+        assembly << instructionSet->mov(std::to_string(elementSizeBytes), scaleReg);
+        assembly << instructionSet->imul(scaleReg);
+    }
+
+    Register& addr = get64BitRegisterExcluding(mulReg);
+    if (baseIsArray) {
+        storeInMemory(base);
+        assembly << instructionSet->lea(memoryOperand(base), addr);
+    } else if (residesInMemory(base)) {
+        emitLoad(base, addr);
+    } else {
+        assembly << instructionSet->mov(base.getAssignedRegister(), addr);
+    }
+
+    if (elementSizeBytes == 1) {
+        if (residesInMemory(index)) {
+            assembly << instructionSet->add(memoryOperand(index), addr);
+        } else {
+            assembly << instructionSet->add(index.getAssignedRegister(), addr);
+        }
+    } else {
+        assembly << instructionSet->add(mulReg, addr);
+    }
+    bindResult(addr, resolve(resultName));
+}
+
+namespace {
+// Low-byte name for NASM size-qualified stores (rax→al, r8→r8b, …).
+std::string lowByteName(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "al";
+    if (n == "rbx") return "bl";
+    if (n == "rcx") return "cl";
+    if (n == "rdx") return "dl";
+    if (n == "rsi") return "sil";
+    if (n == "rdi") return "dil";
+    if (n == "rbp") return "bpl";
+    if (n == "rsp") return "spl";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return n + "b";
+    }
+    return n;
+}
+std::string lowDwordName(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "eax";
+    if (n == "rbx") return "ebx";
+    if (n == "rcx") return "ecx";
+    if (n == "rdx") return "edx";
+    if (n == "rsi") return "esi";
+    if (n == "rdi") return "edi";
+    if (n == "rbp") return "ebp";
+    if (n == "rsp") return "esp";
+    // r8–r15: dword form is r8d…r15d (not e8).
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return n + "d";
+    }
+    return n;
+}
+} // namespace
+
 void StackMachine::dereference(std::string operandName, std::string lvalueName, std::string resultName) {
     auto& operand = resolve(operandName);
+    auto& result = resolve(resultName);
     // Use the register returned by the load path; global pointer homes are not register-bound.
     Register& pointerRegister = residesInMemory(operand) ? assignRegisterTo(operand) : operand.getAssignedRegister();
     Register& resultRegister = get64BitRegisterExcluding(pointerRegister);
-    assembly << instructionSet->mov(MemoryOperand::at(pointerRegister, 0), resultRegister);
-    bindResult(resultRegister, resolve(resultName));
+    const int loadSize = result.getSizeInBytes();
+    if (loadSize == 1) {
+        // Zero-extend byte load so high bits don't pollute int uses (printf %d).
+        assembly << ("movzx " + resultRegister.getName() + ", byte [" + pointerRegister.getName() + "]");
+    } else if (loadSize == 4) {
+        assembly << ("mov " + lowDwordName(resultRegister) + ", dword [" + pointerRegister.getName() + "]");
+    } else {
+        assembly << instructionSet->mov(MemoryOperand::at(pointerRegister, 0), resultRegister);
+    }
+    bindResult(resultRegister, result);
 
     Register& lvalueRegister = get64BitRegisterExcluding(pointerRegister);
     assembly << instructionSet->mov(pointerRegister, lvalueRegister);
@@ -279,7 +383,15 @@ void StackMachine::lvalueAssign(std::string operandName, std::string resultName)
 
     Register& operandRegister = residesInMemory(operand) ? assignRegisterTo(operand) : operand.getAssignedRegister();
     Register& resultRegister = residesInMemory(result) ? assignRegisterExcluding(result, operandRegister) : result.getAssignedRegister();
-    assembly << instructionSet->mov(operandRegister, MemoryOperand::at(resultRegister, 0));
+    // Store width follows the rvalue size so packed char/int array elements do not clobber neighbors.
+    const int storeSize = operand.getSizeInBytes();
+    if (storeSize == 1) {
+        assembly << ("mov byte [" + resultRegister.getName() + "], " + lowByteName(operandRegister));
+    } else if (storeSize == 4) {
+        assembly << ("mov dword [" + resultRegister.getName() + "], " + lowDwordName(operandRegister));
+    } else {
+        assembly << instructionSet->mov(operandRegister, MemoryOperand::at(resultRegister, 0));
+    }
 }
 
 void StackMachine::procedureArgument(std::string argumentName) {

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -229,12 +229,10 @@ void StackMachine::indexAddress(std::string baseName, std::string indexName, int
     storeRegisterValue(rdx);
 
     if (elementSizeBytes != 1) {
-        assignRegisterToSymbol(mulReg, index);
-        Register& sizeReg = get64BitRegisterExcluding(mulReg);
-        if (&sizeReg == &rdx) {
-            // Prefer a third register if get64BitRegisterExcluding only avoids mulReg.
-            storeRegisterValue(rdx);
-        }
+        // Never leave the index Value bound to RAX across one-operand imul (which overwrites RAX).
+        storeInMemory(index);
+        storeRegisterValue(mulReg);
+        loadWithoutBinding(index, mulReg);
         Register& scaleReg = get64BitRegisterExcluding(mulReg);
         assembly << instructionSet->mov(std::to_string(elementSizeBytes), scaleReg);
         assembly << instructionSet->imul(scaleReg);
@@ -304,11 +302,12 @@ void StackMachine::dereference(std::string operandName, std::string lvalueName, 
     Register& pointerRegister = residesInMemory(operand) ? assignRegisterTo(operand) : operand.getAssignedRegister();
     Register& resultRegister = get64BitRegisterExcluding(pointerRegister);
     const int loadSize = result.getSizeInBytes();
+    // Sign-extend into the full 64-bit register: the rest of the ALU uses 64-bit ops/cmp.
+    // (Types are signed-default for char/int on this frontend.)
     if (loadSize == 1) {
-        // Zero-extend byte load so high bits don't pollute int uses (printf %d).
-        assembly << ("movzx " + resultRegister.getName() + ", byte [" + pointerRegister.getName() + "]");
+        assembly << ("movsx " + resultRegister.getName() + ", byte [" + pointerRegister.getName() + "]");
     } else if (loadSize == 4) {
-        assembly << ("mov " + lowDwordName(resultRegister) + ", dword [" + pointerRegister.getName() + "]");
+        assembly << ("movsxd " + resultRegister.getName() + ", dword [" + pointerRegister.getName() + "]");
     } else {
         assembly << instructionSet->mov(MemoryOperand::at(pointerRegister, 0), resultRegister);
     }

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -41,6 +41,8 @@ public:
 
     void addressOf(std::string operandName, std::string resultName);
     void dereference(std::string operandName, std::string lvalueName, std::string resultName);
+    void indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+            bool baseIsArray = false);
 
     void unaryMinus(std::string operandName, std::string resultName);
     void unaryNot(std::string operandName, std::string resultName);

--- a/src/codegen/quadruples/IndexAddress.cpp
+++ b/src/codegen/quadruples/IndexAddress.cpp
@@ -1,0 +1,25 @@
+#include "IndexAddress.h"
+
+#include "codegen/AssemblyGenerator.h"
+
+namespace codegen {
+
+IndexAddress::IndexAddress(std::string base, std::string index, int elementSizeBytes, std::string result, bool baseIsArray) :
+        base { std::move(base) },
+        index { std::move(index) },
+        elementSizeBytes { elementSizeBytes },
+        result { std::move(result) },
+        baseIsArray_ { baseIsArray }
+{
+}
+
+void IndexAddress::generateCode(AssemblyGenerator& generator) const {
+    generator.generateCodeFor(*this);
+}
+
+void IndexAddress::print(std::ostream& stream) const {
+    stream << "\t" << result << " := &" << base << "[" << index << "] stride=" << elementSizeBytes
+            << (baseIsArray_ ? " (array)\n" : " (ptr)\n");
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/IndexAddress.h
+++ b/src/codegen/quadruples/IndexAddress.h
@@ -1,0 +1,33 @@
+#ifndef INDEXADDRESS_QUADRUPLE_H_
+#define INDEXADDRESS_QUADRUPLE_H_
+
+#include <string>
+#include "Quadruple.h"
+
+namespace codegen {
+
+// result = &base[index] with element stride elementSizeBytes.
+// If baseIsArray, base is the array object (use its address); otherwise base holds a pointer.
+class IndexAddress: public Quadruple {
+public:
+    IndexAddress(std::string base, std::string index, int elementSizeBytes, std::string result, bool baseIsArray = false);
+    void generateCode(AssemblyGenerator& generator) const override;
+
+    std::string getBase() const { return base; }
+    std::string getIndex() const { return index; }
+    int getElementSizeBytes() const { return elementSizeBytes; }
+    std::string getResult() const { return result; }
+    bool baseIsArray() const { return baseIsArray_; }
+
+private:
+    void print(std::ostream& stream) const override;
+    std::string base;
+    std::string index;
+    int elementSizeBytes;
+    std::string result;
+    bool baseIsArray_;
+};
+
+} // namespace codegen
+
+#endif

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -113,12 +113,30 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
     }
 
     auto type = arrayAccess.leftOperandType();
-    if (type.isPointer()) {
-        arrayAccess.setLvalue(symbolTable.createTemporarySymbol(type.dereference()));
-        arrayAccess.setResultSymbol(symbolTable.createTemporarySymbol(type.dereference()));
+    type::Type elementType = type::voidType();
+    int stride = 0;
+    bool baseIsArray = false;
+    if (type.isArray()) {
+        elementType = type.getElementType();
+        stride = elementType.getSize();
+        baseIsArray = true;
+    } else if (type.isPointer()) {
+        elementType = type.dereference();
+        stride = elementType.getSize();
+        baseIsArray = false;
     } else {
         semanticError("invalid type for operator[]\n", arrayAccess.getContext());
+        return;
     }
+    if (stride <= 0) {
+        stride = 1;
+    }
+    arrayAccess.setBaseIsArray(baseIsArray);
+    arrayAccess.setElementSize(stride);
+    // Lvalue holds the address of the selected element; result is a loaded rvalue.
+    arrayAccess.setLvalue(symbolTable.createTemporarySymbol(type::pointer(elementType)));
+    arrayAccess.setResultSymbol(symbolTable.createTemporarySymbol(elementType));
+    arrayAccess.setType(elementType);
 }
 
 void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {

--- a/src/semantic_analyzer/ValueScope.cpp
+++ b/src/semantic_analyzer/ValueScope.cpp
@@ -33,6 +33,15 @@ private:
 
 namespace semantic_analyzer {
 
+int ValueScope::wordSlotsFor(const type::Type& type) {
+    const int size = type.getSize();
+    if (size <= 0) {
+        return 1;
+    }
+    // Round up to 8-byte stack slots (MACHINE_WORD_SIZE).
+    return (size + 7) / 8;
+}
+
 bool ValueScope::insertSymbol(std::string name, const type::Type& type, translation_unit::Context context, bool global) {
     if (localSymbols.find(name) != localSymbols.end()) {
         return false;
@@ -42,7 +51,9 @@ bool ValueScope::insertSymbol(std::string name, const type::Type& type, translat
     if (existingArgument != arguments.end()) {
         return false;
     }
-    ValueEntry entry { name, type, false, context, static_cast<int>(localSymbols.size()), global };
+    const int index = nextLocalWordIndex;
+    nextLocalWordIndex += wordSlotsFor(type);
+    ValueEntry entry { name, type, false, context, index, global };
     localSymbols.insert(std::make_pair(name, entry));
     return true;
 }
@@ -81,8 +92,9 @@ void ValueScope::setConstantInitializer(const std::string& name, long value) {
 
 ValueEntry ValueScope::createTemporarySymbol(type::Type type) {
     std::string tempName = generateTempName();
-// FIXME:
-    ValueEntry temp { tempName, type, true, translation_unit::Context { "", 0 }, static_cast<int>(localSymbols.size()) };
+    const int index = nextLocalWordIndex;
+    nextLocalWordIndex += wordSlotsFor(type);
+    ValueEntry temp { tempName, type, true, translation_unit::Context { "", 0 }, index };
     localSymbols.insert(std::make_pair(tempName, temp));
     return temp;
 }

--- a/src/semantic_analyzer/ValueScope.h
+++ b/src/semantic_analyzer/ValueScope.h
@@ -24,8 +24,14 @@ public:
     std::vector<ValueEntry> getArguments() const;
 
 private:
+    // Next free stack-slot index in machine words (8-byte units). Multi-word
+    // objects (arrays, future aggregates) reserve consecutive slots.
+    int nextLocalWordIndex { 0 };
+
     std::vector<ValueEntry> arguments;
     std::map<std::string, ValueEntry> localSymbols;
+
+    static int wordSlotsFor(const type::Type& type);
 };
 
 } // namespace semantic_analyzer

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -127,6 +127,7 @@ add_executable(functionalTest
         functionalTest/GotoTest.cpp
         functionalTest/SwitchTest.cpp
         functionalTest/SizeofTest.cpp
+        functionalTest/ArraysTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/codegenTest/UnimplementedArrayCodegenTest.cpp
+++ b/test/src/codegenTest/UnimplementedArrayCodegenTest.cpp
@@ -23,18 +23,15 @@ translation_unit::Context testContext() {
     return { "test", 1 };
 }
 
-TEST(CodeGeneratingVisitor, arrayAccessIsNotImplemented) {
+TEST(CodeGeneratingVisitor, arrayAccessWithoutSymbolsIsNoOp) {
+    // Without semantic analysis, ArrayAccess has no lvalue/result temps — codegen skips IR.
     ArrayAccess access {
             std::make_unique<IdentifierExpression>("a", testContext()),
             std::make_unique<IdentifierExpression>("i", testContext())
     };
     CodeGeneratingVisitor visitor;
-    try {
-        access.accept(visitor);
-        FAIL() << "expected array access codegen to throw";
-    } catch (const std::runtime_error& error) {
-        EXPECT_THAT(std::string(error.what()), HasSubstr("array access is not implemented"));
-    }
+    EXPECT_NO_THROW(access.accept(visitor));
+    EXPECT_THAT(visitor.getQuadruples().size(), Eq(0u));
 }
 
 TEST(CodeGeneratingVisitor, arrayDeclaratorIsNoOp) {

--- a/test/src/functionalTest/ArraysTest.cpp
+++ b/test/src/functionalTest/ArraysTest.cpp
@@ -1,0 +1,106 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, localArrayReadWrite) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            a[0] = 1;
+            a[1] = 2;
+            a[2] = 3;
+            printf("%d %d %d", a[0], a[1], a[2]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2 3");
+}
+
+TEST(Compiler, arrayIndexExpression) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[5];
+            int i;
+            for (i = 0; i < 5; i = i + 1) {
+                a[i] = i * 10;
+            }
+            printf("%d %d %d", a[0], a[2], a[4]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("0 20 40");
+}
+
+TEST(Compiler, arrayOfPointers) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x;
+            int y;
+            int* p[2];
+            x = 11;
+            y = 22;
+            p[0] = &x;
+            p[1] = &y;
+            printf("%d %d", *p[0], *p[1]);
+            *p[1] = 33;
+            printf(" %d", y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("11 22 33");
+}
+
+TEST(Compiler, pointerSubscript) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int* p;
+            a[0] = 4;
+            a[1] = 5;
+            a[2] = 6;
+            p = &a[0];
+            printf("%d %d", p[1], p[2]);
+            p[0] = 9;
+            printf(" %d", a[0]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5 6 9");
+}
+
+TEST(Compiler, charArray) {
+    SourceProgram program{R"prg(
+        int main() {
+            char s[3];
+            s[0] = 65;
+            s[1] = 66;
+            s[2] = 67;
+            printf("%d %d %d", s[0], s[1], s[2]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("65 66 67");
+}
+
+TEST(Compiler, addressOfArrayElement) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2];
+            int* p;
+            a[0] = 7;
+            a[1] = 8;
+            p = &a[1];
+            printf("%d", *p);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8");
+}
+
+} // namespace

--- a/test/src/functionalTest/ArraysTest.cpp
+++ b/test/src/functionalTest/ArraysTest.cpp
@@ -103,4 +103,33 @@ TEST(Compiler, addressOfArrayElement) {
     program.runAndExpect("8");
 }
 
+TEST(Compiler, negativeArrayElementCompare) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2];
+            a[0] = -1;
+            a[1] = -5;
+            printf("%d %d", a[0] < 0, a[1] + 1);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 -4");
+}
+
+TEST(Compiler, arrayIndexPreservesIndexVariable) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int i;
+            i = 1;
+            a[i] = 10;
+            printf("%d %d", a[1], i);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("10 1");
+}
+
 } // namespace

--- a/test/src/functionalTest/ArraysTest.cpp
+++ b/test/src/functionalTest/ArraysTest.cpp
@@ -87,6 +87,21 @@ TEST(Compiler, charArray) {
     program.runAndExpect("65 66 67");
 }
 
+TEST(Compiler, charArrayReverseOrderStores) {
+    SourceProgram program{R"prg(
+        int main() {
+            char s[3];
+            s[1] = 2;
+            s[0] = 1;
+            s[2] = 3;
+            printf("%d %d %d", s[0], s[1], s[2]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2 3");
+}
+
 TEST(Compiler, addressOfArrayElement) {
     SourceProgram program{R"prg(
         int main() {

--- a/test/src/functionalTest/SemanticErrorsTest.cpp
+++ b/test/src/functionalTest/SemanticErrorsTest.cpp
@@ -288,21 +288,6 @@ INSTANTIATE_TEST_SUITE_P(Compiler, SemanticErrorCatalog,
     )prg",
                                  "global initializer is not a constant expression",
                              },
-                             // Pointer subscript type-checks, then backend rejects array access codegen.
-                             SemanticErrorCase{
-                                 "pointerSubscriptCodegenNotImplemented",
-                                 R"prg(
-        int main() {
-            int a;
-            int *p;
-            a = 1;
-            p = &a;
-            printf("%d", p[0]);
-            return 0;
-        }
-    )prg",
-                                 "code generation for array access is not implemented",
-                             },
                              SemanticErrorCase{
                                  "braceInitializerNotImplemented",
                                  R"prg(


### PR DESCRIPTION
## Summary
- Multi-word stack slots for sized arrays (`ValueScope` word packing)
- `IndexAddress` IR + StackMachine lowering for `a[i]` / `p[i]`
- Size-aware byte/dword load/store for packed elements
- `&a[i]` reuses the element address temp
- Functional `ArraysTest` (1D R/W, loops, pointer arrays, char, address-of)

## Stack
PR 1/N — base **master**. Next: array decay / multi-dim.

## Test plan
- [x] Full local `ctest`
- [ ] CI green / coverage non-regression