### PR TITLE
refactor(symbols): CallPlan as closed Direct|Indirect variant

### DIFF
--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -151,8 +151,8 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
         // SA error path — no IR.
         return;
     }
-    const CallKind kind = symbols::isIndirectCall(*plan) ? CallKind::Indirect : CallKind::Direct;
-    instructions.push_back(std::make_unique<Call>(symbols::callCalleeName(*plan), kind));
+    instructions.push_back(std::make_unique<Call>(
+            symbols::callCalleeName(*plan), symbols::isIndirectCall(*plan)));
     if (functionCall.hasResultSymbol() && !functionCall.getType().isVoid()) {
         instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
     }

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -151,7 +151,8 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
         // SA error path — no IR.
         return;
     }
-    instructions.push_back(std::make_unique<Call>(plan->calleeName, plan->kind));
+    const CallKind kind = symbols::isIndirectCall(*plan) ? CallKind::Indirect : CallKind::Direct;
+    instructions.push_back(std::make_unique<Call>(symbols::callCalleeName(*plan), kind));
     if (functionCall.hasResultSymbol() && !functionCall.getType().isVoid()) {
         instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
     }

--- a/src/codegen/quadruples/Call.cpp
+++ b/src/codegen/quadruples/Call.cpp
@@ -4,9 +4,9 @@
 
 namespace codegen {
 
-Call::Call(std::string procedureName, CallKind kind) :
+Call::Call(std::string procedureName, bool indirect) :
         procedureName { std::move(procedureName) },
-        kind_ { kind }
+        indirect_ { indirect }
 {
 }
 
@@ -18,16 +18,12 @@ std::string Call::getProcedureName() const {
     return procedureName;
 }
 
-CallKind Call::kind() const {
-    return kind_;
-}
-
 bool Call::isIndirect() const {
-    return kind_ == CallKind::Indirect;
+    return indirect_;
 }
 
 void Call::print(std::ostream& stream) const {
-    if (isIndirect()) {
+    if (indirect_) {
         stream << "\tCALL *" << getProcedureName() << "\n";
     } else {
         stream << "\tCALL " << getProcedureName() << "\n";

--- a/src/codegen/quadruples/Call.cpp
+++ b/src/codegen/quadruples/Call.cpp
@@ -4,7 +4,7 @@
 
 namespace codegen {
 
-Call::Call(std::string procedureName, symbols::CallPlan::Kind kind) :
+Call::Call(std::string procedureName, CallKind kind) :
         procedureName { std::move(procedureName) },
         kind_ { kind }
 {
@@ -18,12 +18,12 @@ std::string Call::getProcedureName() const {
     return procedureName;
 }
 
-symbols::CallPlan::Kind Call::kind() const {
+CallKind Call::kind() const {
     return kind_;
 }
 
 bool Call::isIndirect() const {
-    return kind_ == symbols::CallPlan::Kind::Indirect;
+    return kind_ == CallKind::Indirect;
 }
 
 void Call::print(std::ostream& stream) const {

--- a/src/codegen/quadruples/Call.h
+++ b/src/codegen/quadruples/Call.h
@@ -4,28 +4,30 @@
 #include <string>
 
 #include "Quadruple.h"
-#include "symbols/AddressPlan.h"
 
 namespace codegen {
+
+// Mirrors symbols::CallPlan arms without depending on the full variant in IR.
+enum class CallKind { Direct, Indirect };
 
 class Call: public Quadruple {
 public:
     // Direct: procedureName is a function label.
     // Indirect: procedureName is the value holding the callee address.
-    Call(std::string procedureName, symbols::CallPlan::Kind kind = symbols::CallPlan::Kind::Direct);
+    Call(std::string procedureName, CallKind kind = CallKind::Direct);
     virtual ~Call() = default;
 
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getProcedureName() const;
-    symbols::CallPlan::Kind kind() const;
+    CallKind kind() const;
     bool isIndirect() const;
 
 private:
     void print(std::ostream& stream) const override;
 
     std::string procedureName;
-    symbols::CallPlan::Kind kind_ { symbols::CallPlan::Kind::Direct };
+    CallKind kind_ { CallKind::Direct };
 };
 
 } // namespace codegen

--- a/src/codegen/quadruples/Call.h
+++ b/src/codegen/quadruples/Call.h
@@ -7,27 +7,23 @@
 
 namespace codegen {
 
-// Mirrors symbols::CallPlan arms without depending on the full variant in IR.
-enum class CallKind { Direct, Indirect };
-
 class Call: public Quadruple {
 public:
     // Direct: procedureName is a function label.
     // Indirect: procedureName is the value holding the callee address.
-    Call(std::string procedureName, CallKind kind = CallKind::Direct);
+    Call(std::string procedureName, bool indirect = false);
     virtual ~Call() = default;
 
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getProcedureName() const;
-    CallKind kind() const;
     bool isIndirect() const;
 
 private:
     void print(std::ostream& stream) const override;
 
     std::string procedureName;
-    CallKind kind_ { CallKind::Direct };
+    bool indirect_ { false };
 };
 
 } // namespace codegen

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -26,8 +26,7 @@ void setFunctionDesignator(ast::IdentifierExpression& identifier, SymbolTable& s
 
 // Resolved call target: type for arity/return; CallPlan shape for codegen.
 struct Callee {
-    symbols::CallPlan::Kind kind;
-    std::string calleeName;
+    symbols::CallPlan plan;
     type::Function type;
     translation_unit::Context context;
 };
@@ -50,8 +49,7 @@ std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable
         }
         auto entry = symbolTable.findFunction(d->functionName);
         return Callee {
-            symbols::CallPlan::Kind::Direct,
-            d->functionName,
+            symbols::DirectCallPlan { d->functionName },
             entry.getType(),
             entry.getContext(),
         };
@@ -60,8 +58,7 @@ std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable
     if (type::isPointerToBareFunction(operandType)) {
         type::Type pointee = operandType.dereference();
         return Callee {
-            symbols::CallPlan::Kind::Indirect,
-            operandSym->getName(),
+            symbols::IndirectCallPlan { operandSym->getName() },
             pointee.getFunction(),
             functionCall.getContext(),
         };
@@ -121,10 +118,7 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
         }
     }
 
-    symbols::CallPlan plan;
-    plan.kind = callee.kind;
-    plan.calleeName = callee.calleeName;
-    annotations().setCallPlan(&functionCall, plan);
+    annotations().setCallPlan(&functionCall, callee.plan);
 
     auto returnType = callee.type.getReturnType();
     if (!returnType.isVoid()) {

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -72,17 +72,30 @@ struct FunctionDesignatorPlan {
 
 using AddressPlan = std::variant<FieldPlan, IndexPlan, FunctionDesignatorPlan>;
 
-template <typename T>
-inline const T* get_if(const AddressPlan* plan) {
+// SA→CG call shape — closed variant (host-aligned shell; more arms later for va_*/builtins).
+// Direct: calleeName is a function label. Indirect: calleeName is a value holding the address.
+struct DirectCallPlan {
+    std::string calleeName;
+};
+
+struct IndirectCallPlan {
+    std::string calleeName;
+};
+
+using CallPlan = std::variant<DirectCallPlan, IndirectCallPlan>;
+
+template <typename T, typename Variant>
+inline const T* get_if(const Variant* plan) {
     return plan ? std::get_if<T>(plan) : nullptr;
 }
 
-// SA→CG call shape: Direct = label in calleeName; Indirect = value symbol.
-struct CallPlan {
-    enum class Kind { Direct, Indirect };
-    Kind kind { Kind::Direct };
-    std::string calleeName;
-};
+inline bool isIndirectCall(const CallPlan& plan) {
+    return std::holds_alternative<IndirectCallPlan>(plan);
+}
+
+inline const std::string& callCalleeName(const CallPlan& plan) {
+    return std::visit([](const auto& arm) -> const std::string& { return arm.calleeName; }, plan);
+}
 
 // Brace / structure field init stores (string-named temps).
 struct StructFieldInit {

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -26,30 +26,30 @@ TEST(AnnotationStore, addressPlanRoundTrip) {
 TEST(AnnotationStore, callPlanRoundTrip) {
     symbols::AnnotationStore store;
     int node = 2;
-    symbols::CallPlan plan;
-    plan.kind = symbols::CallPlan::Kind::Direct;
-    plan.calleeName = "printf";
-    store.setCallPlan(&node, plan);
+    store.setCallPlan(&node, symbols::DirectCallPlan { "printf" });
 
     const auto* got = store.callPlan(&node);
     ASSERT_NE(got, nullptr);
-    EXPECT_EQ(got->kind, symbols::CallPlan::Kind::Direct);
-    EXPECT_EQ(got->calleeName, "printf");
+    EXPECT_FALSE(symbols::isIndirectCall(*got));
+    EXPECT_EQ(symbols::callCalleeName(*got), "printf");
+    const auto* direct = symbols::get_if<symbols::DirectCallPlan>(got);
+    ASSERT_NE(direct, nullptr);
+    EXPECT_EQ(direct->calleeName, "printf");
     EXPECT_EQ(store.callPlan(&node + 1), nullptr);
 }
 
 TEST(AnnotationStore, callPlanIndirect) {
     symbols::AnnotationStore store;
     int node = 6;
-    symbols::CallPlan plan;
-    plan.kind = symbols::CallPlan::Kind::Indirect;
-    plan.calleeName = "fp";
-    store.setCallPlan(&node, plan);
+    store.setCallPlan(&node, symbols::IndirectCallPlan { "fp" });
 
     const auto* got = store.callPlan(&node);
     ASSERT_NE(got, nullptr);
-    EXPECT_EQ(got->kind, symbols::CallPlan::Kind::Indirect);
-    EXPECT_EQ(got->calleeName, "fp");
+    EXPECT_TRUE(symbols::isIndirectCall(*got));
+    EXPECT_EQ(symbols::callCalleeName(*got), "fp");
+    const auto* indirect = symbols::get_if<symbols::IndirectCallPlan>(got);
+    ASSERT_NE(indirect, nullptr);
+    EXPECT_EQ(indirect->calleeName, "fp");
 }
 
 TEST(AnnotationStore, structFieldInits) {
@@ -91,9 +91,7 @@ TEST(AnnotationStore, structFieldInits) {
 TEST(AnnotationStore, clearEmptiesAll) {
     symbols::AnnotationStore store;
     int node = 4;
-    symbols::CallPlan plan;
-    plan.calleeName = "f";
-    store.setCallPlan(&node, plan);
+    store.setCallPlan(&node, symbols::DirectCallPlan { "f" });
     store.clear();
     EXPECT_EQ(store.callPlan(&node), nullptr);
 }


### PR DESCRIPTION
## Summary
- Replace `CallPlan { Kind, calleeName }` with `std::variant<DirectCallPlan, IndirectCallPlan>`
- Helpers `isIndirectCall` / `callCalleeName`; generic `get_if` for plans
- IR `Call` takes a single `bool indirect` (no parallel `CallKind` enum)

## Stack
Phase A PR 1/3 — foundation for later va_*/builtin call arms.

## Test plan
- [x] symbolsTest, FP functional smoke
- [x] CI + Coveralls