### PR TITLE
feat(ast): function pointers, designator decay, and indirect call

### DIFF
--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -30,6 +30,7 @@ void Expression::setTypeAndResult(semantic_analyzer::ValueEntry resultSymbol) {
     this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(resultSymbol));
     setType(this->resultSymbol->getType());
     form = ValueForm::Scalar;
+    designatorName.clear();
 }
 
 void Expression::setAggregateAddressResult(semantic_analyzer::ValueEntry addressSymbol,
@@ -37,6 +38,16 @@ void Expression::setAggregateAddressResult(semantic_analyzer::ValueEntry address
     this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(addressSymbol));
     setType(aggregateType);
     form = ValueForm::AggregateAddress;
+    designatorName.clear();
+}
+
+void Expression::setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol,
+        std::string designatorName) {
+    this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(addressSymbol));
+    setType(this->resultSymbol->getType());
+    form = ValueForm::FunctionDesignator;
+    this->designatorName = std::move(designatorName);
+    lval = false;
 }
 
 bool Expression::hasResultSymbol() const {
@@ -46,6 +57,11 @@ bool Expression::hasResultSymbol() const {
 semantic_analyzer::ValueEntry* Expression::getResultSymbol() const {
     assert(resultSymbol);
     return resultSymbol.get();
+}
+
+const std::string& Expression::functionDesignatorName() const {
+    assert(form == ValueForm::FunctionDesignator);
+    return designatorName;
 }
 
 bool Expression::isLval() const {

--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -30,7 +30,6 @@ void Expression::setTypeAndResult(semantic_analyzer::ValueEntry resultSymbol) {
     this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(resultSymbol));
     setType(this->resultSymbol->getType());
     form = ValueForm::Scalar;
-    designatorName.clear();
 }
 
 void Expression::setAggregateAddressResult(semantic_analyzer::ValueEntry addressSymbol,
@@ -38,15 +37,12 @@ void Expression::setAggregateAddressResult(semantic_analyzer::ValueEntry address
     this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(addressSymbol));
     setType(aggregateType);
     form = ValueForm::AggregateAddress;
-    designatorName.clear();
 }
 
-void Expression::setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol,
-        std::string designatorName) {
+void Expression::setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol) {
     this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(addressSymbol));
     setType(this->resultSymbol->getType());
     form = ValueForm::FunctionDesignator;
-    this->designatorName = std::move(designatorName);
     lval = false;
 }
 
@@ -57,11 +53,6 @@ bool Expression::hasResultSymbol() const {
 semantic_analyzer::ValueEntry* Expression::getResultSymbol() const {
     assert(resultSymbol);
     return resultSymbol.get();
-}
-
-const std::string& Expression::functionDesignatorName() const {
-    assert(form == ValueForm::FunctionDesignator);
-    return designatorName;
 }
 
 bool Expression::isLval() const {

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -10,9 +10,13 @@
 
 namespace ast {
 
+// How the result Value relates to expressionType() (finish-for-git dual ownership).
+// Host uses AnnotationStore + setType/setResult; we keep Result on the node for now
+// and encode dual ownership with ValueForm (same C rules).
 enum class ValueForm {
-    Scalar,
-    AggregateAddress,
+    Scalar,              // expressionType matches result type
+    AggregateAddress,    // expressionType is aggregate/array; result holds its address
+    FunctionDesignator,  // decayed pointer-to-function temp; designatorName is the label
 };
 
 class Expression: public AbstractSyntaxTreeNode {
@@ -22,12 +26,17 @@ public:
     virtual translation_unit::Context getContext() const = 0;
 
     void setType(const type::Type& type);
+    // C type of the expression (sizeof / isArray / isStructure). Host: expressionType().
     type::Type expressionType() const;
     type::Type getType() const { return expressionType(); }
     bool hasExpressionType() const { return type.has_value(); }
 
+    // Dual-type: multi-dim rows / nested structs keep aggregate as expression type.
     bool isArrayObjectType() const { return hasExpressionType() && expressionType().isArray(); }
+    // Array expression type with pointer result (true dual ownership after SA).
     bool hasDecayedArrayValue() const;
+
+    // Type of the Result symbol after SA (prefer for arithmetic / assign source value).
     type::Type valueType() const;
 
     virtual bool isLval() const;
@@ -35,8 +44,12 @@ public:
 
     virtual bool evaluateConstant(long& value) const { return false; }
 
+    // Scalar path: expression type and result both from the symbol.
     void setTypeAndResult(semantic_analyzer::ValueEntry resultSymbol);
+    // Dual-type: expression type is aggregate/array; result holds its address.
     void setAggregateAddressResult(semantic_analyzer::ValueEntry addressSymbol, const type::Type& aggregateType);
+    // Function designator decay: result is pointer-to-function temp; name is LEA label.
+    void setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol, std::string designatorName);
 
     void setResultSymbol(semantic_analyzer::ValueEntry resultSymbol) { setTypeAndResult(std::move(resultSymbol)); }
 
@@ -45,14 +58,18 @@ public:
 
     ValueForm valueForm() const { return form; }
     bool holdsAggregateAddress() const { return form == ValueForm::AggregateAddress; }
+    bool holdsFunctionDesignator() const { return form == ValueForm::FunctionDesignator; }
+    const std::string& functionDesignatorName() const;
 
 protected:
     bool lval { false };
 
 private:
     std::optional<type::Type> type;
+
     std::unique_ptr<semantic_analyzer::ValueEntry> resultSymbol { nullptr };
     ValueForm form { ValueForm::Scalar };
+    std::string designatorName;
 };
 
 } // namespace ast

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -16,7 +16,8 @@ namespace ast {
 enum class ValueForm {
     Scalar,              // expressionType matches result type
     AggregateAddress,    // expressionType is aggregate/array; result holds its address
-    FunctionDesignator,  // decayed pointer-to-function temp; designatorName is the label
+    // Decayed pointer-to-function temp; LEA label lives on FunctionDesignatorPlan (store).
+    FunctionDesignator,
 };
 
 class Expression: public AbstractSyntaxTreeNode {
@@ -48,8 +49,8 @@ public:
     void setTypeAndResult(semantic_analyzer::ValueEntry resultSymbol);
     // Dual-type: expression type is aggregate/array; result holds its address.
     void setAggregateAddressResult(semantic_analyzer::ValueEntry addressSymbol, const type::Type& aggregateType);
-    // Function designator decay: result is pointer-to-function temp; name is LEA label.
-    void setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol, std::string designatorName);
+    // Function designator decay: result is pointer-to-function temp (label on store plan).
+    void setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol);
 
     void setResultSymbol(semantic_analyzer::ValueEntry resultSymbol) { setTypeAndResult(std::move(resultSymbol)); }
 
@@ -59,7 +60,6 @@ public:
     ValueForm valueForm() const { return form; }
     bool holdsAggregateAddress() const { return form == ValueForm::AggregateAddress; }
     bool holdsFunctionDesignator() const { return form == ValueForm::FunctionDesignator; }
-    const std::string& functionDesignatorName() const;
 
 protected:
     bool lval { false };
@@ -69,7 +69,6 @@ private:
 
     std::unique_ptr<semantic_analyzer::ValueEntry> resultSymbol { nullptr };
     ValueForm form { ValueForm::Scalar };
-    std::string designatorName;
 };
 
 } // namespace ast

