### PR TITLE
refactor(symbols): AddressBaseMode for Field/Index plans

### DIFF
--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -35,12 +35,4 @@ int ArrayAccess::getElementSize() const {
     return elementSize;
 }
 
-void ArrayAccess::setBaseIsArray(bool value) {
-    baseIsArrayFlag = value;
-}
-
-bool ArrayAccess::baseIsArray() const {
-    return baseIsArrayFlag;
-}
-
 } // namespace ast

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -19,15 +19,11 @@ public:
 
     void setElementSize(int sizeInBytes);
     int getElementSize() const;
-    void setBaseIsArray(bool value);
-    bool baseIsArray() const;
-    // Whether this access yields an address (array/struct element) is
-    // Expression::holdsAggregateAddress() — do not duplicate that flag here.
+    // Base LeaObject vs PointerValue is symbols::IndexPlan::baseMode on the store.
 
 private:
     std::unique_ptr<semantic_analyzer::ValueEntry> lvalue { nullptr };
     int elementSize { 0 };
-    bool baseIsArrayFlag { false };
 };
 
 } // namespace ast

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -54,12 +54,12 @@ void AssemblyGenerator::generateCodeFor(const Dereference& dereference) {
 
 void AssemblyGenerator::generateCodeFor(const IndexAddress& indexAddress) {
     stackMachine->indexAddress(indexAddress.getBase(), indexAddress.getIndex(), indexAddress.getElementSizeBytes(),
-            indexAddress.getResult(), indexAddress.baseIsArray());
+            indexAddress.getResult(), indexAddress.baseMode());
 }
 
 void AssemblyGenerator::generateCodeFor(const FieldAddress& fieldAddress) {
     stackMachine->fieldAddress(fieldAddress.getBase(), fieldAddress.getOffsetBytes(), fieldAddress.getResult(),
-            fieldAddress.baseIsPointer());
+            fieldAddress.baseMode());
 }
 
 void AssemblyGenerator::generateCodeFor(const FunctionAddress& functionAddress) {

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -98,15 +98,15 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     }
     const auto* indexPlan = store_.addressPlan(&arrayAccess);
     const auto* index = indexPlan ? symbols::get_if<symbols::IndexPlan>(indexPlan) : nullptr;
