### PR TITLE
feat(ast): multi-dimensional array access and array decay

### DIFF
--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -43,4 +43,12 @@ bool ArrayAccess::baseIsArray() const {
     return baseIsArrayFlag;
 }
 
+void ArrayAccess::setYieldsAddress(bool value) {
+    yieldsAddressFlag = value;
+}
+
+bool ArrayAccess::yieldsAddress() const {
+    return yieldsAddressFlag;
+}
+
 } // namespace ast

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -21,11 +21,16 @@ public:
     int getElementSize() const;
     void setBaseIsArray(bool value);
     bool baseIsArray() const;
+    // When the selected element is itself an array (e.g. a[i] for int a[n][m]),
+    // the access yields an address rather than a loaded scalar.
+    void setYieldsAddress(bool value);
+    bool yieldsAddress() const;
 
 private:
     std::unique_ptr<semantic_analyzer::ValueEntry> lvalue { nullptr };
     int elementSize { 0 };
     bool baseIsArrayFlag { false };
+    bool yieldsAddressFlag { false };
 };
 
 } // namespace ast

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -80,11 +80,13 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
             arrayAccess.getElementSize(),
             arrayAccess.getLvalue()->getName(),
             arrayAccess.baseIsArray()));
-    // Load the element for rvalue uses; stores go through LvalueAssign on the address temp.
-    instructions.push_back(std::make_unique<Dereference>(
-            arrayAccess.getLvalue()->getName(),
-            arrayAccess.getLvalue()->getName(),
-            arrayAccess.getResultSymbol()->getName()));
+    if (!arrayAccess.yieldsAddress()) {
+        // Load scalar element for rvalue uses; stores use LvalueAssign on the address temp.
+        instructions.push_back(std::make_unique<Dereference>(
+                arrayAccess.getLvalue()->getName(),
+                arrayAccess.getLvalue()->getName(),
+                arrayAccess.getResultSymbol()->getName()));
+    }
 }
 
 void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
@@ -172,8 +174,36 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
         }
         break;
     case '*':
-        instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName(),
-                                                             expression.getResultSymbol()->getName()));
+        if (expression.operandSymbol()->getType().isPointer()) {
+            // Already an address (pointer or multi-dim decayed row).
+            if (expression.getResultSymbol()->getName() == expression.getLvalueSymbol()->getName()) {
+                // Address-only multi-dim *a: just materialize &array into the temp if needed.
+                // Result and lvalue share the address temp; operand is the array object.
+                if (expression.operandType().isArray()) {
+                    instructions.push_back(std::make_unique<AddressOf>(
+                            expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName()));
+                } else {
+                    instructions.push_back(std::make_unique<Assign>(
+                            expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+                }
+            } else {
+                instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(),
+                        expression.getLvalueSymbol()->getName(), expression.getResultSymbol()->getName()));
+            }
+        } else if (expression.operandType().isArray()) {
+            // True array object: &a then optional load.
+            instructions.push_back(std::make_unique<AddressOf>(
+                    expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName()));
+            if (expression.getResultSymbol()->getName() != expression.getLvalueSymbol()->getName()) {
+                instructions.push_back(std::make_unique<Dereference>(
+                        expression.getLvalueSymbol()->getName(),
+                        expression.getLvalueSymbol()->getName(),
+                        expression.getResultSymbol()->getName()));
+            }
+        } else {
+            instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(),
+                    expression.getLvalueSymbol()->getName(), expression.getResultSymbol()->getName()));
+        }
         break;
     case '+':
         break;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -113,15 +113,22 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
     }
 
     auto type = arrayAccess.leftOperandType();
+    const type::Type leftSymType = arrayAccess.leftOperandSymbol()->getType();
     type::Type elementType = type::voidType();
     int stride = 0;
     bool baseIsArray = false;
-    if (type.isArray()) {
+    // Multi-dim: a[i] may keep expression type T[N] while the value is already a decayed pointer.
+    if (type.isArray() && leftSymType.isPointer()) {
+        elementType = type.getElementType();
+        stride = elementType.getSize();
+        baseIsArray = false;
+    } else if (type.isArray()) {
         elementType = type.getElementType();
         stride = elementType.getSize();
         baseIsArray = true;
-    } else if (type.isPointer()) {
-        elementType = type.dereference();
+    } else if (type.isPointer() || leftSymType.isPointer()) {
+        type::Type ptr = type.isPointer() ? type : leftSymType;
+        elementType = ptr.dereference();
         stride = elementType.getSize();
         baseIsArray = false;
     } else {
@@ -133,10 +140,21 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
     }
     arrayAccess.setBaseIsArray(baseIsArray);
     arrayAccess.setElementSize(stride);
-    // Lvalue holds the address of the selected element; result is a loaded rvalue.
-    arrayAccess.setLvalue(symbolTable.createTemporarySymbol(type::pointer(elementType)));
-    arrayAccess.setResultSymbol(symbolTable.createTemporarySymbol(elementType));
-    arrayAccess.setType(elementType);
+    if (elementType.isArray()) {
+        // a[i] for multi-dim: yield address of the subarray (decays to pointer-to-element).
+        type::Type decayed = type::pointer(elementType.getElementType());
+        auto addr = symbolTable.createTemporarySymbol(decayed);
+        arrayAccess.setLvalue(addr);
+        arrayAccess.setResultSymbol(addr);
+        arrayAccess.setType(elementType); // expression type remains array (sizeof a[0])
+        arrayAccess.setYieldsAddress(true);
+    } else {
+        // Lvalue holds element address; result is a loaded rvalue.
+        arrayAccess.setLvalue(symbolTable.createTemporarySymbol(type::pointer(elementType)));
+        arrayAccess.setResultSymbol(symbolTable.createTemporarySymbol(elementType));
+        arrayAccess.setType(elementType);
+        arrayAccess.setYieldsAddress(false);
+    }
 }
 
 void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