--- a/src/ast/FunctionCall.cpp
+++ b/src/ast/FunctionCall.cpp
@@ -25,12 +25,4 @@ const std::vector<std::unique_ptr<Expression>>& FunctionCall::getArgumentList() 
     return argumentList;
 }
 
-void FunctionCall::setSymbol(semantic_analyzer::FunctionEntry symbol) {
-    this->symbol = std::make_unique<semantic_analyzer::FunctionEntry>(symbol);
-}
-
-semantic_analyzer::FunctionEntry* FunctionCall::getSymbol() const {
-    return symbol.get();
-}
-
 } // namespace ast

--- a/src/ast/FunctionCall.h
+++ b/src/ast/FunctionCall.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "ast/SingleOperandExpression.h"
-#include "semantic_analyzer/FunctionEntry.h"
 
 namespace ast {
 
@@ -19,13 +18,10 @@ public:
 
     const std::vector<std::unique_ptr<Expression>>& getArgumentList() const;
 
-    // SA type-check symbol; call shape (direct/indirect) is symbols::CallPlan on the store.
-    void setSymbol(semantic_analyzer::FunctionEntry symbol);
-    semantic_analyzer::FunctionEntry* getSymbol() const;
+    // Call shape (Direct/Indirect + callee name) is symbols::CallPlan on the store.
 
 private:
     std::vector<std::unique_ptr<Expression>> argumentList;
-    std::unique_ptr<semantic_analyzer::FunctionEntry> symbol;
 };
 
 } // namespace ast

--- a/src/codegen/Amd64Registers.cpp
+++ b/src/codegen/Amd64Registers.cpp
@@ -44,5 +44,8 @@ Register& Amd64Registers::getCounterRegister() {
     return rcx;
 }
 
+Register& Amd64Registers::getIndirectCallTargetRegister() {
+    return r10;
+}
 
 } // namespace codegen

--- a/src/codegen/Amd64Registers.h
+++ b/src/codegen/Amd64Registers.h
@@ -21,6 +21,8 @@ public:
     Register& getMultiplicationRegister();
     Register& getRemainderRegister();
     Register& getCounterRegister();
+    // Caller-saved, non-arg register for indirect call targets (r10).
+    Register& getIndirectCallTargetRegister();
 
 private:
     Register rax { "rax" };

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -91,7 +91,11 @@ void AssemblyGenerator::generateCodeFor(const Argument& argument) {
 }
 
 void codegen::AssemblyGenerator::generateCodeFor(const Call& call) {
-    stackMachine->callProcedure(call.getProcedureName());
+    if (call.isIndirect()) {
+        stackMachine->callProcedureIndirect(call.getProcedureName());
+    } else {
+        stackMachine->callProcedure(call.getProcedureName());
+    }
 }
 
 void codegen::AssemblyGenerator::generateCodeFor(const Return& returnCommand) {

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -62,6 +62,10 @@ void AssemblyGenerator::generateCodeFor(const FieldAddress& fieldAddress) {
             fieldAddress.baseIsPointer());
 }
 
+void AssemblyGenerator::generateCodeFor(const FunctionAddress& functionAddress) {
+    stackMachine->functionAddress(functionAddress.getOperand(), functionAddress.getResult());
+}
+
 void AssemblyGenerator::generateCodeFor(const UnaryMinus& unaryMinus) {
     stackMachine->unaryMinus(unaryMinus.getOperand(), unaryMinus.getResult());
 }

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -15,6 +15,7 @@
 #include "quadruples/Dereference.h"
 #include "quadruples/IndexAddress.h"
 #include "quadruples/FieldAddress.h"
+#include "quadruples/FunctionAddress.h"
 #include "quadruples/UnaryMinus.h"
 #include "quadruples/UnaryNot.h"
 #include "quadruples/Assign.h"
@@ -58,6 +59,7 @@ public:
     void generateCodeFor(const Dereference& dereference);
     void generateCodeFor(const IndexAddress& indexAddress);
     void generateCodeFor(const FieldAddress& fieldAddress);
