### PR TITLE
feat(ast): brace initializers for scalars and structs

### DIFF
--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -333,4 +333,24 @@ type::Type AbstractSyntaxTreeBuilderContext::lookupStructTag(const std::string& 
     return structTags.at(tag);
 }
 
+void AbstractSyntaxTreeBuilderContext::newInitializerList() {
+    initializerLists.push({});
+}
+
+void AbstractSyntaxTreeBuilderContext::addInitializerElement(std::unique_ptr<Expression> expression) {
+    if (initializerLists.empty()) {
+        newInitializerList();
+    }
+    initializerLists.top().push_back(std::move(expression));
+}
+
+std::vector<std::unique_ptr<Expression>> AbstractSyntaxTreeBuilderContext::popInitializerList() {
+    if (initializerLists.empty()) {
+        return {};
+    }
+    auto list = std::move(initializerLists.top());
+    initializerLists.pop();
+    return list;
+}
+
 } // namespace ast

--- a/src/ast/AbstractSyntaxTreeBuilderContext.h
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.h
@@ -113,6 +113,9 @@ public:
     bool hasStructTag(const std::string& tag) const;
     type::Type lookupStructTag(const std::string& tag) const;
 
+    void newInitializerList();
+    void addInitializerElement(std::unique_ptr<Expression> expression);
+    std::vector<std::unique_ptr<Expression>> popInitializerList();
 
 private:
     std::stack<TerminalSymbol> terminalSymbols;
@@ -146,6 +149,7 @@ private:
     std::stack<std::vector<std::pair<std::string, type::Type>>> structMemberLists;
     std::stack<std::vector<std::unique_ptr<Declarator>>> structDeclaratorLists;
     std::map<std::string, type::Type> structTags;
+    std::stack<std::vector<std::unique_ptr<Expression>>> initializerLists;
 };
 
 }

--- a/src/ast/AbstractSyntaxTreeVisitor.h
+++ b/src/ast/AbstractSyntaxTreeVisitor.h
@@ -3,6 +3,7 @@
 
 #include "ast/ArrayAccess.h"
 #include "ast/MemberAccess.h"
+#include "ast/InitializerListExpression.h"
 #include "ast/ArrayDeclarator.h"
 #include "ast/Block.h"
 #include "ast/ComparisonExpression.h"
@@ -58,6 +59,7 @@ public:
 
     virtual void visit(ArrayAccess& arrayAccess) = 0;
     virtual void visit(MemberAccess& memberAccess) = 0;