@@ -283,14 +301,35 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
     case '&':
         expression.setResultSymbol(symbolTable.createTemporarySymbol(type::pointer(expression.operandType())));
         break;
-    case '*':
-        if (expression.operandType().isPointer()) {
-            expression.setResultSymbol(symbolTable.createTemporarySymbol(expression.operandType().dereference()));
-            expression.setLvalueSymbol(symbolTable.createTemporarySymbol(expression.operandType()));
-        } else {
-            semanticError("invalid type argument of ‘unary *’ :" + expression.operandType().to_string(), expression.getContext());
+    case '*': {
+        type::Type operandType = expression.operandType();
+        const type::Type valueType = expression.operandSymbol()->getType();
+        // Value already a pointer (e.g. multi-dim a[i] decayed row): ordinary *ptr.
+        if (valueType.isPointer()) {
+            expression.setResultSymbol(symbolTable.createTemporarySymbol(valueType.dereference()));
+            expression.setLvalueSymbol(symbolTable.createTemporarySymbol(valueType));
+            break;
         }
+        // Array object in memory: *a ≡ a[0].
+        if (operandType.isArray()) {
+            type::Type elem = operandType.getElementType();
+            if (elem.isArray()) {
+                // *a for multi-dim: yield decayed address of first row; keep array expr type.
+                auto addr = symbolTable.createTemporarySymbol(type::pointer(elem.getElementType()));
+                expression.setLvalueSymbol(addr);
+                expression.setResultSymbol(addr);
+                expression.setType(elem);
+            } else {
+                auto addr = symbolTable.createTemporarySymbol(type::pointer(elem));
+                expression.setLvalueSymbol(addr);
+                expression.setResultSymbol(symbolTable.createTemporarySymbol(elem));
+                expression.setType(elem);
+            }
+            break;
+        }
+        semanticError("invalid type argument of ‘unary *’ :" + operandType.to_string(), expression.getContext());
         break;
+    }
     case '+':
         expression.setResultSymbol(*expression.operandSymbol());
         break;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -304,10 +304,19 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
     case '*': {
         type::Type operandType = expression.operandType();
         const type::Type valueType = expression.operandSymbol()->getType();
-        // Value already a pointer (e.g. multi-dim a[i] decayed row): ordinary *ptr.
+        // Value already a pointer (e.g. multi-dim a[i] decayed row, or int(*)[N]).
         if (valueType.isPointer()) {
-            expression.setResultSymbol(symbolTable.createTemporarySymbol(valueType.dereference()));
-            expression.setLvalueSymbol(symbolTable.createTemporarySymbol(valueType));
+            type::Type pointee = valueType.dereference();
+            if (pointee.isArray()) {
+                // *ptr-to-array yields the array object (address); do not scalar-load the row.
+                auto addr = symbolTable.createTemporarySymbol(type::pointer(pointee.getElementType()));
+                expression.setLvalueSymbol(addr);
+                expression.setResultSymbol(addr);
+                expression.setType(pointee);
+            } else {
+                expression.setResultSymbol(symbolTable.createTemporarySymbol(pointee));
+                expression.setLvalueSymbol(symbolTable.createTemporarySymbol(valueType));
+            }
             break;
         }
         // Array object in memory: *a ≡ a[0].

--- a/test/src/functionalTest/ArraysTest.cpp
+++ b/test/src/functionalTest/ArraysTest.cpp
@@ -147,4 +147,78 @@ TEST(Compiler, arrayIndexPreservesIndexVariable) {
     program.runAndExpect("10 1");
 }
 
+TEST(Compiler, multiDimensionalArrayAccess) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2][3];
+            a[0][0] = 1;
+            a[0][1] = 2;
+            a[0][2] = 3;
+            a[1][0] = 4;
+            a[1][1] = 5;
+            a[1][2] = 6;
+            printf("%d %d %d %d", a[0][0], a[0][2], a[1][1], a[1][2]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 3 5 6");
+}
+
+TEST(Compiler, multiDimensionalRowSizeofIsArray) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2][3];
+            printf("%d %d", sizeof a, sizeof a[0]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("24 12");
+}
+
+TEST(Compiler, unaryDerefOnArray) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            a[0] = 9;
+            a[1] = 8;
+            a[2] = 7;
+            printf("%d", *a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9");
+}
+
+TEST(Compiler, unaryDerefOnMultiDimRow) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2][3];
+            a[0][0] = 9;
+            a[0][1] = 8;
+            printf("%d %d", *a[0], (*a)[1]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9 8");
+}
+
+TEST(Compiler, multiDimRowAsPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2][3];
+            int* p;
+            a[1][2] = 42;
+            p = a[1];
+            printf("%d", p[2]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
 } // namespace

--- a/test/src/functionalTest/ArraysTest.cpp
+++ b/test/src/functionalTest/ArraysTest.cpp
@@ -221,4 +221,20 @@ TEST(Compiler, multiDimRowAsPointer) {
     program.runAndExpect("42");
 }
 
+
+TEST(Compiler, derefPointerToArrayRow) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[2][3];
+            int (*r)[3];
+            a[0][1] = 7;
+            r = &a[0];
+            printf("%d", (*r)[1]);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- Nested `a[i][j]` yields subarray address (no scalar load of the row)
- `*a` decays array to pointer then loads first element
- Functional multi-dim + unary-deref cases in `ArraysTest`

## Stack
PR 2/N — stacks on #array-index-mw

## Test plan
- [x] Full local `ctest`
- [ ] CI green