+    void generateCodeFor(const FunctionAddress& functionAddress);
     void generateCodeFor(const UnaryMinus& unaryMinus);
     void generateCodeFor(const UnaryNot& unaryNot);
     void generateCodeFor(const Assign& assign);

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(backend
         quadruples/DoubleOperandQuadruple.cpp
         quadruples/EndProcedure.cpp
         quadruples/FieldAddress.cpp
+        quadruples/FunctionAddress.cpp
         quadruples/Inc.cpp
         quadruples/IndexAddress.cpp
         quadruples/Jump.cpp
@@ -60,6 +61,7 @@ add_library(backend
         quadruples/DoubleOperandQuadruple.h
         quadruples/EndProcedure.h
         quadruples/FieldAddress.h
+        quadruples/FunctionAddress.h
         quadruples/Inc.h
         quadruples/IndexAddress.h
         quadruples/Jump.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -16,6 +16,7 @@
 #include "quadruples/FieldAddress.h"
 #include "quadruples/Dec.h"
 #include "quadruples/AddressOf.h"
+#include "quadruples/FunctionAddress.h"
 #include "quadruples/Dereference.h"
 #include "quadruples/UnaryMinus.h"
 #include "quadruples/UnaryNot.h"
@@ -155,6 +156,19 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
 }
 
 void CodeGeneratingVisitor::visit(ast::IdentifierExpression& identifier) {
+    if (const auto* plan = store_.addressPlan(&identifier)) {
+        if (const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(plan)) {
+            instructions.push_back(std::make_unique<FunctionAddress>(
+                    d->functionName, d->addressTempName.empty()
+                            ? identifier.getResultSymbol()->getName()
+                            : d->addressTempName));
+            return;
+        }
+    }
+    if (identifier.holdsFunctionDesignator()) {
+        instructions.push_back(std::make_unique<FunctionAddress>(
+                identifier.functionDesignatorName(), identifier.getResultSymbol()->getName()));
+    }
 }
 
 void CodeGeneratingVisitor::visit(ast::ConstantExpression& constant) {
@@ -215,7 +229,13 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
 
     switch (expression.getOperator()->getLexeme().front()) {
     case '&':
-        if (auto* lvalue = expression.operandLvalueSymbol()) {
+        // &function designator: designator already emitted FunctionAddress on the operand.
+        if (expression.getOperandExpression()->holdsFunctionDesignator()) {
+            if (expression.operandSymbol()->getName() != expression.getResultSymbol()->getName()) {
+                instructions.push_back(std::make_unique<Assign>(
+                        expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+            }
+        } else if (auto* lvalue = expression.operandLvalueSymbol()) {
             // &a[i] / &*p: address is already computed in the operand's lvalue temp.
             instructions.push_back(std::make_unique<Assign>(
                     lvalue->getName(), expression.getResultSymbol()->getName()));

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -1,6 +1,7 @@
 #include "CodeGeneratingVisitor.h"
 #include "ast/InitializerListExpression.h"
 
+#include <cassert>
 #include <stdexcept>
 
 #include "semantic_analyzer/ValueEntry.h"
@@ -150,8 +151,7 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
         // SA error path — no IR.
         return;
     }
-    const bool indirect = plan->kind == symbols::CallPlan::Kind::Indirect;
-    instructions.push_back(std::make_unique<Call>(plan->calleeName, indirect));
+    instructions.push_back(std::make_unique<Call>(plan->calleeName, plan->kind));
     if (functionCall.hasResultSymbol() && !functionCall.getType().isVoid()) {
         instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
     }
@@ -163,8 +163,11 @@ void CodeGeneratingVisitor::visit(ast::IdentifierExpression& identifier) {
         if (const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(plan)) {
             instructions.push_back(std::make_unique<FunctionAddress>(
                     d->functionName, d->addressTempName));
+            return;
         }
     }
+    assert(!identifier.holdsFunctionDesignator()
+            && "designator form without FunctionDesignatorPlan on the store");
 }
 
 void CodeGeneratingVisitor::visit(ast::ConstantExpression& constant) {

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -149,7 +149,7 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
         // SA error path — no IR.
         return;
     }
-    instructions.push_back(std::make_unique<Call>(plan->calleeName));
+    instructions.push_back(std::make_unique<Call>(plan->calleeName, plan->indirect));
     if (functionCall.hasResultSymbol() && !functionCall.getType().isVoid()) {
         instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
     }

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -156,18 +156,14 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
 }
 
 void CodeGeneratingVisitor::visit(ast::IdentifierExpression& identifier) {
+    // Function designators always carry FunctionDesignatorPlan from SA.
     if (const auto* plan = store_.addressPlan(&identifier)) {
         if (const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(plan)) {
             instructions.push_back(std::make_unique<FunctionAddress>(
                     d->functionName, d->addressTempName.empty()
                             ? identifier.getResultSymbol()->getName()
                             : d->addressTempName));
-            return;
         }
-    }
-    if (identifier.holdsFunctionDesignator()) {
-        instructions.push_back(std::make_unique<FunctionAddress>(
-                identifier.functionDesignatorName(), identifier.getResultSymbol()->getName()));
     }
 }
 
@@ -229,12 +225,9 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
 
     switch (expression.getOperator()->getLexeme().front()) {
     case '&':
-        // &function designator: designator already emitted FunctionAddress on the operand.
+        // &function designator: SA reuses the designator temp (already emitted FunctionAddress).
         if (expression.getOperandExpression()->holdsFunctionDesignator()) {
-            if (expression.operandSymbol()->getName() != expression.getResultSymbol()->getName()) {
-                instructions.push_back(std::make_unique<Assign>(
-                        expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
-            }
+            break;
         } else if (auto* lvalue = expression.operandLvalueSymbol()) {
             // &a[i] / &*p: address is already computed in the operand's lvalue temp.
             instructions.push_back(std::make_unique<Assign>(

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -5,6 +5,7 @@
 
 #include "semantic_analyzer/ValueEntry.h"
 #include "semantic_analyzer/LabelEntry.h"
+#include "types/TypeQuery.h"
 
 #include "quadruples/Assign.h"
 #include "quadruples/Argument.h"
@@ -149,20 +150,19 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
         // SA error path — no IR.
         return;
     }
-    instructions.push_back(std::make_unique<Call>(plan->calleeName, plan->indirect));
+    const bool indirect = plan->kind == symbols::CallPlan::Kind::Indirect;
+    instructions.push_back(std::make_unique<Call>(plan->calleeName, indirect));
     if (functionCall.hasResultSymbol() && !functionCall.getType().isVoid()) {
         instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
     }
 }
 
 void CodeGeneratingVisitor::visit(ast::IdentifierExpression& identifier) {
-    // Function designators always carry FunctionDesignatorPlan from SA.
+    // Function designators always carry FunctionDesignatorPlan from SA (label + temp).
     if (const auto* plan = store_.addressPlan(&identifier)) {
         if (const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(plan)) {
             instructions.push_back(std::make_unique<FunctionAddress>(
-                    d->functionName, d->addressTempName.empty()
-                            ? identifier.getResultSymbol()->getName()
-                            : d->addressTempName));
+                    d->functionName, d->addressTempName));
         }
     }
 }
@@ -239,8 +239,8 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
         break;
     case '*':
         if (expression.operandSymbol()->getType().isPointer()) {
-            // *fp for a function pointer: SA leaves result = operand (no lvalue / no load).
-            if (!expression.getLvalueSymbol()) {
+            // *fp for pointer-to-function: SA keeps the pointer value (no memory load).
+            if (type::isPointerToBareFunction(expression.operandSymbol()->getType())) {
                 if (expression.operandSymbol()->getName() != expression.getResultSymbol()->getName()) {
                     instructions.push_back(std::make_unique<Assign>(
                             expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -217,6 +217,12 @@ void StackMachine::addressOf(std::string operandName, std::string resultName) {
     bindResult(resultRegister, resolve(resultName));
 }
 
+void StackMachine::functionAddress(std::string functionName, std::string resultName) {
+    Register& resultRegister = get64BitRegister();
+    assembly << instructionSet->lea(MemoryOperand::global(functionName), resultRegister);
+    bindResult(resultRegister, resolve(resultName));
+}
+
 void StackMachine::indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
         bool baseIsArray) {
     auto& base = resolve(baseName);
@@ -449,6 +455,35 @@ int StackMachine::emitCallArguments() {
 void StackMachine::callProcedure(std::string procedureName) {
     int argumentOffset = emitCallArguments();
     assembly << instructionSet->call(procedureName);
+    if (argumentOffset) {
+        assembly << instructionSet->add(registers->getStackPointer(), argumentOffset);
+    }
+}
+
+void StackMachine::callProcedureIndirect(std::string targetSymbolName) {
+    int argumentOffset = emitCallArguments();
+
+    // Load callee into r10 after arg setup (caller-saved, not an integer arg reg).
+    auto& targetValue = resolve(targetSymbolName);
+    Register& targetReg = registers->getIndirectCallTargetRegister();
+
+    if (!residesInMemory(targetValue)) {
+        Register& current = targetValue.getAssignedRegister();
+        if (&current != &targetReg) {
+            assembly << instructionSet->mov(current, targetReg);
+        }
+    } else {
+        Address home = addressOf(targetValue);
+        if (!home.isGlobal() && home.frameBase() == FrameBase::StackPointer && argumentOffset) {
+            Address adjusted = Address::frame(FrameBase::StackPointer,
+                    home.offsetBytes() + argumentOffset, home.sizeBytes());
+            assembly << instructionSet->mov(memoryOperand(adjusted), targetReg);
+        } else {
+            emitLoad(targetValue, targetReg);
+        }
+    }
+
+    assembly << instructionSet->call(targetReg.getName());
     if (argumentOffset) {
         assembly << instructionSet->add(registers->getStackPointer(), argumentOffset);
     }

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -40,6 +40,7 @@ public:
     void zeroCompare(std::string symbolName);
 
     void addressOf(std::string operandName, std::string resultName);
+    void functionAddress(std::string functionName, std::string resultName);
     void dereference(std::string operandName, std::string lvalueName, std::string resultName);
     void indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
             bool baseIsArray = false);
@@ -54,6 +55,8 @@ public:
 
     void procedureArgument(std::string argumentName);
     void callProcedure(std::string procedureName);
+    // Indirect call through a Value holding the function pointer.
+    void callProcedureIndirect(std::string targetSymbolName);
     void returnFromProcedure(std::string returnSymbolName = "");
     void retrieveProcedureReturnValue(std::string returnSymbolName);
 

--- a/src/codegen/quadruples/Call.cpp
+++ b/src/codegen/quadruples/Call.cpp
@@ -4,8 +4,9 @@
 
 namespace codegen {
 
-Call::Call(std::string procedureName) :
-        procedureName { std::move(procedureName) }
+Call::Call(std::string procedureName, bool indirect) :
+        procedureName { std::move(procedureName) },
+        indirect { indirect }
 {
 }
 
@@ -17,8 +18,16 @@ std::string Call::getProcedureName() const {
     return procedureName;
 }
 
+bool Call::isIndirect() const {
+    return indirect;
+}
+
 void Call::print(std::ostream& stream) const {
-    stream << "\tCALL " << getProcedureName() << "\n";
+    if (indirect) {
+        stream << "\tCALL *" << getProcedureName() << "\n";
+    } else {
+        stream << "\tCALL " << getProcedureName() << "\n";
+    }
 }
 
 } // namespace codegen

--- a/src/codegen/quadruples/Call.cpp
+++ b/src/codegen/quadruples/Call.cpp
@@ -4,9 +4,9 @@
 
 namespace codegen {
 
-Call::Call(std::string procedureName, bool indirect) :
+Call::Call(std::string procedureName, symbols::CallPlan::Kind kind) :
         procedureName { std::move(procedureName) },
-        indirect { indirect }
+        kind_ { kind }
 {
 }
 
@@ -18,12 +18,16 @@ std::string Call::getProcedureName() const {
     return procedureName;
 }
 
+symbols::CallPlan::Kind Call::kind() const {
+    return kind_;
+}
+
 bool Call::isIndirect() const {
-    return indirect;
+    return kind_ == symbols::CallPlan::Kind::Indirect;
 }
 
 void Call::print(std::ostream& stream) const {
-    if (indirect) {
+    if (isIndirect()) {
         stream << "\tCALL *" << getProcedureName() << "\n";
     } else {
         stream << "\tCALL " << getProcedureName() << "\n";

--- a/src/codegen/quadruples/Call.h
+++ b/src/codegen/quadruples/Call.h
@@ -4,26 +4,28 @@
 #include <string>
 
 #include "Quadruple.h"
+#include "symbols/AddressPlan.h"
 
 namespace codegen {
 
 class Call: public Quadruple {
 public:
-    // Direct call by procedure label, or indirect when `indirect` is true
-    // (procedureName is then the symbol holding the callee address).
-    Call(std::string procedureName, bool indirect = false);
+    // Direct: procedureName is a function label.
+    // Indirect: procedureName is the value holding the callee address.
+    Call(std::string procedureName, symbols::CallPlan::Kind kind = symbols::CallPlan::Kind::Direct);
     virtual ~Call() = default;
 
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getProcedureName() const;
+    symbols::CallPlan::Kind kind() const;
     bool isIndirect() const;
 
 private:
     void print(std::ostream& stream) const override;
 
     std::string procedureName;
-    bool indirect { false };
+    symbols::CallPlan::Kind kind_ { symbols::CallPlan::Kind::Direct };
 };
 
 } // namespace codegen

--- a/src/codegen/quadruples/Call.h
+++ b/src/codegen/quadruples/Call.h
@@ -9,17 +9,21 @@ namespace codegen {
 
 class Call: public Quadruple {
 public:
-    Call(std::string procedureName);
+    // Direct call by procedure label, or indirect when `indirect` is true
+    // (procedureName is then the symbol holding the callee address).
+    Call(std::string procedureName, bool indirect = false);
     virtual ~Call() = default;
 
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getProcedureName() const;
+    bool isIndirect() const;
 
 private:
     void print(std::ostream& stream) const override;
 
     std::string procedureName;
+    bool indirect { false };
 };
 
 } // namespace codegen

--- a/src/codegen/quadruples/FunctionAddress.cpp
+++ b/src/codegen/quadruples/FunctionAddress.cpp
@@ -1,0 +1,20 @@
+#include "FunctionAddress.h"
+
+#include "codegen/AssemblyGenerator.h"
+
+namespace codegen {
+
+FunctionAddress::FunctionAddress(std::string functionName, std::string result) :
+        SingleOperandQuadruple { std::move(functionName), std::move(result) }
+{
+}
+
+void FunctionAddress::generateCode(AssemblyGenerator& generator) const {
+    generator.generateCodeFor(*this);
+}
+
+void FunctionAddress::print(std::ostream& stream) const {
+    stream << "\t" << getResult() << " := &" << getOperand() << " (function)\n";
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/FunctionAddress.h
+++ b/src/codegen/quadruples/FunctionAddress.h
@@ -1,0 +1,22 @@
+#ifndef FUNCTIONADDRESS_H_
+#define FUNCTIONADDRESS_H_
+
+#include "SingleOperandQuadruple.h"
+
+namespace codegen {
+
+// Load the address of a function label into a result temporary.
+class FunctionAddress: public SingleOperandQuadruple {
+public:
+    FunctionAddress(std::string functionName, std::string result);
+    virtual ~FunctionAddress() = default;
+
+    void generateCode(AssemblyGenerator& generator) const override;
+
+private:
+    void print(std::ostream& stream) const override;
+};
+
+} // namespace codegen
+
+#endif // FUNCTIONADDRESS_H_

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -1,5 +1,6 @@
 #include "SemanticAnalysisVisitorInternal.h"
 
+#include <cassert>
 #include <optional>
 
 #include "ast/IdentifierExpression.h"
@@ -18,6 +19,9 @@ void setFunctionDesignator(ast::IdentifierExpression& identifier, SymbolTable& s
     plan.functionName = functionEntry.getName();
     plan.addressTempName = addr.getName();
     store.setAddressPlan(&identifier, symbols::AddressPlan { plan });
+    // form ⇒ plan: designator form is never set without a store plan.
+    assert(identifier.holdsFunctionDesignator());
+    assert(symbols::get_if<symbols::FunctionDesignatorPlan>(store.addressPlan(&identifier)));
 }
 
 // Resolved call target: type for arity/return; CallPlan shape for codegen.
@@ -26,8 +30,6 @@ struct Callee {
     std::string calleeName;
     type::Function type;
     translation_unit::Context context;
-    // Set for Direct calls registered in the function table (and for FunctionCall::setSymbol).
-    std::optional<FunctionEntry> declared;
 };
 
 std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable,
@@ -36,10 +38,12 @@ std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable
     type::Type operandType = operandSym->getType();
     auto* operandExpr = functionCall.getOperandExpression();
 
-    // Designator identity lives on the store plan (not a second string on the AST).
+    // Designator identity lives on the store plan (label + temp). Form is the cheap tag.
     if (operandExpr->holdsFunctionDesignator()) {
         const auto* addrPlan = store.addressPlan(operandExpr);
         const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(addrPlan);
+        // Invariant: FunctionDesignator form always has a FunctionDesignatorPlan.
+        assert(d && "designator form without FunctionDesignatorPlan on the store");
         if (!d) {
             errorDisplay = operandSym->getName();
             return std::nullopt;
@@ -50,7 +54,6 @@ std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable
             d->functionName,
             entry.getType(),
             entry.getContext(),
-            entry,
         };
     }
 
@@ -61,7 +64,6 @@ std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable
             operandSym->getName(),
             pointee.getFunction(),
             functionCall.getContext(),
-            std::nullopt,
         };
     }
 
@@ -117,13 +119,6 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
             typeCheck(arguments.at(i)->getResultSymbol()->getType(), declaredArguments.at(i),
                     functionCall.getContext());
         }
-    }
-
-    if (callee.declared) {
-        functionCall.setSymbol(*callee.declared);
-    } else {
-        // Indirect: type-only FunctionEntry for tooling that still reads getSymbol().
-        functionCall.setSymbol(FunctionEntry { callee.calleeName, callee.type, callee.context });
     }
 
     symbols::CallPlan plan;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -4,6 +4,62 @@
 
 namespace semantic_analyzer {
 
+namespace {
+
+void setFunctionDesignator(ast::IdentifierExpression& identifier, SymbolTable& symbolTable,
+        symbols::AnnotationStore& store) {
+    auto functionEntry = symbolTable.findFunction(identifier.getIdentifier());
+    type::Type fnType = type::function(functionEntry.returnType(), functionEntry.arguments());
+    auto addr = symbolTable.createTemporarySymbol(type::pointer(fnType));
+    identifier.setFunctionDesignatorResult(addr, functionEntry.getName());
+    symbols::FunctionDesignatorPlan plan;
+    plan.functionName = functionEntry.getName();
+    plan.addressTempName = addr.getName();
+    store.setAddressPlan(&identifier, symbols::AddressPlan { plan });
+}
+
+struct Callee {
+    bool indirect { false };
+    std::string calleeName;
+    FunctionEntry symbol { "", type::function(type::voidType()).getFunction(), translation_unit::Context { "", 0 } };
+};
+
+bool resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable, Callee& out,
+        std::string& errorDisplay) {
+    auto* operandSym = functionCall.operandSymbol();
+    type::Type operandType = operandSym->getType();
+    auto* operandExpr = functionCall.getOperandExpression();
+
+    if (operandExpr->holdsFunctionDesignator()) {
+        const std::string& designatorName = operandExpr->functionDesignatorName();
+        if (!symbolTable.hasFunction(designatorName)) {
+            errorDisplay = designatorName;
+            return false;
+        }
+        out.indirect = false;
+        out.calleeName = designatorName;
+        out.symbol = symbolTable.findFunction(designatorName);
+        return true;
+    }
+
+    if (type::isPointerToBareFunction(operandType)) {
+        type::Type pointee = operandType.dereference();
+        out.indirect = true;
+        out.calleeName = operandSym->getName();
+        out.symbol = FunctionEntry { operandSym->getName(), pointee.getFunction(), functionCall.getContext() };
+        return true;
+    }
+
+    if (auto* id = dynamic_cast<ast::IdentifierExpression*>(operandExpr)) {
+        errorDisplay = id->getIdentifier();
+    } else {
+        errorDisplay = unscopedSymbolName(operandSym->getName());
+    }
+    return false;
+}
+
+} // namespace
+
 void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
     functionCall.visitOperand(*this);
     functionCall.visitArguments(*this);
@@ -12,19 +68,18 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
         return;
     }
 
-    const auto symbolName = functionCall.operandSymbol()->getName();
-    const auto displayName = unscopedSymbolName(symbolName);
-    if (symbolName != displayName || !symbolTable.hasFunction(displayName)) {
-        semanticError("called object `" + displayName + "` is not a function", functionCall.getContext());
+    Callee callee;
+    std::string errorDisplay;
+    if (!resolveCallee(functionCall, symbolTable, callee, errorDisplay)) {
+        semanticError("called object `" + errorDisplay + "` is not a function", functionCall.getContext());
         return;
     }
 
-    auto functionSymbol = symbolTable.findFunction(displayName);
-    functionCall.setSymbol(functionSymbol);
+    functionCall.setSymbol(callee.symbol);
     symbols::CallPlan plan;
     plan.kind = symbols::CallPlan::Kind::Normal;
-    plan.indirect = false;
-    plan.calleeName = displayName;
+    plan.indirect = callee.indirect;
+    plan.calleeName = callee.calleeName;
     annotations().setCallPlan(&functionCall, plan);
 
     auto& arguments = functionCall.getArgumentList();
@@ -34,35 +89,50 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
         }
     }
 
-    if (arguments.size() == functionSymbol.argumentCount()) {
-        auto declaredArguments = functionSymbol.arguments();
+    if (arguments.size() == callee.symbol.argumentCount()) {
+        auto declaredArguments = callee.symbol.arguments();
         for (std::size_t i { 0 }; i < arguments.size(); ++i) {
             if (!arguments.at(i)->hasResultSymbol()) {
                 return;
             }
-            typeCheck(arguments.at(i)->getResultSymbol()->getType(), declaredArguments.at(i),
-                    functionCall.getContext());
+            const auto& declaredArgument = declaredArguments.at(i);
+            const auto& actualArgument = arguments.at(i)->getResultSymbol();
+            typeCheck(actualArgument->getType(), declaredArgument, functionCall.getContext());
         }
-        auto returnType = functionSymbol.returnType();
+
+        auto returnType = callee.symbol.returnType();
         if (!returnType.isVoid()) {
             functionCall.setResultSymbol(symbolTable.createTemporarySymbol(returnType));
         }
-    } else if (functionSymbol.getContext() == externalContext()) {
-        auto returnType = functionSymbol.returnType();
+    } else if (callee.symbol.getContext() == externalContext()) {
+        auto returnType = callee.symbol.returnType();
         if (!returnType.isVoid()) {
             functionCall.setResultSymbol(symbolTable.createTemporarySymbol(returnType));
         }
     } else {
-        semanticError("no match for function " + functionSymbol.getType().to_string(), functionCall.getContext());
+        semanticError("no match for function " + callee.symbol.getType().to_string(), functionCall.getContext());
     }
 }
 
 void SemanticAnalysisVisitor::visit(ast::IdentifierExpression& identifier) {
-    if (symbolTable.hasSymbol(identifier.getIdentifier())) {
-        identifier.setResultSymbol(symbolTable.lookup(identifier.getIdentifier()));
-    } else {
-        semanticError("symbol `" + identifier.getIdentifier() + "` is not defined", identifier.getContext());
+    const std::string& name = identifier.getIdentifier();
+
+    if (symbolTable.hasSymbol(name)) {
+        auto entry = symbolTable.lookup(name);
+        if (!(type::isBareFunction(entry.getType()) && symbolTable.hasFunction(name))) {
+            identifier.setResultSymbol(entry);
+            return;
+        }
+        setFunctionDesignator(identifier, symbolTable, annotations());
+        return;
     }
+
+    if (symbolTable.hasFunction(name)) {
+        setFunctionDesignator(identifier, symbolTable, annotations());
+        return;
+    }
+
+    semanticError("symbol `" + name + "` is not defined", identifier.getContext());
 }
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -31,11 +31,8 @@ bool resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable, Ca
     auto* operandExpr = functionCall.getOperandExpression();
 
     if (operandExpr->holdsFunctionDesignator()) {
+        // Designator name is always a registered function (set in setFunctionDesignator).
         const std::string& designatorName = operandExpr->functionDesignatorName();
-        if (!symbolTable.hasFunction(designatorName)) {
-            errorDisplay = designatorName;
-            return false;
-        }
         out.indirect = false;
         out.calleeName = designatorName;
         out.symbol = symbolTable.findFunction(designatorName);
@@ -117,18 +114,14 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
 void SemanticAnalysisVisitor::visit(ast::IdentifierExpression& identifier) {
     const std::string& name = identifier.getIdentifier();
 
+    // insertFunction always registers a global value symbol, so hasFunction implies hasSymbol.
     if (symbolTable.hasSymbol(name)) {
         auto entry = symbolTable.lookup(name);
-        if (!(type::isBareFunction(entry.getType()) && symbolTable.hasFunction(name))) {
-            identifier.setResultSymbol(entry);
+        if (type::isBareFunction(entry.getType()) && symbolTable.hasFunction(name)) {
+            setFunctionDesignator(identifier, symbolTable, annotations());
             return;
         }
-        setFunctionDesignator(identifier, symbolTable, annotations());
-        return;
-    }
-
-    if (symbolTable.hasFunction(name)) {
-        setFunctionDesignator(identifier, symbolTable, annotations());
+        identifier.setResultSymbol(entry);
         return;
     }
 

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -1,5 +1,7 @@
 #include "SemanticAnalysisVisitorInternal.h"
 
+#include <optional>
+
 #include "ast/IdentifierExpression.h"
 
 namespace semantic_analyzer {
@@ -11,40 +13,56 @@ void setFunctionDesignator(ast::IdentifierExpression& identifier, SymbolTable& s
     auto functionEntry = symbolTable.findFunction(identifier.getIdentifier());
     type::Type fnType = type::function(functionEntry.returnType(), functionEntry.arguments());
     auto addr = symbolTable.createTemporarySymbol(type::pointer(fnType));
-    identifier.setFunctionDesignatorResult(addr, functionEntry.getName());
+    identifier.setFunctionDesignatorResult(addr);
     symbols::FunctionDesignatorPlan plan;
     plan.functionName = functionEntry.getName();
     plan.addressTempName = addr.getName();
     store.setAddressPlan(&identifier, symbols::AddressPlan { plan });
 }
 
+// Resolved call target: type for arity/return; CallPlan shape for codegen.
 struct Callee {
-    bool indirect { false };
+    symbols::CallPlan::Kind kind;
     std::string calleeName;
-    FunctionEntry symbol { "", type::function(type::voidType()).getFunction(), translation_unit::Context { "", 0 } };
+    type::Function type;
+    translation_unit::Context context;
+    // Set for Direct calls registered in the function table (and for FunctionCall::setSymbol).
+    std::optional<FunctionEntry> declared;
 };
 
-bool resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable, Callee& out,
-        std::string& errorDisplay) {
+std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable,
+        symbols::AnnotationStore& store, std::string& errorDisplay) {
     auto* operandSym = functionCall.operandSymbol();
     type::Type operandType = operandSym->getType();
     auto* operandExpr = functionCall.getOperandExpression();
 
+    // Designator identity lives on the store plan (not a second string on the AST).
     if (operandExpr->holdsFunctionDesignator()) {
-        // Designator name is always a registered function (set in setFunctionDesignator).
-        const std::string& designatorName = operandExpr->functionDesignatorName();
-        out.indirect = false;
-        out.calleeName = designatorName;
-        out.symbol = symbolTable.findFunction(designatorName);
-        return true;
+        const auto* addrPlan = store.addressPlan(operandExpr);
+        const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(addrPlan);
+        if (!d) {
+            errorDisplay = operandSym->getName();
+            return std::nullopt;
+        }
+        auto entry = symbolTable.findFunction(d->functionName);
+        return Callee {
+            symbols::CallPlan::Kind::Direct,
+            d->functionName,
+            entry.getType(),
+            entry.getContext(),
+            entry,
+        };
     }
 
     if (type::isPointerToBareFunction(operandType)) {
         type::Type pointee = operandType.dereference();
-        out.indirect = true;
-        out.calleeName = operandSym->getName();
-        out.symbol = FunctionEntry { operandSym->getName(), pointee.getFunction(), functionCall.getContext() };
-        return true;
+        return Callee {
+            symbols::CallPlan::Kind::Indirect,
+            operandSym->getName(),
+            pointee.getFunction(),
+            functionCall.getContext(),
+            std::nullopt,
+        };
     }
 
     if (auto* id = dynamic_cast<ast::IdentifierExpression*>(operandExpr)) {
@@ -52,7 +70,7 @@ bool resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable, Ca
     } else {
         errorDisplay = unscopedSymbolName(operandSym->getName());
     }
-    return false;
+    return std::nullopt;
 }
 
 } // namespace
@@ -65,20 +83,15 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
         return;
     }
 
-    Callee callee;
     std::string errorDisplay;
-    if (!resolveCallee(functionCall, symbolTable, callee, errorDisplay)) {
+    auto resolved = resolveCallee(functionCall, symbolTable, annotations(), errorDisplay);
+    if (!resolved) {
         semanticError("called object `" + errorDisplay + "` is not a function", functionCall.getContext());
         return;
     }
+    const Callee& callee = *resolved;
 
-    functionCall.setSymbol(callee.symbol);
-    symbols::CallPlan plan;
-    plan.kind = symbols::CallPlan::Kind::Normal;
-    plan.indirect = callee.indirect;
-    plan.calleeName = callee.calleeName;
-    annotations().setCallPlan(&functionCall, plan);
-
+    // Type-check args before publishing CallPlan (avoid half-applied call shape).
     auto& arguments = functionCall.getArgumentList();
     for (auto& argument : arguments) {
         if (argument->hasResultSymbol()) {
@@ -86,46 +99,58 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
         }
     }
 
-    if (arguments.size() == callee.symbol.argumentCount()) {
-        auto declaredArguments = callee.symbol.arguments();
+    const auto declaredArguments = callee.type.getArguments();
+    const bool arityOk = arguments.size() == declaredArguments.size();
+    const bool externalVarargs = callee.context == externalContext();
+
+    if (!arityOk && !externalVarargs) {
+        semanticError("no match for function " + type::function(callee.type.getReturnType(),
+                declaredArguments).to_string(), functionCall.getContext());
+        return;
+    }
+
+    if (arityOk) {
         for (std::size_t i { 0 }; i < arguments.size(); ++i) {
             if (!arguments.at(i)->hasResultSymbol()) {
                 return;
             }
-            const auto& declaredArgument = declaredArguments.at(i);
-            const auto& actualArgument = arguments.at(i)->getResultSymbol();
-            typeCheck(actualArgument->getType(), declaredArgument, functionCall.getContext());
+            typeCheck(arguments.at(i)->getResultSymbol()->getType(), declaredArguments.at(i),
+                    functionCall.getContext());
         }
+    }
 
-        auto returnType = callee.symbol.returnType();
-        if (!returnType.isVoid()) {
-            functionCall.setResultSymbol(symbolTable.createTemporarySymbol(returnType));
-        }
-    } else if (callee.symbol.getContext() == externalContext()) {
-        auto returnType = callee.symbol.returnType();
-        if (!returnType.isVoid()) {
-            functionCall.setResultSymbol(symbolTable.createTemporarySymbol(returnType));
-        }
+    if (callee.declared) {
+        functionCall.setSymbol(*callee.declared);
     } else {
-        semanticError("no match for function " + callee.symbol.getType().to_string(), functionCall.getContext());
+        // Indirect: type-only FunctionEntry for tooling that still reads getSymbol().
+        functionCall.setSymbol(FunctionEntry { callee.calleeName, callee.type, callee.context });
+    }
+
+    symbols::CallPlan plan;
+    plan.kind = callee.kind;
+    plan.calleeName = callee.calleeName;
+    annotations().setCallPlan(&functionCall, plan);
+
+    auto returnType = callee.type.getReturnType();
+    if (!returnType.isVoid()) {
+        functionCall.setResultSymbol(symbolTable.createTemporarySymbol(returnType));
     }
 }
 
 void SemanticAnalysisVisitor::visit(ast::IdentifierExpression& identifier) {
     const std::string& name = identifier.getIdentifier();
 
-    // insertFunction always registers a global value symbol, so hasFunction implies hasSymbol.
-    if (symbolTable.hasSymbol(name)) {
-        auto entry = symbolTable.lookup(name);
-        if (type::isBareFunction(entry.getType()) && symbolTable.hasFunction(name)) {
-            setFunctionDesignator(identifier, symbolTable, annotations());
-            return;
-        }
-        identifier.setResultSymbol(entry);
+    // insertFunction always registers a global value symbol of function type.
+    if (!symbolTable.hasSymbol(name)) {
+        semanticError("symbol `" + name + "` is not defined", identifier.getContext());
         return;
     }
-
-    semanticError("symbol `" + name + "` is not defined", identifier.getContext());
+    auto entry = symbolTable.lookup(name);
+    if (type::isBareFunction(entry.getType())) {
+        setFunctionDesignator(identifier, symbolTable, annotations());
+        return;
+    }
+    identifier.setResultSymbol(entry);
 }
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -151,6 +151,14 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
             return;
         }
+        // C: sizeof does not decay a function designator; it remains incomplete.
+        if (expression.getOperandExpression()->holdsFunctionDesignator()) {
+            semanticError(
+                    "invalid application of ‘sizeof’ to incomplete type ‘function’",
+                    expression.getContext());
+            expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+            return;
+        }
         const type::Type& operandType = expression.operandType();
         // Mirror sizeof(type): void and bare function types are incomplete for sizeof.
         // Pointers (including pointer-to-function) remain complete; those types also
@@ -174,6 +182,11 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
 
     switch (lexeme.front()) {
     case '&': {
+        // &function designator: same pointer-to-function value as bare designator decay (C).
+        if (expression.getOperandExpression()->holdsFunctionDesignator()) {
+            expression.setResultSymbol(*expression.operandSymbol());
+            break;
+        }
         rejectFunctionValue(expression.operandType(), expression.getContext());
         expression.setResultSymbol(symbolTable.createTemporarySymbol(type::pointer(expression.operandType())));
         break;
@@ -185,7 +198,11 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
         // Value already a pointer (e.g. multi-dim a[i] decayed row, or int(*)[N]).
         if (valueType.isPointer()) {
             type::Type pointee = valueType.dereference();
-            if (pointee.isArray()) {
+            if (type::isBareFunction(pointee)) {
+                // *fp for a bare function pointee: keep the pointer value (no memory load).
+                // Pointer-to-function pointees still need a load (pointer-to-pointer-to-function).
+                expression.setResultSymbol(*expression.operandSymbol());
+            } else if (pointee.isArray()) {
                 // *ptr-to-array yields the array object (address); do not scalar-load the row.
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(pointee.getElementType()));
                 expression.setLvalueSymbol(addr);

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -77,12 +77,10 @@ inline const T* get_if(const AddressPlan* plan) {
     return plan ? std::get_if<T>(plan) : nullptr;
 }
 
-// SA→CG call shape (Normal only for now; host extends for builtins).
+// SA→CG call shape: Direct = label in calleeName; Indirect = value symbol.
 struct CallPlan {
-    enum class Kind { Normal };
-    Kind kind { Kind::Normal };
-    bool indirect { false };
-    // Direct: function label. Indirect: value holding the callee address.
+    enum class Kind { Direct, Indirect };
+    Kind kind { Kind::Direct };
     std::string calleeName;
 };
 

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -65,7 +65,12 @@ struct IndexPlan {
 };
 
 
-using AddressPlan = std::variant<FieldPlan, IndexPlan>;
+struct FunctionDesignatorPlan {
+    std::string functionName;
+    std::string addressTempName;
+};
+
+using AddressPlan = std::variant<FieldPlan, IndexPlan, FunctionDesignatorPlan>;
 
 template <typename T>
 inline const T* get_if(const AddressPlan* plan) {

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -141,6 +141,7 @@ add_executable(functionalTest
         functionalTest/TypeCastTest.cpp
         functionalTest/StructsTest.cpp
         functionalTest/InitializersTest.cpp
+        functionalTest/FunctionPointersTest.cpp
         functionalTest/FactorialTest.cpp
         functionalTest/FibonacciTest.cpp
         functionalTest/FunctionCallTest.cpp

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -3,6 +3,7 @@
 
 #include "codegen/StackMachine.h"
 #include "codegen/ATandTInstructionSet.h"
+#include "codegen/IntelInstructionSet.h"
 
 #include <memory>
 
@@ -60,6 +61,52 @@ TEST_F(StackMachineTest, procedureCall_doesNotPushUnusedCallerSavedRegisters) {
 
     expectCode("\txorq %rax, %rax\n"
             "\tcall procedure\n");
+}
+
+// Production path uses IntelInstructionSet (LEA + indirect call via r10).
+TEST_F(StackMachineTest, functionAddress_leaGlobalLabel) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+    Value fp = intValue("fp");
+    stackMachine.startProcedure("proc", { fp }, { });
+    assemblyCode.str("");
+
+    stackMachine.functionAddress("foo", "fp");
+
+    // First free GP is rax; LEA of a global label into the result temp.
+    expectCode("\tlea rax, [rel foo]\n");
+}
+
+// Target already in a callee-saved reg survives spillCallerSavedRegisters → mov to r10.
+TEST_F(StackMachineTest, callProcedureIndirect_movesRegisterTargetToR10) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+    Value junk = intValue("junk");
+    Value fp = { "fp", 1, Type::INTEGRAL, 8 };
+    stackMachine.startProcedure("proc", { junk, fp }, { });
+    // Occupy rax so the next functionAddress binds fp to rbx (callee-saved).
+    stackMachine.functionAddress("a", "junk");
+    stackMachine.functionAddress("foo", "fp");
+    assemblyCode.str("");
+
+    stackMachine.callProcedureIndirect("fp");
+
+    // Spill junk from rax (retrieval reg), then mov callee-saved fp → r10 and call.
+    expectCode("\tmov [rsp + 40], rax\n"
+            "\txor rax, rax\n"
+            "\tmov r10, rbx\n"
+            "\tcall r10\n");
+}
+
+TEST_F(StackMachineTest, callProcedureIndirect_loadsMemoryTargetToR10) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+    Value fp = intValue("fp");
+    stackMachine.startProcedure("proc", { fp }, { });
+    assemblyCode.str("");
+
+    stackMachine.callProcedureIndirect("fp");
+
+    // Local starts in a frame slot; load into r10 then indirect call.
+    EXPECT_THAT(assemblyCode.str(), testing::HasSubstr("call r10"));
+    EXPECT_THAT(assemblyCode.str(), testing::HasSubstr("r10"));
 }
 
 TEST_F(StackMachineTest, procedureCall_storesAllDirtyCallerSavedRegisters) {

--- a/test/src/functionalTest/FunctionPointersTest.cpp
+++ b/test/src/functionalTest/FunctionPointersTest.cpp
@@ -170,4 +170,101 @@ TEST(Compiler, addressOfDesignatorToIntIsError) {
     program.assertCompilationErrors("function designator used as a value is not supported");
 }
 
+// Non-identifier callee → unscopedSymbolName + "not a function" (Coveralls path).
+TEST(Compiler, callThroughNonFunctionPointerIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int x;
+            int *p;
+            p = &x;
+            (*p)();
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("is not a function");
+}
+
+TEST(Compiler, callArrayElementIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[1];
+            a[0]();
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("is not a function");
+}
+
+TEST(Compiler, callIntIdentifierIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            a();
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("is not a function");
+}
+
+// Assignment expression result is a scoped local ($s…); strips via unscopedSymbolName.
+TEST(Compiler, callAssignmentExpressionIsError) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            (a = 1)();
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("is not a function");
+}
+
+// Direct call of a designator (not through a pointer variable).
+TEST(Compiler, directDesignatorCall) {
+    SourceProgram program{R"prg(
+        int six() { return 6; }
+        int main() {
+            printf("%d", six());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("6");
+}
+
+TEST(Compiler, functionPointerPassedAsArgument) {
+    SourceProgram program{R"prg(
+        int seven() { return 7; }
+        int apply(int (*fp)()) {
+            return fp();
+        }
+        int main() {
+            printf("%d", apply(seven));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7");
+}
+
+TEST(Compiler, functionPointerStoredInLocalAndCalled) {
+    SourceProgram program{R"prg(
+        int eight() { return 8; }
+        int nine() { return 9; }
+        int main() {
+            int (*table)();
+            table = eight;
+            printf("%d ", table());
+            table = nine;
+            printf("%d", table());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8 9");
+}
+
 } // namespace

--- a/test/src/functionalTest/FunctionPointersTest.cpp
+++ b/test/src/functionalTest/FunctionPointersTest.cpp
@@ -1,0 +1,173 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, simpleFunctionPointer) {
+    SourceProgram program{R"prg(
+        int one() {
+            return 1;
+        }
+
+        int main() {
+            int (*p)();
+            p = one;
+            printf("%d", p());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1");
+}
+
+TEST(Compiler, addressOfFunctionDesignator) {
+    SourceProgram program{R"prg(
+        int two() {
+            return 2;
+        }
+
+        int main() {
+            int (*p)();
+            p = &two;
+            printf("%d", p());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2");
+}
+
+TEST(Compiler, functionPointerReassign) {
+    SourceProgram program{R"prg(
+        int a() { return 3; }
+        int b() { return 4; }
+
+        int main() {
+            int (*p)();
+            p = a;
+            printf("%d ", p());
+            p = b;
+            printf("%d", p());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3 4");
+}
+
+TEST(Compiler, functionPointerWithArgument) {
+    SourceProgram program{R"prg(
+        int add1(int x) {
+            return x + 1;
+        }
+
+        int main() {
+            int (*fp)(int);
+            fp = add1;
+            printf("%d", fp(5));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("6");
+}
+
+TEST(Compiler, callThroughStarFunctionPointer) {
+    SourceProgram program{R"prg(
+        int three() {
+            return 3;
+        }
+
+        int main() {
+            int (*p)();
+            p = three;
+            printf("%d", (*p)());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, functionPointerInitializer) {
+    SourceProgram program{R"prg(
+        int five() { return 5; }
+        int main() {
+            int (*fp)() = five;
+            printf("%d", fp());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("5");
+}
+
+TEST(Compiler, designatorInitToIntIsError) {
+    SourceProgram program{R"prg(
+        int foo() { return 1; }
+        int main() {
+            int a = foo;
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("function designator used as a value is not supported");
+}
+
+TEST(Compiler, designatorReturnIsError) {
+    SourceProgram program{R"prg(
+        int foo() { return 1; }
+        int bad() { return foo; }
+        int main() {
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("function designator used as a value is not supported");
+}
+
+TEST(Compiler, indirectCallWithSevenArgs) {
+    SourceProgram program{R"prg(
+        int sum7(int a, int b, int c, int d, int e, int f, int g) {
+            return a + b + c + d + e + f + g;
+        }
+        int main() {
+            int (*fp)(int, int, int, int, int, int, int);
+            fp = sum7;
+            printf("%d", fp(1, 2, 3, 4, 5, 6, 7));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("28");
+}
+
+TEST(Compiler, doublePointerNotCallable) {
+    SourceProgram program{R"prg(
+        int one() { return 1; }
+        int main() {
+            int (*fp)();
+            int (**pp)();
+            fp = one;
+            pp = &fp;
+            printf("%d", (*pp)());
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1");
+}
+
+TEST(Compiler, addressOfDesignatorToIntIsError) {
+    SourceProgram program{R"prg(
+        int foo() { return 1; }
+        int main() {
+            int a;
+            a = &foo;
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.assertCompilationErrors("function designator used as a value is not supported");
+}
+
+} // namespace

--- a/test/src/functionalTest/FuzzCrashRegressionTest.cpp
+++ b/test/src/functionalTest/FuzzCrashRegressionTest.cpp
@@ -396,15 +396,23 @@ TEST(Compiler, deadBlockInCalleeDoesNotClobberReturn) {
 // Function designators as values (printf("%d", main)) used to throw map::at in codegen.
 // Report a semantic error instead.
 
-TEST(Compiler, functionDesignatorAsValueIsSemanticError) {
+// Function designators now decay to pointer-to-function in value context
+// (needed for `fp = f` / call-through). Passing a designator to printf is
+// therefore accepted; assigning a designator to a non-function-pointer remains
+// an error (see functionDesignatorInAssignmentIsSemanticError).
+TEST(Compiler, functionDesignatorDecaysWhenPassedAsArgument) {
     SourceProgram program{R"prg(
+        int one() { return 1; }
+        int apply(int (*fp)()) {
+            return fp();
+        }
         int main() {
-            printf("%d", main);
+            printf("%d", apply(one));
             return 0;
         }
     )prg"};
     program.compile();
-    program.assertCompilationErrors("function designator used as a value is not supported");
+    program.runAndExpect("1");
 }
 
 TEST(Compiler, functionDesignatorInAssignmentIsSemanticError) {

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -27,15 +27,29 @@ TEST(AnnotationStore, callPlanRoundTrip) {
     symbols::AnnotationStore store;
     int node = 2;
     symbols::CallPlan plan;
-    plan.indirect = false;
+    plan.kind = symbols::CallPlan::Kind::Direct;
     plan.calleeName = "printf";
     store.setCallPlan(&node, plan);
 
     const auto* got = store.callPlan(&node);
     ASSERT_NE(got, nullptr);
-    EXPECT_FALSE(got->indirect);
+    EXPECT_EQ(got->kind, symbols::CallPlan::Kind::Direct);
     EXPECT_EQ(got->calleeName, "printf");
     EXPECT_EQ(store.callPlan(&node + 1), nullptr);
+}
+
+TEST(AnnotationStore, callPlanIndirect) {
+    symbols::AnnotationStore store;
+    int node = 6;
+    symbols::CallPlan plan;
+    plan.kind = symbols::CallPlan::Kind::Indirect;
+    plan.calleeName = "fp";
+    store.setCallPlan(&node, plan);
+
+    const auto* got = store.callPlan(&node);
+    ASSERT_NE(got, nullptr);
+    EXPECT_EQ(got->kind, symbols::CallPlan::Kind::Indirect);
+    EXPECT_EQ(got->calleeName, "fp");
 }
 
 TEST(AnnotationStore, structFieldInits) {


### PR DESCRIPTION
## Summary
- Function designators decay to pointer-to-function (`FunctionAddress` IR)
- Assignment `fp = f` / `fp = &f` and call-through `fp()` / `(*fp)()`
- Indirect `Call` + `StackMachine::callProcedureIndirect` (callee in r10)
- Functional `FunctionPointersTest`; designator-as-argument accepted; designator→int still rejected

## Stack
PR F of remaining track. Base: #74 (initializers) → #73 (structs).

## Test plan
- [x] Full local `ctest`
- [ ] CI green / coverage non-regression