-    const symbols::AddressBaseMode baseMode = index ? index->baseMode
-            : (arrayAccess.baseIsArray() ? symbols::AddressBaseMode::LeaObject
-                                         : symbols::AddressBaseMode::PointerValue);
+    if (!index) {
+        return; // SA error path
+    }
     instructions.push_back(std::make_unique<IndexAddress>(
             arrayAccess.leftOperandSymbol()->getName(),
             arrayAccess.rightOperandSymbol()->getName(),
             arrayAccess.getElementSize(),
             arrayAccess.getLvalue()->getName(),
-            baseMode));
+            index->baseMode));
     if (!arrayAccess.holdsAggregateAddress()) {
         // Load scalar element for rvalue uses; stores use LvalueAssign on the address temp.
         instructions.push_back(std::make_unique<Dereference>(

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -98,9 +98,8 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     }
     const auto* indexPlan = store_.addressPlan(&arrayAccess);
     const auto* index = indexPlan ? symbols::get_if<symbols::IndexPlan>(indexPlan) : nullptr;
-    if (!index) {
-        return; // SA error path
-    }
+    // SA always publishes IndexPlan for successful array access analysis.
+    assert(index && "IndexPlan required for array codegen");
     instructions.push_back(std::make_unique<IndexAddress>(
             arrayAccess.leftOperandSymbol()->getName(),
             arrayAccess.rightOperandSymbol()->getName(),

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -75,7 +75,8 @@ void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
     if (!fieldStores.empty()) {
         for (const auto& field : fieldStores) {
             instructions.push_back(std::make_unique<FieldAddress>(
-                    holder->getName(), field.offsetBytes, field.addressName, false));
+                    holder->getName(), field.offsetBytes, field.addressName,
+                    symbols::AddressBaseMode::LeaObject));
             if (field.zeroInitialize) {
                 instructions.push_back(std::make_unique<AssignConstant>("0", field.sourceName));
             }
@@ -95,12 +96,17 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     if (!arrayAccess.getLvalue() || !arrayAccess.getResultSymbol()) {
         return;
     }
+    const auto* indexPlan = store_.addressPlan(&arrayAccess);
+    const auto* index = indexPlan ? symbols::get_if<symbols::IndexPlan>(indexPlan) : nullptr;
+    const symbols::AddressBaseMode baseMode = index ? index->baseMode
+            : (arrayAccess.baseIsArray() ? symbols::AddressBaseMode::LeaObject
+                                         : symbols::AddressBaseMode::PointerValue);
     instructions.push_back(std::make_unique<IndexAddress>(
             arrayAccess.leftOperandSymbol()->getName(),
             arrayAccess.rightOperandSymbol()->getName(),
             arrayAccess.getElementSize(),
             arrayAccess.getLvalue()->getName(),
-            arrayAccess.baseIsArray()));
+            baseMode));
     if (!arrayAccess.holdsAggregateAddress()) {
         // Load scalar element for rvalue uses; stores use LvalueAssign on the address temp.
         instructions.push_back(std::make_unique<Dereference>(
@@ -131,7 +137,7 @@ void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
             memberAccess.getBase()->getResultSymbol()->getName(),
             field->fieldOffsetBytes,
             addrTemp,
-            field->baseIsPointer));
+            field->baseMode));
     if (!memberAccess.holdsAggregateAddress()) {
         instructions.push_back(std::make_unique<Dereference>(
                 addrTemp, addrTemp, memberAccess.getResultSymbol()->getName()));

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -224,7 +224,7 @@ void StackMachine::functionAddress(std::string functionName, std::string resultN
 }
 
 void StackMachine::indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
-        bool baseIsArray) {
+        symbols::AddressBaseMode baseMode) {
     auto& base = resolve(baseName);
     auto& index = resolve(indexName);
 
@@ -245,7 +245,7 @@ void StackMachine::indexAddress(std::string baseName, std::string indexName, int
     }
 
     Register& addr = get64BitRegisterExcluding(mulReg);
-    if (baseIsArray) {
+    if (symbols::addressBaseIsArrayObject(baseMode)) {
         storeInMemory(base);
         assembly << instructionSet->lea(memoryOperand(base), addr);
     } else if (residesInMemory(base)) {
@@ -266,10 +266,11 @@ void StackMachine::indexAddress(std::string baseName, std::string indexName, int
     bindResult(addr, resolve(resultName));
 }
 
-void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer) {
+void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName,
+        symbols::AddressBaseMode baseMode) {
     auto& base = resolve(baseName);
     Register& addr = get64BitRegister();
-    if (baseIsPointer) {
+    if (symbols::addressBaseIsPointerValue(baseMode)) {
         if (residesInMemory(base)) {
             emitLoad(base, addr);
         } else {

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -245,7 +245,7 @@ void StackMachine::indexAddress(std::string baseName, std::string indexName, int
     }
 
     Register& addr = get64BitRegisterExcluding(mulReg);
-    if (symbols::addressBaseIsArrayObject(baseMode)) {
+    if (symbols::addressBaseUsesLea(baseMode)) {
         storeInMemory(base);
         assembly << instructionSet->lea(memoryOperand(base), addr);
     } else if (residesInMemory(base)) {

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -14,6 +14,7 @@
 #include "quadruples/Jump.h"
 #include "Value.h"
 #include "Assembly.h"
+#include "symbols/AddressPlan.h"
 
 namespace codegen {
 
@@ -43,8 +44,9 @@ public:
     void functionAddress(std::string functionName, std::string resultName);
     void dereference(std::string operandName, std::string lvalueName, std::string resultName);
     void indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
-            bool baseIsArray = false);
-    void fieldAddress(std::string baseName, int offsetBytes, std::string resultName, bool baseIsPointer = false);
+            symbols::AddressBaseMode baseMode = symbols::AddressBaseMode::LeaObject);
+    void fieldAddress(std::string baseName, int offsetBytes, std::string resultName,
+            symbols::AddressBaseMode baseMode = symbols::AddressBaseMode::LeaObject);
 
     void unaryMinus(std::string operandName, std::string resultName);
     void unaryNot(std::string operandName, std::string resultName);

--- a/src/codegen/quadruples/FieldAddress.cpp
+++ b/src/codegen/quadruples/FieldAddress.cpp
@@ -4,11 +4,12 @@
 
 namespace codegen {
 
-FieldAddress::FieldAddress(std::string base, int offsetBytes, std::string result, bool baseIsPointer) :
+FieldAddress::FieldAddress(std::string base, int offsetBytes, std::string result,
+        symbols::AddressBaseMode baseMode) :
         base { std::move(base) },
         offsetBytes { offsetBytes },
         result { std::move(result) },
-        baseIsPointer_ { baseIsPointer }
+        baseMode_ { baseMode }
 {
 }
 
@@ -17,7 +18,8 @@ void FieldAddress::generateCode(AssemblyGenerator& generator) const {
 }
 
 void FieldAddress::print(std::ostream& stream) const {
-    stream << "\t" << result << " := &(" << base << (baseIsPointer_ ? "->" : ".") << offsetBytes << ")\n";
+    const char* op = symbols::addressBaseIsPointerValue(baseMode_) ? "->" : ".";
+    stream << "\t" << result << " := &(" << base << op << offsetBytes << ")\n";
 }
 
 } // namespace codegen

--- a/src/codegen/quadruples/FieldAddress.h
+++ b/src/codegen/quadruples/FieldAddress.h
@@ -3,25 +3,27 @@
 
 #include <string>
 #include "Quadruple.h"
+#include "symbols/AddressPlan.h"
 
 namespace codegen {
 
-// result = address of field: (&base) + offset, or (*base) + offset when baseIsPointer (arrow).
+// result = address of field using SA AddressBaseMode (LeaObject vs PointerValue).
 class FieldAddress: public Quadruple {
 public:
-    FieldAddress(std::string base, int offsetBytes, std::string result, bool baseIsPointer = false);
+    FieldAddress(std::string base, int offsetBytes, std::string result,
+            symbols::AddressBaseMode baseMode = symbols::AddressBaseMode::LeaObject);
     void generateCode(AssemblyGenerator& generator) const override;
     std::string getBase() const { return base; }
     int getOffsetBytes() const { return offsetBytes; }
     std::string getResult() const { return result; }
-    bool baseIsPointer() const { return baseIsPointer_; }
+    symbols::AddressBaseMode baseMode() const { return baseMode_; }
 
 private:
     void print(std::ostream& stream) const override;
     std::string base;
     int offsetBytes;
     std::string result;
-    bool baseIsPointer_;
+    symbols::AddressBaseMode baseMode_;
 };
 
 } // namespace codegen

--- a/src/codegen/quadruples/IndexAddress.cpp
+++ b/src/codegen/quadruples/IndexAddress.cpp
@@ -20,7 +20,7 @@ void IndexAddress::generateCode(AssemblyGenerator& generator) const {
 
 void IndexAddress::print(std::ostream& stream) const {
     stream << "\t" << result << " := &" << base << "[" << index << "] stride=" << elementSizeBytes
-            << (symbols::addressBaseIsArrayObject(baseMode_) ? " (array)\n" : " (ptr)\n");
+            << (symbols::addressBaseUsesLea(baseMode_) ? " (array)\n" : " (ptr)\n");
 }
 
 } // namespace codegen

--- a/src/codegen/quadruples/IndexAddress.cpp
+++ b/src/codegen/quadruples/IndexAddress.cpp
@@ -4,12 +4,13 @@
 
 namespace codegen {
 
-IndexAddress::IndexAddress(std::string base, std::string index, int elementSizeBytes, std::string result, bool baseIsArray) :
+IndexAddress::IndexAddress(std::string base, std::string index, int elementSizeBytes, std::string result,
+        symbols::AddressBaseMode baseMode) :
         base { std::move(base) },
         index { std::move(index) },
         elementSizeBytes { elementSizeBytes },
         result { std::move(result) },
-        baseIsArray_ { baseIsArray }
+        baseMode_ { baseMode }
 {
 }
 
@@ -19,7 +20,7 @@ void IndexAddress::generateCode(AssemblyGenerator& generator) const {
 
 void IndexAddress::print(std::ostream& stream) const {
     stream << "\t" << result << " := &" << base << "[" << index << "] stride=" << elementSizeBytes
-            << (baseIsArray_ ? " (array)\n" : " (ptr)\n");
+            << (symbols::addressBaseIsArrayObject(baseMode_) ? " (array)\n" : " (ptr)\n");
 }
 
 } // namespace codegen

--- a/src/codegen/quadruples/IndexAddress.h
+++ b/src/codegen/quadruples/IndexAddress.h
@@ -3,21 +3,23 @@
 
 #include <string>
 #include "Quadruple.h"
+#include "symbols/AddressPlan.h"
 
 namespace codegen {
 
 // result = &base[index] with element stride elementSizeBytes.
-// If baseIsArray, base is the array object (use its address); otherwise base holds a pointer.
+// LeaObject: base is the array object (LEA); PointerValue: base holds a pointer.
 class IndexAddress: public Quadruple {
 public:
-    IndexAddress(std::string base, std::string index, int elementSizeBytes, std::string result, bool baseIsArray = false);
+    IndexAddress(std::string base, std::string index, int elementSizeBytes, std::string result,
+            symbols::AddressBaseMode baseMode = symbols::AddressBaseMode::LeaObject);
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getBase() const { return base; }
     std::string getIndex() const { return index; }
     int getElementSizeBytes() const { return elementSizeBytes; }
     std::string getResult() const { return result; }
-    bool baseIsArray() const { return baseIsArray_; }
+    symbols::AddressBaseMode baseMode() const { return baseMode_; }
 
 private:
     void print(std::ostream& stream) const override;
@@ -25,7 +27,7 @@ private:
     std::string index;
     int elementSizeBytes;
     std::string result;
-    bool baseIsArray_;
+    symbols::AddressBaseMode baseMode_;
 };
 
 } // namespace codegen

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -29,7 +29,8 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
     indexPlan.baseExpr = arrayAccess.getLeftOperand();
     indexPlan.indexExpr = arrayAccess.getRightOperand();
     indexPlan.elementSize = sub.elementStride;
-    indexPlan.baseIsArray = sub.baseIsArray;
+    indexPlan.baseMode = sub.baseIsArray ? symbols::AddressBaseMode::LeaObject
+                                         : symbols::AddressBaseMode::PointerValue;
 
     if (elementType.isArray() || elementType.isStructure()) {
         type::Type addrType = elementType.isArray()
@@ -88,7 +89,8 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
     symbols::FieldPlan fieldPlan;
     fieldPlan.baseExpr = memberAccess.getBase();
     fieldPlan.fieldOffsetBytes = offset;
-    fieldPlan.baseIsPointer = base.addressIsPointer;
+    fieldPlan.baseMode = base.addressIsPointer ? symbols::AddressBaseMode::PointerValue
+                                               : symbols::AddressBaseMode::LeaObject;
     fieldPlan.addressTempName = fieldAddr.getName();
     annotations().setAddressPlan(&memberAccess, symbols::AddressPlan { fieldPlan });
     if (memberType.isStructure() || memberType.isArray()) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -21,7 +21,6 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
         return;
     }
 
-    arrayAccess.setBaseIsArray(sub.baseIsArray);
     arrayAccess.setElementSize(sub.elementStride);
     type::Type elementType = sub.elementType;
 

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -49,21 +49,19 @@ private:
 };
 
 // SA-owned base story for Field/Index IR (replaces dual baseIsPointer / baseIsArray).
-// LeaObject:     LEA from object/array symbol (dot on plain object, array id).
-// PointerValue:  base holds a pointer/address value in result (arrow, p[i], dual-type).
-// LvalueAddress: base name from lvalue annotation (nested a[i].m — reserved for later).
+// LeaObject:    LEA from object home (plain struct, array id).
+// PointerValue: base holds a pointer/address value in result (arrow, p[i], dual-type).
 enum class AddressBaseMode {
     LeaObject,
     PointerValue,
-    LvalueAddress,
 };
 
-inline bool addressBaseIsPointerValue(AddressBaseMode mode) {
-    return mode != AddressBaseMode::LeaObject;
+inline bool addressBaseUsesLea(AddressBaseMode mode) {
+    return mode == AddressBaseMode::LeaObject;
 }
 
-inline bool addressBaseIsArrayObject(AddressBaseMode mode) {
-    return mode == AddressBaseMode::LeaObject;
+inline bool addressBaseIsPointerValue(AddressBaseMode mode) {
+    return mode == AddressBaseMode::PointerValue;
 }
 
 struct FieldPlan {

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -48,10 +48,28 @@ private:
     const void* ptr_ { nullptr };
 };
 
+// SA-owned base story for Field/Index IR (replaces dual baseIsPointer / baseIsArray).
+// LeaObject:     LEA from object/array symbol (dot on plain object, array id).
+// PointerValue:  base holds a pointer/address value in result (arrow, p[i], dual-type).
+// LvalueAddress: base name from lvalue annotation (nested a[i].m — reserved for later).
+enum class AddressBaseMode {
+    LeaObject,
+    PointerValue,
+    LvalueAddress,
+};
+
+inline bool addressBaseIsPointerValue(AddressBaseMode mode) {
+    return mode != AddressBaseMode::LeaObject;
+}
+
+inline bool addressBaseIsArrayObject(AddressBaseMode mode) {
+    return mode == AddressBaseMode::LeaObject;
+}
+
 struct FieldPlan {
     ExpressionRef baseExpr;
     int fieldOffsetBytes { 0 };
-    bool baseIsPointer { false };
+    AddressBaseMode baseMode { AddressBaseMode::LeaObject };
     // Temp name for the computed field address (SA-allocated).
     std::string addressTempName;
 };
@@ -60,7 +78,7 @@ struct IndexPlan {
     ExpressionRef baseExpr;
     ExpressionRef indexExpr;
     int elementSize { 8 };
-    bool baseIsArray { false };
+    AddressBaseMode baseMode { AddressBaseMode::LeaObject };
     std::string addressTempName;
 };
 

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -111,7 +111,7 @@ TEST(AnnotationStore, indexPlanVariant) {
     ASSERT_NE(i, nullptr);
     EXPECT_EQ(i->elementSize, 4);
     EXPECT_EQ(i->baseMode, symbols::AddressBaseMode::LeaObject);
-    EXPECT_TRUE(symbols::addressBaseIsArrayObject(i->baseMode));
+    EXPECT_TRUE(symbols::addressBaseUsesLea(i->baseMode));
 }
 
 } // namespace

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -9,7 +9,7 @@ TEST(AnnotationStore, addressPlanRoundTrip) {
     int node = 1;
     symbols::FieldPlan field;
     field.fieldOffsetBytes = 8;
-    field.baseIsPointer = true;
+    field.baseMode = symbols::AddressBaseMode::PointerValue;
     field.addressTempName = "t0";
     store.setAddressPlan(&node, symbols::AddressPlan { field });
 
@@ -18,7 +18,8 @@ TEST(AnnotationStore, addressPlanRoundTrip) {
     const auto* f = symbols::get_if<symbols::FieldPlan>(plan);
     ASSERT_NE(f, nullptr);
     EXPECT_EQ(f->fieldOffsetBytes, 8);
-    EXPECT_TRUE(f->baseIsPointer);
+    EXPECT_EQ(f->baseMode, symbols::AddressBaseMode::PointerValue);
+    EXPECT_TRUE(symbols::addressBaseIsPointerValue(f->baseMode));
     EXPECT_EQ(f->addressTempName, "t0");
     EXPECT_EQ(store.addressPlan(&node + 1), nullptr);
 }
@@ -101,7 +102,7 @@ TEST(AnnotationStore, indexPlanVariant) {
     int node = 5;
     symbols::IndexPlan idx;
     idx.elementSize = 4;
-    idx.baseIsArray = true;
+    idx.baseMode = symbols::AddressBaseMode::LeaObject;
     idx.addressTempName = "idx";
     store.setAddressPlan(&node, symbols::AddressPlan { idx });
     const auto* plan = store.addressPlan(&node);
@@ -109,7 +110,8 @@ TEST(AnnotationStore, indexPlanVariant) {
     const auto* i = symbols::get_if<symbols::IndexPlan>(plan);
     ASSERT_NE(i, nullptr);
     EXPECT_EQ(i->elementSize, 4);
-    EXPECT_TRUE(i->baseIsArray);
+    EXPECT_EQ(i->baseMode, symbols::AddressBaseMode::LeaObject);
+    EXPECT_TRUE(symbols::addressBaseIsArrayObject(i->baseMode));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
- `AddressBaseMode` (`LeaObject` | `PointerValue`) replaces `baseIsPointer` / `baseIsArray` on Field/Index plans
- IR + StackMachine take the mode; CG prefers plan over AST dual flags
- Drop unused `LvalueAddress`; `addressBaseUsesLea` names the LEA path

## Stack
Phase A PR 2/3 — base: #76 CallPlan variant

## Test plan
- [x] symbolsTest, struct/array/init functional tests
- [x] CI + Coveralls