+    virtual void visit(InitializerListExpression& expression) = 0;
     virtual void visit(FunctionCall& functionCall) = 0;
     virtual void visit(IdentifierExpression& identifier) = 0;
     virtual void visit(ConstantExpression& constant) = 0;

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(ast
         LogicalOrExpression.cpp
         LoopHeader.cpp
         MemberAccess.cpp
+        InitializerListExpression.cpp
         LoopStatement.cpp
         Operator.cpp
         ParenthesizedDeclarator.cpp
@@ -104,6 +105,7 @@ add_library(ast
         LogicalOrExpression.h
         LoopHeader.h
         MemberAccess.h
+        InitializerListExpression.h
         LoopStatement.h
         Operator.h
         ParenthesizedDeclarator.h

--- a/src/ast/CSNB_Creators.cpp
+++ b/src/ast/CSNB_Creators.cpp
@@ -390,15 +390,20 @@ void assignmentExpression(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void braceInitializer(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "brace initializer is not implemented yet" };
+    context.popTerminal(); // }
+    auto elements = context.popInitializerList();
+    context.popTerminal(); // {
+    context.pushExpression(std::make_unique<InitializerListExpression>(std::move(elements)));
 }
 
 void initializerListFirst(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "brace initializer is not implemented yet" };
+    context.newInitializerList();
+    context.addInitializerElement(context.popExpression());
 }
 
 void initializerListAppend(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "brace initializer is not implemented yet" };
+    context.popTerminal(); // ,
+    context.addInitializerElement(context.popExpression());
 }
 
 void initializedDeclarator(AbstractSyntaxTreeBuilderContext& context) {

--- a/src/ast/CSNB_Internal.h
+++ b/src/ast/CSNB_Internal.h
@@ -20,6 +20,7 @@
 #include "Constant.h"
 #include "ConstantExpression.h"
 #include "MemberAccess.h"
+#include "InitializerListExpression.h"
 #include "types/Type.h"
 #include "types/TypeQuery.h"
 #include "ExpressionList.h"

--- a/src/ast/InitializerListExpression.cpp
+++ b/src/ast/InitializerListExpression.cpp
@@ -1,0 +1,33 @@
+#include "InitializerListExpression.h"
+#include "AbstractSyntaxTreeVisitor.h"
+
+namespace ast {
+
+InitializerListExpression::InitializerListExpression(std::vector<std::unique_ptr<Expression>> elements) :
+        elements { std::move(elements) } {
+}
+
+void InitializerListExpression::accept(AbstractSyntaxTreeVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+translation_unit::Context InitializerListExpression::getContext() const {
+    if (!elements.empty() && elements.front()) {
+        return elements.front()->getContext();
+    }
+    return translation_unit::Context { "", 0 };
+}
+
+const std::vector<std::unique_ptr<Expression>>& InitializerListExpression::getElements() const {
+    return elements;
+}
+
+void InitializerListExpression::visitElements(AbstractSyntaxTreeVisitor& visitor) {
+    for (auto& e : elements) {
+        if (e) {
+            e->accept(visitor);
+        }
+    }
+}
+
+} // namespace ast

--- a/src/ast/InitializerListExpression.h
+++ b/src/ast/InitializerListExpression.h
@@ -1,0 +1,26 @@
+#ifndef INITIALIZERLISTEXPRESSION_H_
+#define INITIALIZERLISTEXPRESSION_H_
+
+#include <memory>
+#include <vector>
+
+#include "Expression.h"
+
+namespace ast {
+
+// Brace-enclosed list: { e1, e2, ... } (no designators in this slice).
+class InitializerListExpression: public Expression {
+public:
+    explicit InitializerListExpression(std::vector<std::unique_ptr<Expression>> elements);
+    void accept(AbstractSyntaxTreeVisitor& visitor) override;
+    translation_unit::Context getContext() const override;
+    const std::vector<std::unique_ptr<Expression>>& getElements() const;
+    void visitElements(AbstractSyntaxTreeVisitor& visitor);
+
+private:
+    std::vector<std::unique_ptr<Expression>> elements;
+};
+
+} // namespace ast
+
+#endif

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -1,4 +1,5 @@
 #include "CodeGeneratingVisitor.h"
+#include "ast/InitializerListExpression.h"
 
 #include <stdexcept>
 
@@ -58,13 +59,30 @@ void CodeGeneratingVisitor::visit(ast::Declarator& declarator) {
 }
 
 void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
+    // File-scope variables are initialized in .data; skip children (would emit assigns with no procedure).
     if (declarator.hasInitializer() && declarator.getHolder()->isGlobal()) {
         return;
     }
     declarator.visitChildren(*this);
-    if (declarator.hasInitializer()) {
+    if (!declarator.hasInitializer()) {
+        return;
+    }
+    auto* holder = declarator.getHolder();
+    const auto& fieldStores = store_.structFieldInits(&declarator);
+    if (!fieldStores.empty()) {
+        for (const auto& field : fieldStores) {
+            instructions.push_back(std::make_unique<FieldAddress>(
+                    holder->getName(), field.offsetBytes, field.addressName, false));
+            if (field.zeroInitialize) {
+                instructions.push_back(std::make_unique<AssignConstant>("0", field.sourceName));
+            }
+            instructions.push_back(std::make_unique<LvalueAssign>(field.sourceName, field.addressName));
+        }
+        return;
+    }
+    if (declarator.getInitializer()->hasResultSymbol()) {
         instructions.push_back(std::make_unique<Assign>(
-                declarator.getInitializerHolder()->getName(), declarator.getHolder()->getName()));
+                declarator.getInitializerHolder()->getName(), holder->getName()));
     }
 }
 
@@ -87,6 +105,10 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
                 arrayAccess.getLvalue()->getName(),
                 arrayAccess.getResultSymbol()->getName()));
     }
+}
+
+void CodeGeneratingVisitor::visit(ast::InitializerListExpression& expression) {
+    expression.visitElements(*this);
 }
 
 void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {

--- a/src/codegen/CodeGeneratingVisitor.h
+++ b/src/codegen/CodeGeneratingVisitor.h
@@ -23,6 +23,7 @@ public:
 
     void visit(ast::ArrayAccess& arrayAccess) override;
     void visit(ast::MemberAccess& memberAccess) override;
+    void visit(ast::InitializerListExpression& expression) override;
     void visit(ast::FunctionCall& functionCall) override;
     void visit(ast::IdentifierExpression& identifier) override;
     void visit(ast::ConstantExpression& constant) override;

--- a/src/semantic_analyzer/CMakeLists.txt
+++ b/src/semantic_analyzer/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(semantic_analyzer
         FunctionEntry.cpp
+        InitializerLowering.cpp
         LabelEntry.cpp
         SemanticAnalysisVisitor.cpp
         SemanticAnalysisVisitor_Calls.cpp

--- a/src/semantic_analyzer/InitializerLowering.cpp
+++ b/src/semantic_analyzer/InitializerLowering.cpp
@@ -1,0 +1,100 @@
+#include "SemanticAnalysisVisitorInternal.h"
+
+#include <memory>
+
+#include "ast/InitializerListExpression.h"
+#include "types/TypeQuery.h"
+
+namespace semantic_analyzer {
+
+void SemanticAnalysisVisitor::lowerLocalInitializer(ast::InitializedDeclarator& declarator,
+        const type::Type& objectType) {
+    if (!declarator.hasInitializer()) {
+        return;
+    }
+
+    if (symbolTable.isAtFileScope()) {
+        long initValue = 0;
+        if (declarator.getInitializer()->evaluateConstant(initValue)) {
+            symbolTable.setGlobalInitializer(declarator.getName(), initValue);
+            return;
+        }
+        if (auto* list = dynamic_cast<ast::InitializerListExpression*>(declarator.getInitializer())) {
+            if (list->getElements().size() == 1 && list->getElements().front()
+                    && list->getElements().front()->evaluateConstant(initValue)) {
+                symbolTable.setGlobalInitializer(declarator.getName(), initValue);
+                return;
+            }
+            semanticError("global brace initializer is not a constant expression", declarator.getContext());
+            return;
+        }
+        semanticError("global initializer is not a constant expression", declarator.getContext());
+        return;
+    }
+
+    if (auto* list = dynamic_cast<ast::InitializerListExpression*>(declarator.getInitializer())) {
+        if (objectType.isStructure()) {
+            if (static_cast<int>(list->getElements().size()) > objectType.memberCount()) {
+                semanticError("excess elements in structure initializer", declarator.getContext());
+            }
+            std::vector<symbols::StructFieldInit> plan;
+            plan.reserve(static_cast<std::size_t>(objectType.memberCount()));
+            for (int i = 0; i < objectType.memberCount(); ++i) {
+                std::string name;
+                type::Type memberType = type::voidType();
+                int offset = 0;
+                if (!objectType.memberAt(i, name, memberType, offset)) {
+                    break;
+                }
+                if (memberType.isStructure() || memberType.isArray()) {
+                    semanticError(
+                            "aggregate member initializer requires nested braces (not implemented)",
+                            declarator.getContext());
+                }
+
+                symbols::StructFieldInit field;
+                field.offsetBytes = offset;
+                auto addr = symbolTable.createTemporarySymbol(type::pointer(memberType));
+                field.addressName = addr.getName();
+
+                const bool hasElement = i < static_cast<int>(list->getElements().size())
+                        && list->getElements()[static_cast<std::size_t>(i)]
+                        && list->getElements()[static_cast<std::size_t>(i)]->hasResultSymbol();
+                if (hasElement) {
+                    auto& element = list->getElements()[static_cast<std::size_t>(i)];
+                    typeCheck(assignSourceType(*element, memberType), memberType, declarator.getContext());
+                    field.zeroInitialize = false;
+                    field.sourceName = element->getResultSymbol()->getName();
+                } else {
+                    auto zero = symbolTable.createTemporarySymbol(memberType);
+                    field.zeroInitialize = true;
+                    field.sourceName = zero.getName();
+                }
+                plan.push_back(std::move(field));
+            }
+            annotations().setStructFieldInits(&declarator, std::move(plan));
+            return;
+        }
+        if (objectType.isArray()) {
+            semanticError("array brace initializers are not implemented", declarator.getContext());
+            return;
+        }
+        if (list->getElements().size() > 1) {
+            semanticError("excess elements in scalar initializer", declarator.getContext());
+        }
+    }
+
+    ast::Expression* initExpr = declarator.getInitializer();
+    if (auto* list = dynamic_cast<ast::InitializerListExpression*>(initExpr);
+            list && list->getElements().size() == 1) {
+        initExpr = list->getElements().front().get();
+    }
+    if (initExpr && initExpr->hasResultSymbol()) {
+        type::Type src = assignSourceType(*initExpr, objectType);
+        if (!initExpr->holdsAggregateAddress() || objectType.isPointer()) {
+            typeCheck(src, objectType, declarator.getContext());
+        }
+    }
+}
+
+} // namespace semantic_analyzer

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -1,5 +1,6 @@
 #include "SemanticAnalysisVisitorInternal.h"
 
+#include "ast/InitializerListExpression.h"
 #include "ast/IdentifierExpression.h"
 
 namespace semantic_analyzer {
@@ -50,13 +51,8 @@ void SemanticAnalysisVisitor::visit(ast::Declaration& declaration) {
                     declarator->getContext());
         } else if (symbolTable.insertSymbol(declarator->getName(), type, declarator->getContext())) {
             declarator->setHolder(symbolTable.lookup(declarator->getName()));
-            if (declarator->hasInitializer() && symbolTable.isAtFileScope()) {
-                long initValue = 0;
-                if (declarator->getInitializer()->evaluateConstant(initValue)) {
-                    symbolTable.setGlobalInitializer(declarator->getName(), initValue);
-                } else {
-                    semanticError("global initializer is not a constant expression", declarator->getContext());
-                }
+            if (declarator->hasInitializer()) {
+                lowerLocalInitializer(*declarator, type);
             }
         } else {
             semanticError(

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -26,6 +26,7 @@ public:
 
     void visit(ast::ArrayAccess& arrayAccess) override;
     void visit(ast::MemberAccess& memberAccess) override;
+    void visit(ast::InitializerListExpression& expression) override;
     void visit(ast::FunctionCall& functionCall) override;
     void visit(ast::IdentifierExpression& identifier) override;
     void visit(ast::ConstantExpression& constant) override;
@@ -90,6 +91,7 @@ public:
 
 private:
     void typeCheck(const type::Type& typeFrom, const type::Type& typeTo, const translation_unit::Context& context);
+    void lowerLocalInitializer(ast::InitializedDeclarator& declarator, const type::Type& objectType);
     void semanticError(std::string message, const translation_unit::Context& context);
     void rejectFunctionValue(const type::Type& type, const translation_unit::Context& context);
 

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -1,6 +1,7 @@
 #include "SemanticAnalysisVisitorInternal.h"
 #include "types/TypeQuery.h"
 
+#include "ast/InitializerListExpression.h"
 
 namespace semantic_analyzer {
 
@@ -45,6 +46,22 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
         indexPlan.addressTempName = addr.getName();
     }
     annotations().setAddressPlan(&arrayAccess, symbols::AddressPlan { indexPlan });
+}
+
+void SemanticAnalysisVisitor::visit(ast::InitializerListExpression& expression) {
+    expression.visitElements(*this);
+    // Nested brace lists are not yet applied to aggregate members.
+    for (const auto& element : expression.getElements()) {
+        if (dynamic_cast<ast::InitializerListExpression*>(element.get())) {
+            semanticError("nested brace initializers are not implemented", expression.getContext());
+            return;
+        }
+    }
+    // Positional list has no single scalar result; InitializedDeclarator handles it.
+    if (expression.getElements().size() == 1 && expression.getElements().front()
+            && expression.getElements().front()->hasResultSymbol()) {
+        expression.setResultSymbol(*expression.getElements().front()->getResultSymbol());
+    }
 }
 
 void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.cpp
@@ -112,6 +112,13 @@ void SemanticXmlOutputVisitor::visit(ast::MemberAccess& memberAccess) {
     closeXmlNode(nodeId);
 }
 
+void SemanticXmlOutputVisitor::visit(ast::InitializerListExpression& expression) {
+    const std::string nodeId { "initializerList" };
+    openXmlNode(nodeId);
+    expression.visitElements(*this);
+    closeXmlNode(nodeId);
+}
+
 void SemanticXmlOutputVisitor::visit(ast::FunctionCall& functionCall) {
     const std::string nodeId { "functionCall" };
     openXmlNode(nodeId);

--- a/src/semantic_analyzer/SemanticXmlOutputVisitor.h
+++ b/src/semantic_analyzer/SemanticXmlOutputVisitor.h
@@ -21,6 +21,7 @@ public:
 
     void visit(ast::ArrayAccess& arrayAccess) override;
     void visit(ast::MemberAccess& memberAccess) override;
+    void visit(ast::InitializerListExpression& expression) override;
     void visit(ast::FunctionCall& functionCall) override;
     void visit(ast::IdentifierExpression& identifier) override;
     void visit(ast::ConstantExpression& constant) override;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -140,6 +140,7 @@ add_executable(functionalTest
         functionalTest/ArraysTest.cpp
         functionalTest/TypeCastTest.cpp
         functionalTest/StructsTest.cpp
+        functionalTest/InitializersTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/functionalTest/InitializersTest.cpp
+++ b/test/src/functionalTest/InitializersTest.cpp
@@ -1,0 +1,147 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, scalarBraceInitializer) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x = { 7 };
+            printf("%d", x);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+TEST(Compiler, scalarNonBraceInitializerStillWorks) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x = 11;
+            printf("%d", x);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("11");
+}
+
+TEST(Compiler, structBraceInitializer) {
+    SourceProgram program{R"prg(
+        struct S {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct S s = { 1, 2 };
+            printf("%d %d", s.x, s.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2");
+}
+
+TEST(Compiler, structPartialBraceZeroFills) {
+    SourceProgram program{R"prg(
+        struct S {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct S s = { 5 };
+            printf("%d %d", s.x, s.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5 0");
+}
+
+TEST(Compiler, structBraceTrailingComma) {
+    SourceProgram program{R"prg(
+        struct S {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct S s = { 3, 4, };
+            printf("%d %d", s.x, s.y);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3 4");
+}
+
+TEST(Compiler, structBraceExcessElementsIsError) {
+    SourceProgram program{R"prg(
+        struct S {
+            int x;
+            int y;
+        };
+
+        int main() {
+            struct S s = { 1, 2, 3 };
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("excess elements");
+}
+
+TEST(Compiler, scalarBraceExcessElementsIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x = { 1, 2 };
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("excess elements");
+}
+
+TEST(Compiler, nestedBraceInitializerNotImplemented) {
+    SourceProgram program{R"prg(
+        struct Inner {
+            int a;
+            int b;
+        };
+        struct Outer {
+            struct Inner in;
+            int w;
+        };
+
+        int main() {
+            struct Outer o = { { 1, 2 }, 3 };
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("nested brace");
+}
+
+TEST(Compiler, flatInitOfStructMemberIsError) {
+    SourceProgram program{R"prg(
+        struct Inner {
+            int a;
+            int b;
+        };
+        struct Outer {
+            struct Inner in;
+            int w;
+        };
+
+        int main() {
+            struct Outer o = { 1, 2 };
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("aggregate member");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
- Parse `{ e1, e2, … }` into `InitializerListExpression`
- Local scalar braces assign the single element; local struct braces store members by offset via `FieldAddress`
- Functional `InitializersTest`

## Stack
PR E of remaining track. Base: #73 (structs). Next: function pointers.

## Test plan
- [x] Full local `ctest`
- [ ] CI green / coverage non-regression