### PR TITLE
refactor(symbols): Result lives only on AnnotationStore

### DIFF
--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -15,15 +15,16 @@ void ArrayAccess::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void ArrayAccess::setLvalue(semantic_analyzer::ValueEntry lvalue) {
-    this->lvalue = std::make_unique<semantic_analyzer::ValueEntry>(lvalue);
+void ArrayAccess::setLvalue(symbols::ValueEntry lvalue) {
+    this->lvalue = std::make_unique<symbols::ValueEntry>(lvalue);
 }
 
-semantic_analyzer::ValueEntry* ArrayAccess::getLvalue() const {
+symbols::ValueEntry* ArrayAccess::getLvalue() const {
     return lvalue.get();
 }
 
-semantic_analyzer::ValueEntry* ArrayAccess::getLvalueSymbol() const {
+symbols::ValueEntry* ArrayAccess::getLvalueSymbol(symbols::AnnotationStore& store) const {
+    (void)store;
     return getLvalue();
 }
 

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -13,16 +13,16 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setLvalue(semantic_analyzer::ValueEntry lvalue);
-    semantic_analyzer::ValueEntry* getLvalue() const;
-    semantic_analyzer::ValueEntry* getLvalueSymbol() const override;
+    void setLvalue(symbols::ValueEntry lvalue);
+    symbols::ValueEntry* getLvalue() const;
+    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
     void setElementSize(int sizeInBytes);
     int getElementSize() const;
     // Base LeaObject vs PointerValue is symbols::IndexPlan::baseMode on the store.
 
 private:
-    std::unique_ptr<semantic_analyzer::ValueEntry> lvalue { nullptr };
+    std::unique_ptr<symbols::ValueEntry> lvalue { nullptr };
     int elementSize { 0 };
 };
 

--- a/src/ast/AssignmentExpression.cpp
+++ b/src/ast/AssignmentExpression.cpp
@@ -17,8 +17,8 @@ void AssignmentExpression::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-semantic_analyzer::ValueEntry* AssignmentExpression::leftOperandLvalueSymbol() const {
-    return leftOperand->getLvalueSymbol();
+symbols::ValueEntry* AssignmentExpression::leftOperandLvalueSymbol(symbols::AnnotationStore& store) const {
+    return leftOperand->getLvalueSymbol(store);
 }
 
 } // namespace ast

--- a/src/ast/AssignmentExpression.h
+++ b/src/ast/AssignmentExpression.h
@@ -13,7 +13,7 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    semantic_analyzer::ValueEntry* leftOperandLvalueSymbol() const;
+    symbols::ValueEntry* leftOperandLvalueSymbol(symbols::AnnotationStore& store) const;
 };
 
 } // namespace ast

--- a/src/ast/ConditionalExpression.cpp
+++ b/src/ast/ConditionalExpression.cpp
@@ -28,16 +28,16 @@ void ConditionalExpression::visitFalseExpression(AbstractSyntaxTreeVisitor& visi
     falseExpression->accept(visitor);
 }
 
-semantic_analyzer::ValueEntry* ConditionalExpression::conditionSymbol() const {
-    return condition->getResultSymbol();
+symbols::ValueEntry* ConditionalExpression::conditionSymbol(symbols::AnnotationStore& store) const {
+    return condition->getResultSymbol(store);
 }
 
-semantic_analyzer::ValueEntry* ConditionalExpression::trueSymbol() const {
-    return trueExpression->getResultSymbol();
+symbols::ValueEntry* ConditionalExpression::trueSymbol(symbols::AnnotationStore& store) const {
+    return trueExpression->getResultSymbol(store);
 }
 
-semantic_analyzer::ValueEntry* ConditionalExpression::falseSymbol() const {
-    return falseExpression->getResultSymbol();
+symbols::ValueEntry* ConditionalExpression::falseSymbol(symbols::AnnotationStore& store) const {
+    return falseExpression->getResultSymbol(store);
 }
 
 translation_unit::Context ConditionalExpression::getContext() const {

--- a/src/ast/ConditionalExpression.h
+++ b/src/ast/ConditionalExpression.h
@@ -25,9 +25,9 @@ public:
     Expression* getTrueExpression() const { return trueExpression.get(); }
     Expression* getFalseExpression() const { return falseExpression.get(); }
 
-    semantic_analyzer::ValueEntry* conditionSymbol() const;
-    semantic_analyzer::ValueEntry* trueSymbol() const;
-    semantic_analyzer::ValueEntry* falseSymbol() const;
+    symbols::ValueEntry* conditionSymbol(symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* trueSymbol(symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* falseSymbol(symbols::AnnotationStore& store) const;
 
     translation_unit::Context getContext() const override;
 

--- a/src/ast/DirectDeclarator.h
+++ b/src/ast/DirectDeclarator.h
@@ -29,7 +29,7 @@ private:
 
     translation_unit::Context context;
 
-    std::unique_ptr<semantic_analyzer::ValueEntry> holder { nullptr };
+    std::unique_ptr<symbols::ValueEntry> holder { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/DoubleOperandExpression.cpp
+++ b/src/ast/DoubleOperandExpression.cpp
@@ -70,20 +70,20 @@ type::Type DoubleOperandExpression::rightOperandType() const {
     return rightOperand->getType();
 }
 
-bool DoubleOperandExpression::hasLeftOperandSymbol() const {
-    return leftOperand->hasResultSymbol();
+bool DoubleOperandExpression::hasLeftOperandSymbol(const symbols::AnnotationStore& store) const {
+    return leftOperand->hasResultSymbol(store);
 }
 
-bool DoubleOperandExpression::hasRightOperandSymbol() const {
-    return rightOperand->hasResultSymbol();
+bool DoubleOperandExpression::hasRightOperandSymbol(const symbols::AnnotationStore& store) const {
+    return rightOperand->hasResultSymbol(store);
 }
 
-semantic_analyzer::ValueEntry* DoubleOperandExpression::leftOperandSymbol() const {
-    return leftOperand->getResultSymbol();
+symbols::ValueEntry* DoubleOperandExpression::leftOperandSymbol(symbols::AnnotationStore& store) const {
+    return leftOperand->getResultSymbol(store);
 }
 
-semantic_analyzer::ValueEntry* DoubleOperandExpression::rightOperandSymbol() const {
-    return rightOperand->getResultSymbol();
+symbols::ValueEntry* DoubleOperandExpression::rightOperandSymbol(symbols::AnnotationStore& store) const {
+    return rightOperand->getResultSymbol(store);
 }
 
 Expression* DoubleOperandExpression::getLeftOperand() const {

--- a/src/ast/DoubleOperandExpression.h
+++ b/src/ast/DoubleOperandExpression.h
@@ -19,10 +19,10 @@ public:
     type::Type leftOperandType() const;
     type::Type rightOperandType() const;
 
-    bool hasLeftOperandSymbol() const;
-    bool hasRightOperandSymbol() const;
-    semantic_analyzer::ValueEntry* leftOperandSymbol() const;
-    semantic_analyzer::ValueEntry* rightOperandSymbol() const;
+    bool hasLeftOperandSymbol(const symbols::AnnotationStore& store) const;
+    bool hasRightOperandSymbol(const symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* leftOperandSymbol(symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* rightOperandSymbol(symbols::AnnotationStore& store) const;
     Expression* getLeftOperand() const;
     Expression* getRightOperand() const;
 

--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -53,7 +53,7 @@ bool Expression::hasResultSymbol(const symbols::AnnotationStore& store) const {
 }
 
 symbols::ValueEntry* Expression::getResultSymbol(symbols::AnnotationStore& store) const {
-    return store.value(this, symbols::ValueSlot::Result);
+    return store.result(this);
 }
 
 bool Expression::isLval() const {

--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -1,6 +1,7 @@
 #include "Expression.h"
 
 #include <cassert>
+#include <stdexcept>
 
 namespace ast {
 
@@ -15,51 +16,52 @@ type::Type Expression::expressionType() const {
     return *type;
 }
 
-type::Type Expression::valueType() const {
-    if (resultSymbol) {
-        return resultSymbol->getType();
+type::Type Expression::valueType(const symbols::AnnotationStore& store) const {
+    if (const auto* r = store.value(this, symbols::ValueSlot::Result)) {
+        return r->getType();
     }
     return expressionType();
 }
 
-bool Expression::hasDecayedArrayValue() const {
-    return isArrayObjectType() && hasResultSymbol() && valueType().isPointer();
+bool Expression::hasDecayedArrayValue(const symbols::AnnotationStore& store) const {
+    return isArrayObjectType() && hasResultSymbol(store) && valueType(store).isPointer();
 }
 
-void Expression::setTypeAndResult(semantic_analyzer::ValueEntry resultSymbol) {
-    this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(resultSymbol));
-    setType(this->resultSymbol->getType());
+void Expression::setTypeAndResult(symbols::AnnotationStore& store, symbols::ValueEntry result) {
+    setType(result.getType());
     form = ValueForm::Scalar;
+    store.setResult(this, std::move(result));
 }
 
-void Expression::setAggregateAddressResult(semantic_analyzer::ValueEntry addressSymbol,
-        const type::Type& aggregateType) {
-    this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(addressSymbol));
+void Expression::setAggregateAddressResult(symbols::AnnotationStore& store,
+        symbols::ValueEntry addressSymbol, const type::Type& aggregateType) {
     setType(aggregateType);
     form = ValueForm::AggregateAddress;
+    store.setResult(this, std::move(addressSymbol));
 }
 
-void Expression::setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol) {
-    this->resultSymbol = std::make_unique<semantic_analyzer::ValueEntry>(std::move(addressSymbol));
-    setType(this->resultSymbol->getType());
+void Expression::setFunctionDesignatorResult(symbols::AnnotationStore& store,
+        symbols::ValueEntry addressSymbol) {
+    setType(addressSymbol.getType());
     form = ValueForm::FunctionDesignator;
     lval = false;
+    store.setResult(this, std::move(addressSymbol));
 }
 
-bool Expression::hasResultSymbol() const {
-    return resultSymbol != nullptr;
+bool Expression::hasResultSymbol(const symbols::AnnotationStore& store) const {
+    return store.hasResult(this);
 }
 
-semantic_analyzer::ValueEntry* Expression::getResultSymbol() const {
-    assert(resultSymbol);
-    return resultSymbol.get();
+symbols::ValueEntry* Expression::getResultSymbol(symbols::AnnotationStore& store) const {
+    return store.value(this, symbols::ValueSlot::Result);
 }
 
 bool Expression::isLval() const {
     return lval;
 }
 
-semantic_analyzer::ValueEntry* Expression::getLvalueSymbol() const {
+symbols::ValueEntry* Expression::getLvalueSymbol(symbols::AnnotationStore& store) const {
+    (void)store;
     return nullptr;
 }
 

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -46,7 +46,7 @@ public:
 
     virtual bool evaluateConstant(long& value) const { return false; }
 
-    // Result lives only on the store.
+    // Result lives only on the store (no node cache).
     void setTypeAndResult(symbols::AnnotationStore& store, symbols::ValueEntry resultSymbol);
     void setAggregateAddressResult(symbols::AnnotationStore& store, symbols::ValueEntry addressSymbol,
             const type::Type& aggregateType);
@@ -57,6 +57,8 @@ public:
     }
 
     bool hasResultSymbol(const symbols::AnnotationStore& store) const;
+    // Required Result after successful SA — asserts if missing (same contract as AnnotationStore::result).
+    // Probe with hasResultSymbol before calling when the expression may have failed analysis.
     symbols::ValueEntry* getResultSymbol(symbols::AnnotationStore& store) const;
 
     ValueForm valueForm() const { return form; }

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -1,18 +1,19 @@
 #ifndef _EXPR_NODE_H_
 #define _EXPR_NODE_H_
 
-#include <memory>
 #include <optional>
 #include <string>
 
 #include "AbstractSyntaxTreeNode.h"
-#include "semantic_analyzer/ValueEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/ValueEntry.h"
 
 namespace ast {
 
-// How the result Value relates to expressionType() (finish-for-git dual ownership).
-// Host uses AnnotationStore + setType/setResult; we keep Result on the node for now
-// and encode dual ownership with ValueForm (same C rules).
+// Dual ownership of C type vs value (finish-for-git protocol):
+//   expressionType() — C type for sizeof / isArray (on the node)
+//   Result — ValueEntry only in AnnotationStore (ValueSlot::Result)
+// ValueForm encodes dual-type cases without separate AST fields.
 enum class ValueForm {
     Scalar,              // expressionType matches result type
     AggregateAddress,    // expressionType is aggregate/array; result holds its address
@@ -27,7 +28,7 @@ public:
     virtual translation_unit::Context getContext() const = 0;
 
     void setType(const type::Type& type);
-    // C type of the expression (sizeof / isArray / isStructure). Host: expressionType().
+    // C type of the expression (sizeof / isArray / isStructure).
     type::Type expressionType() const;
     type::Type getType() const { return expressionType(); }
     bool hasExpressionType() const { return type.has_value(); }
@@ -35,27 +36,28 @@ public:
     // Dual-type: multi-dim rows / nested structs keep aggregate as expression type.
     bool isArrayObjectType() const { return hasExpressionType() && expressionType().isArray(); }
     // Array expression type with pointer result (true dual ownership after SA).
-    bool hasDecayedArrayValue() const;
+    bool hasDecayedArrayValue(const symbols::AnnotationStore& store) const;
 
     // Type of the Result symbol after SA (prefer for arithmetic / assign source value).
-    type::Type valueType() const;
+    type::Type valueType(const symbols::AnnotationStore& store) const;
 
     virtual bool isLval() const;
-    virtual semantic_analyzer::ValueEntry* getLvalueSymbol() const;
+    virtual symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const;
 
     virtual bool evaluateConstant(long& value) const { return false; }
 
-    // Scalar path: expression type and result both from the symbol.
-    void setTypeAndResult(semantic_analyzer::ValueEntry resultSymbol);
-    // Dual-type: expression type is aggregate/array; result holds its address.
-    void setAggregateAddressResult(semantic_analyzer::ValueEntry addressSymbol, const type::Type& aggregateType);
-    // Function designator decay: result is pointer-to-function temp (label on store plan).
-    void setFunctionDesignatorResult(semantic_analyzer::ValueEntry addressSymbol);
+    // Result lives only on the store.
+    void setTypeAndResult(symbols::AnnotationStore& store, symbols::ValueEntry resultSymbol);
+    void setAggregateAddressResult(symbols::AnnotationStore& store, symbols::ValueEntry addressSymbol,
+            const type::Type& aggregateType);
+    void setFunctionDesignatorResult(symbols::AnnotationStore& store, symbols::ValueEntry addressSymbol);
 
-    void setResultSymbol(semantic_analyzer::ValueEntry resultSymbol) { setTypeAndResult(std::move(resultSymbol)); }
+    void setResultSymbol(symbols::AnnotationStore& store, symbols::ValueEntry resultSymbol) {
+        setTypeAndResult(store, std::move(resultSymbol));
+    }
 
-    bool hasResultSymbol() const;
-    semantic_analyzer::ValueEntry* getResultSymbol() const;
+    bool hasResultSymbol(const symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* getResultSymbol(symbols::AnnotationStore& store) const;
 
     ValueForm valueForm() const { return form; }
     bool holdsAggregateAddress() const { return form == ValueForm::AggregateAddress; }
@@ -66,8 +68,6 @@ protected:
 
 private:
     std::optional<type::Type> type;
-
-    std::unique_ptr<semantic_analyzer::ValueEntry> resultSymbol { nullptr };
     ValueForm form { ValueForm::Scalar };
 };
 

--- a/src/ast/FunctionDefinition.cpp
+++ b/src/ast/FunctionDefinition.cpp
@@ -54,19 +54,19 @@ std::string FunctionDefinition::getName() const {
 }
 
 
-void FunctionDefinition::setLocalVariables(std::map<std::string, semantic_analyzer::ValueEntry> localVariables) {
+void FunctionDefinition::setLocalVariables(std::map<std::string, symbols::ValueEntry> localVariables) {
     this->localVariables = localVariables;
 }
 
-void FunctionDefinition::setArguments(std::vector<semantic_analyzer::ValueEntry> arguments) {
+void FunctionDefinition::setArguments(std::vector<symbols::ValueEntry> arguments) {
     this->arguments = arguments;
 }
 
-std::map<std::string, semantic_analyzer::ValueEntry> FunctionDefinition::getLocalVariables() const {
+std::map<std::string, symbols::ValueEntry> FunctionDefinition::getLocalVariables() const {
     return localVariables;
 }
 
-std::vector<semantic_analyzer::ValueEntry> FunctionDefinition::getArguments() const {
+std::vector<symbols::ValueEntry> FunctionDefinition::getArguments() const {
     return arguments;
 }
 

--- a/src/ast/FunctionDefinition.h
+++ b/src/ast/FunctionDefinition.h
@@ -26,13 +26,13 @@ public:
     void visitBodyChildren(AbstractSyntaxTreeVisitor& visitor);
 
     void setSymbol(semantic_analyzer::FunctionEntry symbol);
-    void setLocalVariables(std::map<std::string, semantic_analyzer::ValueEntry> localVariables);
-    void setArguments(std::vector<semantic_analyzer::ValueEntry> arguments);
+    void setLocalVariables(std::map<std::string, symbols::ValueEntry> localVariables);
+    void setArguments(std::vector<symbols::ValueEntry> arguments);
 
     bool hasSymbol() const { return symbol != nullptr; }
     semantic_analyzer::FunctionEntry* getSymbol() const;
-    std::map<std::string, semantic_analyzer::ValueEntry> getLocalVariables() const;
-    std::vector<semantic_analyzer::ValueEntry> getArguments() const;
+    std::map<std::string, symbols::ValueEntry> getLocalVariables() const;
+    std::vector<symbols::ValueEntry> getArguments() const;
 
     std::string getName() const;
 
@@ -43,8 +43,8 @@ private:
 
     std::unique_ptr<semantic_analyzer::FunctionEntry> symbol;
 
-    std::map<std::string, semantic_analyzer::ValueEntry> localVariables;
-    std::vector<semantic_analyzer::ValueEntry> arguments;
+    std::map<std::string, symbols::ValueEntry> localVariables;
+    std::vector<symbols::ValueEntry> arguments;
 };
 
 } // namespace ast

--- a/src/ast/InitializedDeclarator.cpp
+++ b/src/ast/InitializedDeclarator.cpp
@@ -33,19 +33,19 @@ Expression* InitializedDeclarator::getInitializer() const {
     return initializer.get();
 }
 
-semantic_analyzer::ValueEntry* InitializedDeclarator::getInitializerHolder() const {
-    return initializer->getResultSymbol();
+symbols::ValueEntry* InitializedDeclarator::getInitializerHolder(symbols::AnnotationStore& store) const {
+    return initializer->getResultSymbol(store);
 }
 
 translation_unit::Context ast::InitializedDeclarator::getContext() const {
     return declarator->getContext();
 }
 
-void InitializedDeclarator::setHolder(semantic_analyzer::ValueEntry holder) {
-    this->holder = std::make_unique<semantic_analyzer::ValueEntry>(holder);
+void InitializedDeclarator::setHolder(symbols::ValueEntry holder) {
+    this->holder = std::make_unique<symbols::ValueEntry>(holder);
 }
 
-semantic_analyzer::ValueEntry* InitializedDeclarator::getHolder() const {
+symbols::ValueEntry* InitializedDeclarator::getHolder() const {
     if (!holder) {
         throw std::runtime_error { "InitializedDeclarator::getHolder() == nullptr" };
     }

--- a/src/ast/InitializedDeclarator.h
+++ b/src/ast/InitializedDeclarator.h
@@ -22,17 +22,17 @@ public:
 
     bool hasInitializer() const;
     Expression* getInitializer() const;
-    semantic_analyzer::ValueEntry* getInitializerHolder() const;
+    symbols::ValueEntry* getInitializerHolder(symbols::AnnotationStore& store) const;
 
     translation_unit::Context getContext() const;
 
-    void setHolder(semantic_analyzer::ValueEntry holder);
-    semantic_analyzer::ValueEntry* getHolder() const;
+    void setHolder(symbols::ValueEntry holder);
+    symbols::ValueEntry* getHolder() const;
 
 private:
     std::unique_ptr<Declarator> declarator;
     std::unique_ptr<Expression> initializer;
-    std::unique_ptr<semantic_analyzer::ValueEntry> holder;
+    std::unique_ptr<symbols::ValueEntry> holder;
 };
 
 } // namespace ast

--- a/src/ast/MemberAccess.cpp
+++ b/src/ast/MemberAccess.cpp
@@ -33,15 +33,16 @@ bool MemberAccess::isArrow() const {
     return arrow;
 }
 
-void MemberAccess::setFieldAddressSymbol(semantic_analyzer::ValueEntry symbol) {
-    fieldAddress = std::make_unique<semantic_analyzer::ValueEntry>(std::move(symbol));
+void MemberAccess::setFieldAddressSymbol(symbols::ValueEntry symbol) {
+    fieldAddress = std::make_unique<symbols::ValueEntry>(std::move(symbol));
 }
 
-semantic_analyzer::ValueEntry* MemberAccess::getFieldAddressSymbol() const {
+symbols::ValueEntry* MemberAccess::getFieldAddressSymbol() const {
     return fieldAddress.get();
 }
 
-semantic_analyzer::ValueEntry* MemberAccess::getLvalueSymbol() const {
+symbols::ValueEntry* MemberAccess::getLvalueSymbol(symbols::AnnotationStore& store) const {
+    (void)store;
     return fieldAddress.get();
 }
 

--- a/src/ast/MemberAccess.h
+++ b/src/ast/MemberAccess.h
@@ -10,7 +10,7 @@
 namespace ast {
 
 // postfix . id  or  postfix -> id
-// Field offset / baseIsPointer live in symbols::AddressPlan (Field) on the store.
+// Field offset / AddressBaseMode live in symbols::AddressPlan (Field) on the store.
 class MemberAccess: public Expression {
 public:
     MemberAccess(std::unique_ptr<Expression> base, std::string memberName, bool arrow,
@@ -23,16 +23,16 @@ public:
     const std::string& getMemberName() const;
     bool isArrow() const;
 
-    void setFieldAddressSymbol(semantic_analyzer::ValueEntry symbol);
-    semantic_analyzer::ValueEntry* getFieldAddressSymbol() const;
-    semantic_analyzer::ValueEntry* getLvalueSymbol() const override;
+    void setFieldAddressSymbol(symbols::ValueEntry symbol);
+    symbols::ValueEntry* getFieldAddressSymbol() const;
+    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
 private:
     std::unique_ptr<Expression> base;
     std::string memberName;
     bool arrow;
     translation_unit::Context context;
-    std::unique_ptr<semantic_analyzer::ValueEntry> fieldAddress;
+    std::unique_ptr<symbols::ValueEntry> fieldAddress;
 };
 
 } // namespace ast

--- a/src/ast/PostfixExpression.cpp
+++ b/src/ast/PostfixExpression.cpp
@@ -14,12 +14,12 @@ void PostfixExpression::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void PostfixExpression::setPreOperationSymbol(semantic_analyzer::ValueEntry resultSymbol) {
-    this->preOperationSymbol = std::make_unique<semantic_analyzer::ValueEntry>(resultSymbol);
+void PostfixExpression::setPreOperationSymbol(symbols::ValueEntry resultSymbol) {
+    this->preOperationSymbol = std::make_unique<symbols::ValueEntry>(resultSymbol);
     setType(this->preOperationSymbol->getType());
 }
 
-semantic_analyzer::ValueEntry* PostfixExpression::getPreOperationSymbol() const {
+symbols::ValueEntry* PostfixExpression::getPreOperationSymbol() const {
     assert(preOperationSymbol);
     return preOperationSymbol.get();
 }

--- a/src/ast/PostfixExpression.h
+++ b/src/ast/PostfixExpression.h
@@ -13,11 +13,11 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setPreOperationSymbol(semantic_analyzer::ValueEntry resultSymbol);
-    semantic_analyzer::ValueEntry* getPreOperationSymbol() const;
+    void setPreOperationSymbol(symbols::ValueEntry resultSymbol);
+    symbols::ValueEntry* getPreOperationSymbol() const;
 
 private:
-    std::unique_ptr<semantic_analyzer::ValueEntry> preOperationSymbol { nullptr };
+    std::unique_ptr<symbols::ValueEntry> preOperationSymbol { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/SingleOperandExpression.cpp
+++ b/src/ast/SingleOperandExpression.cpp
@@ -19,16 +19,16 @@ type::Type SingleOperandExpression::operandType() const {
     return _operand->getType();
 }
 
-bool SingleOperandExpression::hasOperandSymbol() const {
-    return _operand->hasResultSymbol();
+bool SingleOperandExpression::hasOperandSymbol(const symbols::AnnotationStore& store) const {
+    return _operand->hasResultSymbol(store);
 }
 
-semantic_analyzer::ValueEntry* SingleOperandExpression::operandSymbol() const {
-    return _operand->getResultSymbol();
+symbols::ValueEntry* SingleOperandExpression::operandSymbol(symbols::AnnotationStore& store) const {
+    return _operand->getResultSymbol(store);
 }
 
-semantic_analyzer::ValueEntry* SingleOperandExpression::operandLvalueSymbol() const {
-    return _operand->getLvalueSymbol();
+symbols::ValueEntry* SingleOperandExpression::operandLvalueSymbol(symbols::AnnotationStore& store) const {
+    return _operand->getLvalueSymbol(store);
 }
 
 Expression* SingleOperandExpression::getOperandExpression() const {

--- a/src/ast/SingleOperandExpression.h
+++ b/src/ast/SingleOperandExpression.h
@@ -15,9 +15,9 @@ public:
 
     void visitOperand(AbstractSyntaxTreeVisitor& visitor);
     type::Type operandType() const;
-    bool hasOperandSymbol() const;
-    semantic_analyzer::ValueEntry* operandSymbol() const;
-    semantic_analyzer::ValueEntry* operandLvalueSymbol() const;
+    bool hasOperandSymbol(const symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* operandSymbol(symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* operandLvalueSymbol(symbols::AnnotationStore& store) const;
     Expression* getOperandExpression() const;
 
     bool isLval() const override;

--- a/src/ast/SwitchStatement.cpp
+++ b/src/ast/SwitchStatement.cpp
@@ -23,11 +23,11 @@ semantic_analyzer::LabelEntry* SwitchStatement::getExitLabel() const {
     return exitLabel.get();
 }
 
-void SwitchStatement::setCaseTemp(semantic_analyzer::ValueEntry temp) {
-    this->caseTemp = std::make_unique<semantic_analyzer::ValueEntry>(temp);
+void SwitchStatement::setCaseTemp(symbols::ValueEntry temp) {
+    this->caseTemp = std::make_unique<symbols::ValueEntry>(temp);
 }
 
-semantic_analyzer::ValueEntry* SwitchStatement::getCaseTemp() const {
+symbols::ValueEntry* SwitchStatement::getCaseTemp() const {
     return caseTemp.get();
 }
 

--- a/src/ast/SwitchStatement.h
+++ b/src/ast/SwitchStatement.h
@@ -24,8 +24,8 @@ public:
     void setExitLabel(semantic_analyzer::LabelEntry exitLabel);
     semantic_analyzer::LabelEntry* getExitLabel() const;
 
-    void setCaseTemp(semantic_analyzer::ValueEntry temp);
-    semantic_analyzer::ValueEntry* getCaseTemp() const;
+    void setCaseTemp(symbols::ValueEntry temp);
+    symbols::ValueEntry* getCaseTemp() const;
 
     void addCase(CaseLabel* caseLabel);
     const std::vector<CaseLabel*>& getCases() const;
@@ -38,7 +38,7 @@ public:
 
 private:
     std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
-    std::unique_ptr<semantic_analyzer::ValueEntry> caseTemp { nullptr };
+    std::unique_ptr<symbols::ValueEntry> caseTemp { nullptr };
     std::vector<CaseLabel*> cases;
     DefaultLabel* defaultLabelNode { nullptr };
 };

--- a/src/ast/UnaryExpression.cpp
+++ b/src/ast/UnaryExpression.cpp
@@ -60,11 +60,12 @@ semantic_analyzer::LabelEntry* UnaryExpression::getFalsyLabel() const {
     return falsyLabel.get();
 }
 
-void UnaryExpression::setLvalueSymbol(semantic_analyzer::ValueEntry lvalueSymbol) {
-    this->lvalueSymbol = std::make_unique<semantic_analyzer::ValueEntry>(lvalueSymbol);
+void UnaryExpression::setLvalueSymbol(symbols::ValueEntry lvalueSymbol) {
+    this->lvalueSymbol = std::make_unique<symbols::ValueEntry>(lvalueSymbol);
 }
 
-semantic_analyzer::ValueEntry* UnaryExpression::getLvalueSymbol() const {
+symbols::ValueEntry* UnaryExpression::getLvalueSymbol(symbols::AnnotationStore& store) const {
+    (void)store;
     return lvalueSymbol.get();
 }
 

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -22,8 +22,8 @@ public:
     void setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel);
     semantic_analyzer::LabelEntry* getFalsyLabel() const;
 
-    void setLvalueSymbol(semantic_analyzer::ValueEntry lvalueSymbol);
-    semantic_analyzer::ValueEntry* getLvalueSymbol() const override;
+    void setLvalueSymbol(symbols::ValueEntry lvalueSymbol);
+    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
     void setSizeofValue(int bytes);
     int getSizeofValue() const;
@@ -32,7 +32,7 @@ private:
     std::unique_ptr<semantic_analyzer::LabelEntry> truthyLabel { nullptr };
     std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
 
-    std::unique_ptr<semantic_analyzer::ValueEntry> lvalueSymbol { nullptr };
+    std::unique_ptr<symbols::ValueEntry> lvalueSymbol { nullptr };
     int sizeofValue { -1 };
 };
 

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -84,16 +84,16 @@ void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
         }
         return;
     }
-    if (declarator.getInitializer()->hasResultSymbol()) {
+    if (declarator.getInitializer()->hasResultSymbol(store_)) {
         instructions.push_back(std::make_unique<Assign>(
-                declarator.getInitializerHolder()->getName(), holder->getName()));
+                declarator.getInitializerHolder(store_)->getName(), holder->getName()));
     }
 }
 
 void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     arrayAccess.visitLeftOperand(*this);
     arrayAccess.visitRightOperand(*this);
-    if (!arrayAccess.getLvalue() || !arrayAccess.getResultSymbol()) {
+    if (!arrayAccess.getLvalue() || !arrayAccess.getResultSymbol(store_)) {
         return;
     }
     const auto* indexPlan = store_.addressPlan(&arrayAccess);
@@ -101,8 +101,8 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     // SA always publishes IndexPlan for successful array access analysis.
     assert(index && "IndexPlan required for array codegen");
     instructions.push_back(std::make_unique<IndexAddress>(
-            arrayAccess.leftOperandSymbol()->getName(),
-            arrayAccess.rightOperandSymbol()->getName(),
+            arrayAccess.leftOperandSymbol(store_)->getName(),
+            arrayAccess.rightOperandSymbol(store_)->getName(),
             arrayAccess.getElementSize(),
             arrayAccess.getLvalue()->getName(),
             index->baseMode));
@@ -111,7 +111,7 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
         instructions.push_back(std::make_unique<Dereference>(
                 arrayAccess.getLvalue()->getName(),
                 arrayAccess.getLvalue()->getName(),
-                arrayAccess.getResultSymbol()->getName()));
+                arrayAccess.getResultSymbol(store_)->getName()));
     }
 }
 
@@ -121,25 +121,23 @@ void CodeGeneratingVisitor::visit(ast::InitializerListExpression& expression) {
 
 void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
     memberAccess.getBase()->accept(*this);
-    if (!memberAccess.getFieldAddressSymbol() || !memberAccess.getResultSymbol()) {
+    if (!memberAccess.getFieldAddressSymbol() || !memberAccess.getResultSymbol(store_)) {
         return;
     }
     const auto* plan = store_.addressPlan(&memberAccess);
     const auto* field = plan ? symbols::get_if<symbols::FieldPlan>(plan) : nullptr;
-    if (!field) {
-        return; // SA error path
-    }
+    assert(field && "FieldPlan required for member access codegen");
     const std::string addrTemp = !field->addressTempName.empty()
             ? field->addressTempName
             : memberAccess.getFieldAddressSymbol()->getName();
     instructions.push_back(std::make_unique<FieldAddress>(
-            memberAccess.getBase()->getResultSymbol()->getName(),
+            memberAccess.getBase()->getResultSymbol(store_)->getName(),
             field->fieldOffsetBytes,
             addrTemp,
             field->baseMode));
     if (!memberAccess.holdsAggregateAddress()) {
         instructions.push_back(std::make_unique<Dereference>(
-                addrTemp, addrTemp, memberAccess.getResultSymbol()->getName()));
+                addrTemp, addrTemp, memberAccess.getResultSymbol(store_)->getName()));
     }
 }
 
@@ -148,7 +146,7 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
     functionCall.visitArguments(*this);
 
     for (auto& expression : functionCall.getArgumentList()) {
-        instructions.push_back(std::make_unique<Argument>(expression->getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Argument>(expression->getResultSymbol(store_)->getName()));
     }
 
     const symbols::CallPlan* plan = store_.callPlan(&functionCall);
@@ -158,8 +156,8 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
     }
     instructions.push_back(std::make_unique<Call>(
             symbols::callCalleeName(*plan), symbols::isIndirectCall(*plan)));
-    if (functionCall.hasResultSymbol() && !functionCall.getType().isVoid()) {
-        instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol()->getName()));
+    if (functionCall.hasResultSymbol(store_) && !functionCall.getType().isVoid()) {
+        instructions.push_back(std::make_unique<Retrieve>(functionCall.getResultSymbol(store_)->getName()));
     }
 }
 
@@ -177,19 +175,19 @@ void CodeGeneratingVisitor::visit(ast::IdentifierExpression& identifier) {
 }
 
 void CodeGeneratingVisitor::visit(ast::ConstantExpression& constant) {
-    instructions.push_back(std::make_unique<AssignConstant>(constant.getValue(), constant.getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>(constant.getValue(), constant.getResultSymbol(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::StringLiteralExpression& stringLiteral) {
     instructions.push_back(
-        std::make_unique<AssignConstant>(stringLiteral.getConstantSymbol(), stringLiteral.getResultSymbol()->getName())
+        std::make_unique<AssignConstant>(stringLiteral.getConstantSymbol(), stringLiteral.getResultSymbol(store_)->getName())
     );
 }
 
 void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
     expression.visitOperand(*this);
 
-    auto resultSymbolName = expression.getResultSymbol()->getName();
+    auto resultSymbolName = expression.getResultSymbol(store_)->getName();
     auto preOperationSymbol = expression.getPreOperationSymbol()->getName();
     instructions.push_back(std::make_unique<Assign>(resultSymbolName, preOperationSymbol));
 
@@ -200,24 +198,24 @@ void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
     }
 
     // Dereference (and similar) lvalues: value lives in a temp; store new value through the pointer.
-    if (auto* lvalue = expression.operandLvalueSymbol()) {
+    if (auto* lvalue = expression.operandLvalueSymbol(store_)) {
         instructions.push_back(std::make_unique<LvalueAssign>(resultSymbolName, lvalue->getName()));
     }
 
-    expression.setResultSymbol(*expression.getPreOperationSymbol());
+    expression.setResultSymbol(store_, *expression.getPreOperationSymbol());
 }
 
 void CodeGeneratingVisitor::visit(ast::PrefixExpression& expression) {
     expression.visitOperand(*this);
 
-    auto resultSymbolName = expression.getResultSymbol()->getName();
+    auto resultSymbolName = expression.getResultSymbol(store_)->getName();
     if (expression.getOperator()->getLexeme() == "++") {
         instructions.push_back(std::make_unique<Inc>(resultSymbolName));
     } else if (expression.getOperator()->getLexeme() == "--") {
         instructions.push_back(std::make_unique<Dec>(resultSymbolName));
     }
 
-    if (auto* lvalue = expression.operandLvalueSymbol()) {
+    if (auto* lvalue = expression.operandLvalueSymbol(store_)) {
         instructions.push_back(std::make_unique<LvalueAssign>(resultSymbolName, lvalue->getName()));
     }
 }
@@ -226,7 +224,7 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
     if (expression.getOperator()->getLexeme() == "sizeof") {
         // Operand is unevaluated at runtime; emit the folded size constant.
         instructions.push_back(std::make_unique<AssignConstant>(
-                std::to_string(expression.getSizeofValue()), expression.getResultSymbol()->getName()));
+                std::to_string(expression.getSizeofValue()), expression.getResultSymbol(store_)->getName()));
         return;
     }
 
@@ -237,70 +235,70 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
         // &function designator: SA reuses the designator temp (already emitted FunctionAddress).
         if (expression.getOperandExpression()->holdsFunctionDesignator()) {
             break;
-        } else if (auto* lvalue = expression.operandLvalueSymbol()) {
+        } else if (auto* lvalue = expression.operandLvalueSymbol(store_)) {
             // &a[i] / &*p: address is already computed in the operand's lvalue temp.
             instructions.push_back(std::make_unique<Assign>(
-                    lvalue->getName(), expression.getResultSymbol()->getName()));
+                    lvalue->getName(), expression.getResultSymbol(store_)->getName()));
         } else {
             instructions.push_back(std::make_unique<AddressOf>(
-                    expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+                    expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
         }
         break;
     case '*':
-        if (expression.operandSymbol()->getType().isPointer()) {
+        if (expression.operandSymbol(store_)->getType().isPointer()) {
             // *fp for pointer-to-function: SA keeps the pointer value (no memory load).
-            if (type::isPointerToBareFunction(expression.operandSymbol()->getType())) {
-                if (expression.operandSymbol()->getName() != expression.getResultSymbol()->getName()) {
+            if (type::isPointerToBareFunction(expression.operandSymbol(store_)->getType())) {
+                if (expression.operandSymbol(store_)->getName() != expression.getResultSymbol(store_)->getName()) {
                     instructions.push_back(std::make_unique<Assign>(
-                            expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+                            expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
                 }
                 break;
             }
             // Already an address (pointer or multi-dim decayed row).
-            if (expression.getResultSymbol()->getName() == expression.getLvalueSymbol()->getName()) {
+            if (expression.getResultSymbol(store_)->getName() == expression.getLvalueSymbol(store_)->getName()) {
                 // Address-only multi-dim *a: just materialize &array into the temp if needed.
                 // Result and lvalue share the address temp; operand is the array object.
                 if (expression.operandType().isArray()) {
                     instructions.push_back(std::make_unique<AddressOf>(
-                            expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName()));
+                            expression.operandSymbol(store_)->getName(), expression.getLvalueSymbol(store_)->getName()));
                 } else {
                     instructions.push_back(std::make_unique<Assign>(
-                            expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+                            expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
                 }
             } else {
-                instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(),
-                        expression.getLvalueSymbol()->getName(), expression.getResultSymbol()->getName()));
+                instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol(store_)->getName(),
+                        expression.getLvalueSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
             }
         } else if (expression.operandType().isArray()) {
             // True array object: &a then optional load.
             instructions.push_back(std::make_unique<AddressOf>(
-                    expression.operandSymbol()->getName(), expression.getLvalueSymbol()->getName()));
-            if (expression.getResultSymbol()->getName() != expression.getLvalueSymbol()->getName()) {
+                    expression.operandSymbol(store_)->getName(), expression.getLvalueSymbol(store_)->getName()));
+            if (expression.getResultSymbol(store_)->getName() != expression.getLvalueSymbol(store_)->getName()) {
                 instructions.push_back(std::make_unique<Dereference>(
-                        expression.getLvalueSymbol()->getName(),
-                        expression.getLvalueSymbol()->getName(),
-                        expression.getResultSymbol()->getName()));
+                        expression.getLvalueSymbol(store_)->getName(),
+                        expression.getLvalueSymbol(store_)->getName(),
+                        expression.getResultSymbol(store_)->getName()));
             }
         } else {
-            instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol()->getName(),
-                    expression.getLvalueSymbol()->getName(), expression.getResultSymbol()->getName()));
+            instructions.push_back(std::make_unique<Dereference>(expression.operandSymbol(store_)->getName(),
+                    expression.getLvalueSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
         }
         break;
     case '+':
         break;
     case '-':
-        instructions.push_back(std::make_unique<UnaryMinus>(expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<UnaryMinus>(expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
         break;
     case '~':
-        instructions.push_back(std::make_unique<UnaryNot>(expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<UnaryNot>(expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
         break;
     case '!':
-        instructions.push_back(std::make_unique<ZeroCompare>(expression.operandSymbol()->getName()));
+        instructions.push_back(std::make_unique<ZeroCompare>(expression.operandSymbol(store_)->getName()));
         instructions.push_back(std::make_unique<Jump>(expression.getTruthyLabel()->getName(), JumpCondition::IF_EQUAL));
-        instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
         instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName()));
         instructions.push_back(std::make_unique<Label>(expression.getTruthyLabel()->getName()));
-        instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
         instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
         break;
     default:
@@ -312,12 +310,12 @@ void CodeGeneratingVisitor::visit(ast::TypeCast& expression) {
     expression.visitOperand(*this);
     // Only true array objects need AddressOf. Multi-dim rows already hold a decayed pointer
     // in the result symbol while expression type may still be array.
-    if (expression.operandSymbol()->getType().isArray()) {
+    if (expression.operandSymbol(store_)->getType().isArray()) {
         instructions.push_back(std::make_unique<AddressOf>(
-                expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+                expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
     } else {
         instructions.push_back(std::make_unique<Assign>(
-                expression.operandSymbol()->getName(), expression.getResultSymbol()->getName()));
+                expression.operandSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
     }
 }
 
@@ -327,24 +325,24 @@ void CodeGeneratingVisitor::visit(ast::ArithmeticExpression& expression) {
 
     switch (expression.getOperator()->getLexeme().front()) {
     case '+':
-        instructions.push_back(std::make_unique<Add>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Add>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     case '-':
-        instructions.push_back(std::make_unique<Sub>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Sub>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     case '*':
-        instructions.push_back(std::make_unique<Mul>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Mul>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     case '/':
-        instructions.push_back(std::make_unique<Div>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Div>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     case '%':
-        instructions.push_back(std::make_unique<Mod>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Mod>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     default:
         throw std::runtime_error { "unidentified arithmetic operator: " + expression.getOperator()->getLexeme() };
@@ -358,15 +356,15 @@ void CodeGeneratingVisitor::visit(ast::ShiftExpression& expression) {
     switch (expression.getOperator()->getLexeme().front()) {
     case '<':   // <<
         instructions.push_back(std::make_unique<Shl>(
-                    expression.leftOperandSymbol()->getName(),
-                    expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()));
+                    expression.leftOperandSymbol(store_)->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
+                    expression.getResultSymbol(store_)->getName()));
         break;
     case '>':   // >>
         instructions.push_back(std::make_unique<Shr>(
-                    expression.leftOperandSymbol()->getName(),
-                    expression.rightOperandSymbol()->getName(),
-                    expression.getResultSymbol()->getName()));
+                    expression.leftOperandSymbol(store_)->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
+                    expression.getResultSymbol(store_)->getName()));
         break;
     default:
         throw std::runtime_error { "unidentified shift operator!" };
@@ -377,7 +375,7 @@ void CodeGeneratingVisitor::visit(ast::ComparisonExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
 
-    instructions.push_back(std::make_unique<ValueCompare>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName()));
+    instructions.push_back(std::make_unique<ValueCompare>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName()));
 
     auto truthyLabel = expression.getTruthyLabel()->getName();
     if (expression.getOperator()->getLexeme() == ">") {
@@ -396,10 +394,10 @@ void CodeGeneratingVisitor::visit(ast::ComparisonExpression& expression) {
         throw std::runtime_error { "unidentified ml_op operator!\n" };
     }
 
-    instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName()));
     instructions.push_back(std::make_unique<Label>(truthyLabel));
-    instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
 }
 
@@ -409,16 +407,16 @@ void CodeGeneratingVisitor::visit(ast::BitwiseExpression& expression) {
 
     switch (expression.getOperator()->getLexeme().front()) {
     case '&':
-        instructions.push_back(std::make_unique<And>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<And>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     case '|':
-        instructions.push_back(std::make_unique<Or>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                    expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Or>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                    expression.getResultSymbol(store_)->getName()));
         break;
     case '^':
-        instructions.push_back(std::make_unique<Xor>(expression.leftOperandSymbol()->getName(), expression.rightOperandSymbol()->getName(),
-                                                     expression.getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<Xor>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
+                                                     expression.getResultSymbol(store_)->getName()));
         break;
     default:
         throw std::runtime_error { "no semantic actions defined for bitwise operator: " + expression.getOperator()->getLexeme() };
@@ -428,15 +426,15 @@ void CodeGeneratingVisitor::visit(ast::BitwiseExpression& expression) {
 void CodeGeneratingVisitor::visit(ast::LogicalAndExpression& expression) {
     expression.visitLeftOperand(*this);
 
-    instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol()->getName()));
-    instructions.push_back(std::make_unique<ZeroCompare>(expression.leftOperandSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(expression.leftOperandSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_EQUAL));
 
     expression.visitRightOperand(*this);
 
-    instructions.push_back(std::make_unique<ZeroCompare>(expression.rightOperandSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(expression.rightOperandSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_EQUAL));
-    instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
 
     instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
 }
@@ -444,33 +442,33 @@ void CodeGeneratingVisitor::visit(ast::LogicalAndExpression& expression) {
 void CodeGeneratingVisitor::visit(ast::LogicalOrExpression& expression) {
     expression.visitLeftOperand(*this);
 
-    instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol()->getName()));
-    instructions.push_back(std::make_unique<ZeroCompare>(expression.leftOperandSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(expression.leftOperandSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_NOT_EQUAL));
 
     expression.visitRightOperand(*this);
 
-    instructions.push_back(std::make_unique<ZeroCompare>(expression.rightOperandSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(expression.rightOperandSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_NOT_EQUAL));
-    instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
 
     instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::ConditionalExpression& expression) {
     expression.visitCondition(*this);
-    instructions.push_back(std::make_unique<ZeroCompare>(expression.conditionSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(expression.conditionSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
 
     expression.visitTrueExpression(*this);
     instructions.push_back(std::make_unique<Assign>(
-            expression.trueSymbol()->getName(), expression.getResultSymbol()->getName()));
+            expression.trueSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName()));
 
     instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
     expression.visitFalseExpression(*this);
     instructions.push_back(std::make_unique<Assign>(
-            expression.falseSymbol()->getName(), expression.getResultSymbol()->getName()));
+            expression.falseSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
 
     instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
 }
@@ -480,81 +478,81 @@ void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
     expression.visitRightOperand(*this);
 
     auto assignmentOperator = expression.getOperator();
-    auto resultName = expression.getResultSymbol()->getName();
+    auto resultName = expression.getResultSymbol(store_)->getName();
     if (assignmentOperator->getLexeme() == "+=")
         instructions.push_back(std::make_unique<Add>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "-=")
         instructions.push_back(std::make_unique<Sub>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "*=")
         instructions.push_back(std::make_unique<Mul>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "/=")
         instructions.push_back(std::make_unique<Div>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "%=")
         instructions.push_back(std::make_unique<Mod>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "&=")
         instructions.push_back(std::make_unique<And>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "^=")
         instructions.push_back(std::make_unique<Xor>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "|=")
         instructions.push_back(std::make_unique<Or>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     else if (assignmentOperator->getLexeme() == "<<=") {
         instructions.push_back(std::make_unique<Shl>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     } else if (assignmentOperator->getLexeme() == ">>=") {
         instructions.push_back(std::make_unique<Shr>(
                     resultName,
-                    expression.rightOperandSymbol()->getName(),
+                    expression.rightOperandSymbol(store_)->getName(),
                     resultName
         ));
     } else if (assignmentOperator->getLexeme() == "=") {
-        if (expression.leftOperandLvalueSymbol()) {
+        if (expression.leftOperandLvalueSymbol(store_)) {
             // Convert into the LHS value temp (correct store width) then write through the address.
             instructions.push_back(std::make_unique<Assign>(
-                        expression.rightOperandSymbol()->getName(),
+                        expression.rightOperandSymbol(store_)->getName(),
                         resultName
             ));
             instructions.push_back(std::make_unique<LvalueAssign>(
                         resultName,
-                        expression.leftOperandLvalueSymbol()->getName()
+                        expression.leftOperandLvalueSymbol(store_)->getName()
             ));
         } else {
             instructions.push_back(std::make_unique<Assign>(
-                        expression.rightOperandSymbol()->getName(),
+                        expression.rightOperandSymbol(store_)->getName(),
                         resultName
             ));
         }
@@ -564,7 +562,7 @@ void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
     }
 
     // Compound assign updated the value temp; write back through pointer lvalues (e.g. *p += 1).
-    if (auto* lvalue = expression.leftOperandLvalueSymbol()) {
+    if (auto* lvalue = expression.leftOperandLvalueSymbol(store_)) {
         instructions.push_back(std::make_unique<LvalueAssign>(resultName, lvalue->getName()));
     }
 }
@@ -587,7 +585,7 @@ void CodeGeneratingVisitor::visit(ast::JumpStatement& statement) {
 void CodeGeneratingVisitor::visit(ast::SwitchStatement& statement) {
     statement.expression->accept(*this);
 
-    auto switchResult = statement.expression->getResultSymbol()->getName();
+    auto switchResult = statement.expression->getResultSymbol(store_)->getName();
     auto caseTemp = statement.getCaseTemp()->getName();
 
     for (auto* caseLabel : statement.getCases()) {
@@ -634,7 +632,7 @@ void CodeGeneratingVisitor::visit(ast::LabeledStatement& statement) {
 
 void CodeGeneratingVisitor::visit(ast::ReturnStatement& statement) {
     statement.returnExpression->accept(*this);
-    instructions.push_back(std::make_unique<Return>(statement.returnExpression->getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<Return>(statement.returnExpression->getResultSymbol(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::VoidReturnStatement &statement) { instructions.push_back(std::make_unique<VoidReturn>()); }
@@ -642,7 +640,7 @@ void CodeGeneratingVisitor::visit(ast::VoidReturnStatement &statement) { instruc
 void CodeGeneratingVisitor::visit(ast::IfStatement& statement) {
     statement.testExpression->accept(*this);
 
-    instructions.push_back(std::make_unique<ZeroCompare>(statement.testExpression->getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(statement.testExpression->getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(statement.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
 
     statement.body->accept(*this);
@@ -653,7 +651,7 @@ void CodeGeneratingVisitor::visit(ast::IfStatement& statement) {
 void CodeGeneratingVisitor::visit(ast::IfElseStatement& statement) {
     statement.testExpression->accept(*this);
 
-    instructions.push_back(std::make_unique<ZeroCompare>(statement.testExpression->getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(statement.testExpression->getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(statement.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
 
     statement.truthyBody->accept(*this);
@@ -698,7 +696,7 @@ void CodeGeneratingVisitor::visit(ast::ForLoopHeader& loopHeader) {
     instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry()->getName()));
     if (loopHeader.clause) {
         loopHeader.clause->accept(*this);
-        instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
+        instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol(store_)->getName()));
         instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
     }
 }
@@ -706,14 +704,14 @@ void CodeGeneratingVisitor::visit(ast::ForLoopHeader& loopHeader) {
 void CodeGeneratingVisitor::visit(ast::WhileLoopHeader& loopHeader) {
     instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry()->getName()));
     loopHeader.clause->accept(*this);
-    instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
 }
 
 void CodeGeneratingVisitor::visit(ast::DoWhileLoopHeader& loopHeader) {
     // Invoked after the body and continue label (see visit(LoopStatement)).
     loopHeader.clause->accept(*this);
-    instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol()->getName()));
+    instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopEntry()->getName(), JumpCondition::IF_NOT_EQUAL));
 }
 

--- a/src/semantic_analyzer/CMakeLists.txt
+++ b/src/semantic_analyzer/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(semantic_analyzer
         SemanticAnalyzer.cpp
         SemanticXmlOutputVisitor.cpp
         SymbolTable.cpp
-        ValueEntry.cpp
         ValueScope.cpp
         FunctionEntry.h
         LabelEntry.h

--- a/src/semantic_analyzer/InitializerLowering.cpp
+++ b/src/semantic_analyzer/InitializerLowering.cpp
@@ -59,12 +59,12 @@ void SemanticAnalysisVisitor::lowerLocalInitializer(ast::InitializedDeclarator& 
 
                 const bool hasElement = i < static_cast<int>(list->getElements().size())
                         && list->getElements()[static_cast<std::size_t>(i)]
-                        && list->getElements()[static_cast<std::size_t>(i)]->hasResultSymbol();
+                        && list->getElements()[static_cast<std::size_t>(i)]->hasResultSymbol(annotations());
                 if (hasElement) {
                     auto& element = list->getElements()[static_cast<std::size_t>(i)];
-                    typeCheck(assignSourceType(*element, memberType), memberType, declarator.getContext());
+                    typeCheck(assignSourceType(*element, memberType, annotations()), memberType, declarator.getContext());
                     field.zeroInitialize = false;
-                    field.sourceName = element->getResultSymbol()->getName();
+                    field.sourceName = element->getResultSymbol(annotations())->getName();
                 } else {
                     auto zero = symbolTable.createTemporarySymbol(memberType);
                     field.zeroInitialize = true;
@@ -89,8 +89,8 @@ void SemanticAnalysisVisitor::lowerLocalInitializer(ast::InitializedDeclarator& 
             list && list->getElements().size() == 1) {
         initExpr = list->getElements().front().get();
     }
-    if (initExpr && initExpr->hasResultSymbol()) {
-        type::Type src = assignSourceType(*initExpr, objectType);
+    if (initExpr && initExpr->hasResultSymbol(annotations())) {
+        type::Type src = assignSourceType(*initExpr, objectType, annotations());
         if (!initExpr->holdsAggregateAddress() || objectType.isPointer()) {
             typeCheck(src, objectType, declarator.getContext());
         }

--- a/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
@@ -47,6 +47,7 @@ inline Logger& semanticErrorLogger() {
 // (array-row decay); structure destinations still see the aggregate expression type.
 inline type::Type assignSourceType(const ast::Expression& expr, const type::Type& dest,
         symbols::AnnotationStore& store) {
+    // AggregateAddress form always has a Result after successful SA (set with the form).
     if (expr.holdsAggregateAddress() && dest.isPointer()) {
         return expr.getResultSymbol(store)->getType();
     }

--- a/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
@@ -45,9 +45,10 @@ inline Logger& semanticErrorLogger() {
 // Source type for assignment/init/return into `dest`.
 // Dual-type aggregate addresses use the pointer value when dest is a pointer
 // (array-row decay); structure destinations still see the aggregate expression type.
-inline type::Type assignSourceType(const ast::Expression& expr, const type::Type& dest) {
+inline type::Type assignSourceType(const ast::Expression& expr, const type::Type& dest,
+        symbols::AnnotationStore& store) {
     if (expr.holdsAggregateAddress() && dest.isPointer()) {
-        return expr.getResultSymbol()->getType();
+        return expr.getResultSymbol(store)->getType();
     }
     return expr.getType();
 }

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -14,7 +14,7 @@ void setFunctionDesignator(ast::IdentifierExpression& identifier, SymbolTable& s
     auto functionEntry = symbolTable.findFunction(identifier.getIdentifier());
     type::Type fnType = type::function(functionEntry.returnType(), functionEntry.arguments());
     auto addr = symbolTable.createTemporarySymbol(type::pointer(fnType));
-    identifier.setFunctionDesignatorResult(addr);
+    identifier.setFunctionDesignatorResult(store, addr);
     symbols::FunctionDesignatorPlan plan;
     plan.functionName = functionEntry.getName();
     plan.addressTempName = addr.getName();
@@ -33,7 +33,7 @@ struct Callee {
 
 std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable& symbolTable,
         symbols::AnnotationStore& store, std::string& errorDisplay) {
-    auto* operandSym = functionCall.operandSymbol();
+    auto* operandSym = functionCall.operandSymbol(store);
     type::Type operandType = operandSym->getType();
     auto* operandExpr = functionCall.getOperandExpression();
 
@@ -78,7 +78,7 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
     functionCall.visitOperand(*this);
     functionCall.visitArguments(*this);
 
-    if (!functionCall.hasOperandSymbol()) {
+    if (!functionCall.hasOperandSymbol(annotations())) {
         return;
     }
 
@@ -93,8 +93,8 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
     // Type-check args before publishing CallPlan (avoid half-applied call shape).
     auto& arguments = functionCall.getArgumentList();
     for (auto& argument : arguments) {
-        if (argument->hasResultSymbol()) {
-            rejectFunctionValue(argument->getResultSymbol()->getType(), functionCall.getContext());
+        if (argument->hasResultSymbol(annotations())) {
+            rejectFunctionValue(argument->getResultSymbol(annotations())->getType(), functionCall.getContext());
         }
     }
 
@@ -110,10 +110,10 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
 
     if (arityOk) {
         for (std::size_t i { 0 }; i < arguments.size(); ++i) {
-            if (!arguments.at(i)->hasResultSymbol()) {
+            if (!arguments.at(i)->hasResultSymbol(annotations())) {
                 return;
             }
-            typeCheck(arguments.at(i)->getResultSymbol()->getType(), declaredArguments.at(i),
+            typeCheck(arguments.at(i)->getResultSymbol(annotations())->getType(), declaredArguments.at(i),
                     functionCall.getContext());
         }
     }
@@ -122,7 +122,7 @@ void SemanticAnalysisVisitor::visit(ast::FunctionCall& functionCall) {
 
     auto returnType = callee.type.getReturnType();
     if (!returnType.isVoid()) {
-        functionCall.setResultSymbol(symbolTable.createTemporarySymbol(returnType));
+        functionCall.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(returnType));
     }
 }
 
@@ -139,7 +139,7 @@ void SemanticAnalysisVisitor::visit(ast::IdentifierExpression& identifier) {
         setFunctionDesignator(identifier, symbolTable, annotations());
         return;
     }
-    identifier.setResultSymbol(entry);
+    identifier.setResultSymbol(annotations(), entry);
 }
 
 } // namespace semantic_analyzer

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -9,12 +9,12 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
     arrayAccess.visitLeftOperand(*this);
     arrayAccess.visitRightOperand(*this);
 
-    if (!arrayAccess.hasLeftOperandSymbol() || !arrayAccess.hasRightOperandSymbol()) {
+    if (!arrayAccess.hasLeftOperandSymbol(annotations()) || !arrayAccess.hasRightOperandSymbol(annotations())) {
         return;
     }
 
     type::Type exprType = arrayAccess.getLeftOperand()->expressionType();
-    type::Type valueType = arrayAccess.getLeftOperand()->valueType();
+    type::Type valueType = arrayAccess.getLeftOperand()->valueType(annotations());
     type::ArraySubscriptInfo sub = type::arraySubscriptInfo(exprType, valueType);
     if (!sub.valid()) {
         semanticError("invalid type for operator[]\n", arrayAccess.getContext());
@@ -37,12 +37,12 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
                 : type::pointer(elementType);
         auto addr = symbolTable.createTemporarySymbol(addrType);
         arrayAccess.setLvalue(addr);
-        arrayAccess.setAggregateAddressResult(addr, elementType);
+        arrayAccess.setAggregateAddressResult(annotations(), addr, elementType);
         indexPlan.addressTempName = addr.getName();
     } else {
         auto addr = symbolTable.createTemporarySymbol(type::pointer(elementType));
         arrayAccess.setLvalue(addr);
-        arrayAccess.setTypeAndResult(symbolTable.createTemporarySymbol(elementType));
+        arrayAccess.setTypeAndResult(annotations(), symbolTable.createTemporarySymbol(elementType));
         indexPlan.addressTempName = addr.getName();
     }
     annotations().setAddressPlan(&arrayAccess, symbols::AddressPlan { indexPlan });
@@ -59,14 +59,14 @@ void SemanticAnalysisVisitor::visit(ast::InitializerListExpression& expression) 
     }
     // Positional list has no single scalar result; InitializedDeclarator handles it.
     if (expression.getElements().size() == 1 && expression.getElements().front()
-            && expression.getElements().front()->hasResultSymbol()) {
-        expression.setResultSymbol(*expression.getElements().front()->getResultSymbol());
+            && expression.getElements().front()->hasResultSymbol(annotations())) {
+        expression.setResultSymbol(annotations(), *expression.getElements().front()->getResultSymbol(annotations()));
     }
 }
 
 void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
     memberAccess.getBase()->accept(*this);
-    if (!memberAccess.getBase()->hasResultSymbol()) {
+    if (!memberAccess.getBase()->hasResultSymbol(annotations())) {
         return;
     }
     MemberBaseResolution base = resolveMemberBase(*memberAccess.getBase(), memberAccess.isArrow());
@@ -93,32 +93,32 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
     fieldPlan.addressTempName = fieldAddr.getName();
     annotations().setAddressPlan(&memberAccess, symbols::AddressPlan { fieldPlan });
     if (memberType.isStructure() || memberType.isArray()) {
-        memberAccess.setAggregateAddressResult(fieldAddr, memberType);
+        memberAccess.setAggregateAddressResult(annotations(), fieldAddr, memberType);
     } else {
-        memberAccess.setTypeAndResult(symbolTable.createTemporarySymbol(memberType));
+        memberAccess.setTypeAndResult(annotations(), symbolTable.createTemporarySymbol(memberType));
     }
 }
 
 void SemanticAnalysisVisitor::visit(ast::ConstantExpression& constant) {
-    constant.setResultSymbol(symbolTable.createTemporarySymbol(constant.getType()));
+    constant.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(constant.getType()));
 }
 
 void SemanticAnalysisVisitor::visit(ast::StringLiteralExpression& stringLiteral) {
     std::string constantSymbol = symbolTable.newConstant(stringLiteral.getValue());
     stringLiteral.setConstantSymbol(constantSymbol);
-    stringLiteral.setResultSymbol(symbolTable.createTemporarySymbol(stringLiteral.getType()));
+    stringLiteral.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(stringLiteral.getType()));
 }
 
 void SemanticAnalysisVisitor::visit(ast::PostfixExpression& expression) {
     expression.visitOperand(*this);
-    if (!expression.hasOperandSymbol()) {
+    if (!expression.hasOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.operandType(), expression.getContext());
 
     expression.setType(expression.operandType());
-    auto operandSymbol = *expression.operandSymbol();
-    expression.setResultSymbol(operandSymbol);
+    auto operandSymbol = *expression.operandSymbol(annotations());
+    expression.setResultSymbol(annotations(), operandSymbol);
 
     auto preOperationSymbolName = operandSymbol.getName() + "_pre";
     symbolTable.insertSymbol(preOperationSymbolName, operandSymbol.getType(), operandSymbol.getContext());
@@ -131,13 +131,13 @@ void SemanticAnalysisVisitor::visit(ast::PostfixExpression& expression) {
 
 void SemanticAnalysisVisitor::visit(ast::PrefixExpression& expression) {
     expression.visitOperand(*this);
-    if (!expression.hasOperandSymbol()) {
+    if (!expression.hasOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.operandType(), expression.getContext());
 
     expression.setType(expression.operandType());
-    expression.setResultSymbol(*expression.operandSymbol());
+    expression.setResultSymbol(annotations(), *expression.operandSymbol(annotations()));
 
     if (!expression.isLval()) {
         semanticError("lvalue required as increment operand", expression.getContext());
@@ -148,8 +148,8 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
     const auto& lexeme = expression.getOperator()->getLexeme();
     if (lexeme == "sizeof") {
         expression.visitOperand(*this);
-        if (!expression.hasOperandSymbol()) {
-            expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+        if (!expression.hasOperandSymbol(annotations())) {
+            expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
             return;
         }
         // C: sizeof does not decay a function designator; it remains incomplete.
@@ -157,7 +157,7 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             semanticError(
                     "invalid application of ‘sizeof’ to incomplete type ‘function’",
                     expression.getContext());
-            expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+            expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
             return;
         }
         const type::Type& operandType = expression.operandType();
@@ -168,16 +168,16 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             semanticError(
                     "invalid application of ‘sizeof’ to incomplete type ‘" + operandType.to_string() + "’",
                     expression.getContext());
-            expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+            expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
             return;
         }
         expression.setSizeofValue(operandType.getSize());
-        expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
         return;
     }
 
     expression.visitOperand(*this);
-    if (!expression.hasOperandSymbol()) {
+    if (!expression.hasOperandSymbol(annotations())) {
         return;
     }
 
@@ -185,31 +185,31 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
     case '&': {
         // &function designator: same pointer-to-function value as bare designator decay (C).
         if (expression.getOperandExpression()->holdsFunctionDesignator()) {
-            expression.setResultSymbol(*expression.operandSymbol());
+            expression.setResultSymbol(annotations(), *expression.operandSymbol(annotations()));
             break;
         }
         rejectFunctionValue(expression.operandType(), expression.getContext());
-        expression.setResultSymbol(symbolTable.createTemporarySymbol(type::pointer(expression.operandType())));
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::pointer(expression.operandType())));
         break;
     }
     case '*': {
         rejectFunctionValue(expression.operandType(), expression.getContext());
         type::Type operandType = expression.operandType();
-        const type::Type valueType = expression.operandSymbol()->getType();
+        const type::Type valueType = expression.operandSymbol(annotations())->getType();
         // Value already a pointer (e.g. multi-dim a[i] decayed row, or int(*)[N]).
         if (valueType.isPointer()) {
             type::Type pointee = valueType.dereference();
             if (type::isBareFunction(pointee)) {
                 // *fp for a bare function pointee: keep the pointer value (no memory load).
                 // Pointer-to-function pointees still need a load (pointer-to-pointer-to-function).
-                expression.setResultSymbol(*expression.operandSymbol());
+                expression.setResultSymbol(annotations(), *expression.operandSymbol(annotations()));
             } else if (pointee.isArray()) {
                 // *ptr-to-array yields the array object (address); do not scalar-load the row.
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(pointee.getElementType()));
                 expression.setLvalueSymbol(addr);
-                expression.setAggregateAddressResult(addr, pointee);
+                expression.setAggregateAddressResult(annotations(), addr, pointee);
             } else {
-                expression.setResultSymbol(symbolTable.createTemporarySymbol(pointee));
+                expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(pointee));
                 expression.setLvalueSymbol(symbolTable.createTemporarySymbol(valueType));
             }
             break;
@@ -221,11 +221,11 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
                 // *a for multi-dim: yield decayed address of first row; keep array expr type.
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(elem.getElementType()));
                 expression.setLvalueSymbol(addr);
-                expression.setAggregateAddressResult(addr, elem);
+                expression.setAggregateAddressResult(annotations(), addr, elem);
             } else {
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(elem));
                 expression.setLvalueSymbol(addr);
-                expression.setResultSymbol(symbolTable.createTemporarySymbol(elem));
+                expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(elem));
                 expression.setType(elem);
             }
             break;
@@ -235,19 +235,19 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
     }
     case '+':
         rejectFunctionValue(expression.operandType(), expression.getContext());
-        expression.setResultSymbol(*expression.operandSymbol());
+        expression.setResultSymbol(annotations(), *expression.operandSymbol(annotations()));
         break;
     case '-':
         rejectFunctionValue(expression.operandType(), expression.getContext());
-        expression.setResultSymbol(symbolTable.createTemporarySymbol(expression.operandType()));
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(expression.operandType()));
         break;
     case '~':
         rejectFunctionValue(expression.operandType(), expression.getContext());
-        expression.setResultSymbol(symbolTable.createTemporarySymbol(expression.operandType()));
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(expression.operandType()));
         break;
     case '!':
         rejectFunctionValue(expression.operandType(), expression.getContext());
-        expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
         expression.setTruthyLabel(symbolTable.newLabel());
         expression.setFalsyLabel(symbolTable.newLabel());
         break;
@@ -258,7 +258,7 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
 
 void SemanticAnalysisVisitor::visit(ast::TypeCast& expression) {
     expression.visitOperand(*this);
-    if (!expression.hasOperandSymbol()) {
+    if (!expression.hasOperandSymbol(annotations())) {
         return;
     }
 
@@ -275,13 +275,13 @@ void SemanticAnalysisVisitor::visit(ast::TypeCast& expression) {
     }
     // Operand may be an array object or a dual-type multi-dim row (value already a pointer).
     // Codegen materializes AddressOf only when the value type is still an array.
-    expression.setResultSymbol(symbolTable.createTemporarySymbol(target));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(target));
 }
 
 void SemanticAnalysisVisitor::visit(ast::ArithmeticExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.leftOperandType(), expression.getContext());
@@ -292,20 +292,20 @@ void SemanticAnalysisVisitor::visit(ast::ArithmeticExpression& expression) {
             expression.rightOperandType(),
             expression.getContext());
     // FIXME: type conversion
-    expression.setResultSymbol(symbolTable.createTemporarySymbol(expression.leftOperandType()));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(expression.leftOperandType()));
 }
 
 void SemanticAnalysisVisitor::visit(ast::ShiftExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.leftOperandType(), expression.getContext());
     rejectFunctionValue(expression.rightOperandType(), expression.getContext());
 
     if (expression.rightOperandType().isPrimitive() && !expression.rightOperandType().getPrimitive().isFloating()) {
-        expression.setResultSymbol(symbolTable.createTemporarySymbol(expression.leftOperandType()));
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(expression.leftOperandType()));
     } else {
         semanticError("argument of type int required for shift expression", expression.getContext());
     }
@@ -314,7 +314,7 @@ void SemanticAnalysisVisitor::visit(ast::ShiftExpression& expression) {
 void SemanticAnalysisVisitor::visit(ast::ComparisonExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.leftOperandType(), expression.getContext());
@@ -325,7 +325,7 @@ void SemanticAnalysisVisitor::visit(ast::ComparisonExpression& expression) {
             expression.rightOperandType(),
             expression.getContext());
 
-    expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
     expression.setTruthyLabel(symbolTable.newLabel());
     expression.setFalsyLabel(symbolTable.newLabel());
 }
@@ -333,7 +333,7 @@ void SemanticAnalysisVisitor::visit(ast::ComparisonExpression& expression) {
 void SemanticAnalysisVisitor::visit(ast::BitwiseExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.leftOperandType(), expression.getContext());
@@ -345,14 +345,14 @@ void SemanticAnalysisVisitor::visit(ast::BitwiseExpression& expression) {
             expression.rightOperandType(),
             expression.getContext());
 
-    expression.setResultSymbol(
+    expression.setResultSymbol(annotations(), 
             symbolTable.createTemporarySymbol(expression.getType()));
 }
 
 void SemanticAnalysisVisitor::visit(ast::LogicalAndExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.leftOperandType(), expression.getContext());
@@ -363,14 +363,14 @@ void SemanticAnalysisVisitor::visit(ast::LogicalAndExpression& expression) {
             expression.rightOperandType(),
             expression.getContext());
 
-    expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
     expression.setExitLabel(symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::LogicalOrExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     rejectFunctionValue(expression.leftOperandType(), expression.getContext());
@@ -381,7 +381,7 @@ void SemanticAnalysisVisitor::visit(ast::LogicalOrExpression& expression) {
             expression.rightOperandType(),
             expression.getContext());
 
-    expression.setResultSymbol(symbolTable.createTemporarySymbol(type::signedInteger()));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
     expression.setExitLabel(symbolTable.newLabel());
 }
 
@@ -390,25 +390,25 @@ void SemanticAnalysisVisitor::visit(ast::ConditionalExpression& expression) {
     expression.visitTrueExpression(*this);
     expression.visitFalseExpression(*this);
 
-    if (!expression.getCondition()->hasResultSymbol()
-            || !expression.getTrueExpression()->hasResultSymbol()
-            || !expression.getFalseExpression()->hasResultSymbol()) {
+    if (!expression.getCondition()->hasResultSymbol(annotations())
+            || !expression.getTrueExpression()->hasResultSymbol(annotations())
+            || !expression.getFalseExpression()->hasResultSymbol(annotations())) {
         return;
     }
 
-    rejectFunctionValue(expression.conditionSymbol()->getType(), expression.getContext());
-    rejectFunctionValue(expression.trueSymbol()->getType(), expression.getContext());
-    rejectFunctionValue(expression.falseSymbol()->getType(), expression.getContext());
+    rejectFunctionValue(expression.conditionSymbol(annotations())->getType(), expression.getContext());
+    rejectFunctionValue(expression.trueSymbol(annotations())->getType(), expression.getContext());
+    rejectFunctionValue(expression.falseSymbol(annotations())->getType(), expression.getContext());
 
     typeCheck(
-            expression.trueSymbol()->getType(),
-            expression.falseSymbol()->getType(),
+            expression.trueSymbol(annotations())->getType(),
+            expression.falseSymbol(annotations())->getType(),
             expression.getContext());
 
     // Result type follows the true arm after typeCheck (same policy as other binary ops).
-    const type::Type resultType = expression.trueSymbol()->getType();
+    const type::Type resultType = expression.trueSymbol(annotations())->getType();
     expression.setType(resultType);
-    expression.setResultSymbol(symbolTable.createTemporarySymbol(resultType));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(resultType));
     expression.setFalsyLabel(symbolTable.newLabel());
     expression.setExitLabel(symbolTable.newLabel());
 }
@@ -416,7 +416,7 @@ void SemanticAnalysisVisitor::visit(ast::ConditionalExpression& expression) {
 void SemanticAnalysisVisitor::visit(ast::AssignmentExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasLeftOperandSymbol() || !expression.hasRightOperandSymbol()) {
+    if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
 
@@ -430,13 +430,13 @@ void SemanticAnalysisVisitor::visit(ast::AssignmentExpression& expression) {
             return;
         }
         rejectFunctionValue(left, expression.getContext());
-        type::Type srcType = assignSourceType(*right, left);
+        type::Type srcType = assignSourceType(*right, left, annotations());
         if (!right->holdsAggregateAddress()) {
             rejectFunctionValue(srcType, expression.getContext());
         }
         typeCheck(srcType, left, expression.getContext());
 
-        expression.setTypeAndResult(*expression.leftOperandSymbol());
+        expression.setTypeAndResult(annotations(), *expression.leftOperandSymbol(annotations()));
     } else {
         semanticError("lvalue required on the left side of assignment", expression.getContext());
     }
@@ -445,12 +445,12 @@ void SemanticAnalysisVisitor::visit(ast::AssignmentExpression& expression) {
 void SemanticAnalysisVisitor::visit(ast::ExpressionList& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
-    if (!expression.hasRightOperandSymbol()) {
+    if (!expression.hasRightOperandSymbol(annotations())) {
         return;
     }
     // Comma operator: value and type of the right operand
     expression.setType(expression.rightOperandType());
-    expression.setResultSymbol(*expression.rightOperandSymbol());
+    expression.setResultSymbol(annotations(), *expression.rightOperandSymbol(annotations()));
 }
 
 void SemanticAnalysisVisitor::visit(ast::Operator&) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
@@ -24,8 +24,8 @@ void SemanticAnalysisVisitor::visit(ast::JumpStatement& statement) {
 
 void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
     statement.expression->accept(*this);
-    if (statement.expression->hasResultSymbol()) {
-        rejectFunctionValue(statement.expression->getResultSymbol()->getType(),
+    if (statement.expression->hasResultSymbol(annotations())) {
+        rejectFunctionValue(statement.expression->getResultSymbol(annotations())->getType(),
                 statement.expression->getContext());
     }
 
@@ -116,7 +116,7 @@ void SemanticAnalysisVisitor::visit(ast::LabeledStatement& statement) {
 
 void SemanticAnalysisVisitor::visit(ast::ReturnStatement& statement) {
     statement.returnExpression->accept(*this);
-    if (!statement.returnExpression->hasResultSymbol()) {
+    if (!statement.returnExpression->hasResultSymbol(annotations())) {
         return;
     }
     auto* retExpr = statement.returnExpression.get();
@@ -126,7 +126,7 @@ void SemanticAnalysisVisitor::visit(ast::ReturnStatement& statement) {
         return;
     }
     type::Type dest = currentReturnType ? *currentReturnType : type::voidType();
-    type::Type retVal = currentReturnType ? assignSourceType(*retExpr, dest) : retExpr->getType();
+    type::Type retVal = currentReturnType ? assignSourceType(*retExpr, dest, annotations()) : retExpr->getType();
     rejectFunctionValue(retVal, retExpr->getContext());
     if (currentReturnType) {
         typeCheck(retVal, *currentReturnType, retExpr->getContext());
@@ -138,8 +138,8 @@ void SemanticAnalysisVisitor::visit(ast::VoidReturnStatement& statement) {
 
 void SemanticAnalysisVisitor::visit(ast::IfStatement& statement) {
     statement.testExpression->accept(*this);
-    if (statement.testExpression->hasResultSymbol()) {
-        rejectFunctionValue(statement.testExpression->getResultSymbol()->getType(),
+    if (statement.testExpression->hasResultSymbol(annotations())) {
+        rejectFunctionValue(statement.testExpression->getResultSymbol(annotations())->getType(),
                 statement.testExpression->getContext());
     }
     statement.body->accept(*this);
@@ -149,8 +149,8 @@ void SemanticAnalysisVisitor::visit(ast::IfStatement& statement) {
 
 void SemanticAnalysisVisitor::visit(ast::IfElseStatement& statement) {
     statement.testExpression->accept(*this);
-    if (statement.testExpression->hasResultSymbol()) {
-        rejectFunctionValue(statement.testExpression->getResultSymbol()->getType(),
+    if (statement.testExpression->hasResultSymbol(annotations())) {
+        rejectFunctionValue(statement.testExpression->getResultSymbol(annotations())->getType(),
                 statement.testExpression->getContext());
     }
     statement.truthyBody->accept(*this);

--- a/src/semantic_analyzer/ValueEntry.h
+++ b/src/semantic_analyzer/ValueEntry.h
@@ -1,42 +1,11 @@
 #ifndef VALUEENTRY_H_
 #define VALUEENTRY_H_
 
-#include <memory>
-#include <optional>
-#include <string>
-
-#include "translation_unit/Context.h"
-#include "types/Type.h"
+// ValueEntry lives in symbols (host-aligned). This header re-exports for SA.
+#include "symbols/ValueEntry.h"
 
 namespace semantic_analyzer {
+using ValueEntry = symbols::ValueEntry;
+}
 
-class ValueEntry {
-public:
-    ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index, bool global = false);
-
-    std::string getName() const;
-    bool isGlobal() const;
-    type::Type getType() const;
-    translation_unit::Context getContext() const;
-    int getIndex() const;
-
-    // Folded integer constant initializer for file-scope variables (unset means default 0).
-    void setConstantInitializer(long value);
-    std::optional<long> getConstantInitializer() const;
-
-    std::string to_string() const;
-
-private:
-    std::string name;
-    type::Type type;
-    translation_unit::Context context;
-    int index;
-
-    bool temp;
-    bool global;
-    std::optional<long> constantInitializer;
-};
-
-} // namespace semantic_analyzer
-
-#endif // VALUEENTRY_H_
+#endif

--- a/src/semantic_analyzer/ValueScope.cpp
+++ b/src/semantic_analyzer/ValueScope.cpp
@@ -21,7 +21,7 @@ public:
             name { name }
     {
     }
-    bool operator()(const semantic_analyzer::ValueEntry& entry) {
+    bool operator()(const symbols::ValueEntry& entry) {
         return entry.getName() == name;
     }
 

--- a/src/symbols/AnnotationStore.cpp
+++ b/src/symbols/AnnotationStore.cpp
@@ -1,5 +1,7 @@
 #include "AnnotationStore.h"
 
+#include <cassert>
+
 namespace symbols {
 
 const std::vector<StructFieldInit> AnnotationStore::kEmptyFieldInits {};
@@ -14,6 +16,50 @@ const NodeAnnotations* AnnotationStore::nodeIfAny(NodeRef key) const {
         return nullptr;
     }
     return &it->second;
+}
+
+void AnnotationStore::setValue(NodeRef node, ValueSlot slot, ValueEntry value) {
+    this->node(node).values[slot] = std::make_unique<ValueEntry>(std::move(value));
+}
+
+ValueEntry* AnnotationStore::value(NodeRef node, ValueSlot slot) {
+    auto* n = nodeIfAny(node);
+    if (!n) {
+        return nullptr;
+    }
+    auto it = n->values.find(slot);
+    if (it == n->values.end()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+const ValueEntry* AnnotationStore::value(NodeRef node, ValueSlot slot) const {
+    auto* n = nodeIfAny(node);
+    if (!n) {
+        return nullptr;
+    }
+    auto it = n->values.find(slot);
+    if (it == n->values.end()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+bool AnnotationStore::hasValue(NodeRef node, ValueSlot slot) const {
+    return value(node, slot) != nullptr;
+}
+
+ValueEntry* AnnotationStore::result(NodeRef node) {
+    auto* r = value(node, ValueSlot::Result);
+    assert(r && "Result annotation required but missing");
+    return r;
+}
+
+const ValueEntry* AnnotationStore::result(NodeRef node) const {
+    auto* r = value(node, ValueSlot::Result);
+    assert(r && "Result annotation required but missing");
+    return r;
 }
 
 void AnnotationStore::setAddressPlan(NodeRef node, AddressPlan plan) {

--- a/src/symbols/AnnotationStore.h
+++ b/src/symbols/AnnotationStore.h
@@ -1,19 +1,28 @@
 #ifndef SYMBOLS_ANNOTATION_STORE_H_
 #define SYMBOLS_ANNOTATION_STORE_H_
 
+#include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
 
 #include "AddressPlan.h"
+#include "ValueEntry.h"
 
 // Side table for SA→CG facts (finish-for-git AnnotationStore subset).
-// Expression Result values still live on ast::Expression for this stack slice;
-// plans and field-init schedules live here so they are not AST syntax.
+// Value annotations (Result / Lvalue) and plans live here — not on AST syntax nodes.
 
 namespace symbols {
 
+enum class ValueSlot {
+    Result,
+    // Sole address temp for this expression when stored on the side table
+    // (array/member lvalues still use node fields until a follow-up migrates them).
+    Lvalue,
+};
+
 struct NodeAnnotations {
+    std::unordered_map<ValueSlot, std::unique_ptr<ValueEntry>> values;
     std::optional<AddressPlan> addressPlan;
     std::optional<CallPlan> callPlan;
     std::vector<StructFieldInit> fieldInits;
@@ -21,6 +30,24 @@ struct NodeAnnotations {
 
 class AnnotationStore {
 public:
+    void setValue(NodeRef node, ValueSlot slot, ValueEntry value);
+    ValueEntry* value(NodeRef node, ValueSlot slot);
+    const ValueEntry* value(NodeRef node, ValueSlot slot) const;
+    bool hasValue(NodeRef node, ValueSlot slot) const;
+
+    void setResult(NodeRef node, ValueEntry value) {
+        setValue(node, ValueSlot::Result, std::move(value));
+    }
+    ValueEntry* result(NodeRef node);
+    const ValueEntry* result(NodeRef node) const;
+    bool hasResult(NodeRef node) const { return hasValue(node, ValueSlot::Result); }
+
+    void setLvalue(NodeRef node, ValueEntry value) {
+        setValue(node, ValueSlot::Lvalue, std::move(value));
+    }
+    ValueEntry* lvalue(NodeRef node) { return value(node, ValueSlot::Lvalue); }
+    const ValueEntry* lvalue(NodeRef node) const { return value(node, ValueSlot::Lvalue); }
+
     void setAddressPlan(NodeRef node, AddressPlan plan);
     const AddressPlan* addressPlan(NodeRef node) const;
 

--- a/src/symbols/AnnotationStore.h
+++ b/src/symbols/AnnotationStore.h
@@ -10,14 +10,14 @@
 #include "ValueEntry.h"
 
 // Side table for SA→CG facts (finish-for-git AnnotationStore subset).
-// Value annotations (Result / Lvalue) and plans live here — not on AST syntax nodes.
+// Result and plans live here. Lvalue slot is reserved; production address temps
+// for array/member/* still use AST node fields until a follow-up migrates them.
 
 namespace symbols {
 
 enum class ValueSlot {
     Result,
-    // Sole address temp for this expression when stored on the side table
-    // (array/member lvalues still use node fields until a follow-up migrates them).
+    // Reserved for a future migration of array/member/* address temps off the AST.
     Lvalue,
 };
 
@@ -38,10 +38,12 @@ public:
     void setResult(NodeRef node, ValueEntry value) {
         setValue(node, ValueSlot::Result, std::move(value));
     }
+    // Required Result after successful SA (asserts if missing). Prefer hasResult + value() for probes.
     ValueEntry* result(NodeRef node);
     const ValueEntry* result(NodeRef node) const;
     bool hasResult(NodeRef node) const { return hasValue(node, ValueSlot::Result); }
 
+    // Store Lvalue API is for tests / future migration; SA still writes node fields.
     void setLvalue(NodeRef node, ValueEntry value) {
         setValue(node, ValueSlot::Lvalue, std::move(value));
     }

--- a/src/symbols/CMakeLists.txt
+++ b/src/symbols/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(symbols
         AnnotationStore.cpp
         AnnotationStore.h
         AddressPlan.h
+        ValueEntry.cpp
+        ValueEntry.h
         )
 
 trans_target_defaults(symbols)
+target_link_libraries(symbols PUBLIC types translation_unit)

--- a/src/symbols/ValueEntry.cpp
+++ b/src/symbols/ValueEntry.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <sstream>
 
-namespace semantic_analyzer {
+namespace symbols {
 
 ValueEntry::ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index, bool global) :
         name { name },
@@ -49,5 +49,5 @@ std::optional<long> ValueEntry::getConstantInitializer() const {
     return constantInitializer;
 }
 
-} // namespace semantic_analyzer
+} // namespace symbols
 

--- a/src/symbols/ValueEntry.h
+++ b/src/symbols/ValueEntry.h
@@ -1,0 +1,42 @@
+#ifndef SYMBOLS_VALUEENTRY_H_
+#define SYMBOLS_VALUEENTRY_H_
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "translation_unit/Context.h"
+#include "types/Type.h"
+
+namespace symbols {
+
+class ValueEntry {
+public:
+    ValueEntry(std::string name, const type::Type& type, bool tmp, translation_unit::Context context, int index, bool global = false);
+
+    std::string getName() const;
+    bool isGlobal() const;
+    type::Type getType() const;
+    translation_unit::Context getContext() const;
+    int getIndex() const;
+
+    // Folded integer constant initializer for file-scope variables (unset means default 0).
+    void setConstantInitializer(long value);
+    std::optional<long> getConstantInitializer() const;
+
+    std::string to_string() const;
+
+private:
+    std::string name;
+    type::Type type;
+    translation_unit::Context context;
+    int index;
+
+    bool temp;
+    bool global;
+    std::optional<long> constantInitializer;
+};
+
+} // namespace symbols
+
+#endif // SYMBOLS_VALUEENTRY_H_

--- a/test/src/astTest/ExpressionDualTypeTest.cpp
+++ b/test/src/astTest/ExpressionDualTypeTest.cpp
@@ -74,9 +74,10 @@ TEST(Expression, resultGoneWhenStoreCleared) {
     id.setTypeAndResult(store, v);
     store.clear();
     // Result is store-only; expression type remains on the node.
+    // Probe with hasResultSymbol — getResultSymbol asserts when Result is required-missing.
     EXPECT_TRUE(id.valueType(store).isPrimitive());
     EXPECT_FALSE(id.hasResultSymbol(store));
-    EXPECT_EQ(id.getResultSymbol(store), nullptr);
+    EXPECT_EQ(store.value(&id, symbols::ValueSlot::Result), nullptr);
     EXPECT_FALSE(id.hasDecayedArrayValue(store));
 }
 

--- a/test/src/astTest/ExpressionDualTypeTest.cpp
+++ b/test/src/astTest/ExpressionDualTypeTest.cpp
@@ -1,7 +1,8 @@
 #include "gtest/gtest.h"
 
 #include "ast/IdentifierExpression.h"
-#include "semantic_analyzer/ValueEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/ValueEntry.h"
 #include "translation_unit/Context.h"
 #include "types/Type.h"
 
@@ -17,36 +18,77 @@ TEST(Expression, expressionTypeThrowsWhenUnset) {
 }
 
 TEST(Expression, valueTypeFallsBackToExpressionType) {
+    symbols::AnnotationStore store;
     ast::IdentifierExpression id("x", ctx());
     id.setType(type::signedInteger());
-    EXPECT_TRUE(id.valueType().isPrimitive());
-    EXPECT_FALSE(id.hasResultSymbol());
+    EXPECT_TRUE(id.valueType(store).isPrimitive());
+    EXPECT_FALSE(id.hasResultSymbol(store));
 }
 
 TEST(Expression, hasDecayedArrayValue) {
+    symbols::AnnotationStore store;
     ast::IdentifierExpression id("a", ctx());
     type::Type arr = type::array(type::signedInteger(), 3);
-    semantic_analyzer::ValueEntry addr("t", type::pointer(type::signedInteger()), true, ctx(), 0);
-    id.setAggregateAddressResult(addr, arr);
+    symbols::ValueEntry addr("t", type::pointer(type::signedInteger()), true, ctx(), 0);
+    id.setAggregateAddressResult(store, addr, arr);
     EXPECT_TRUE(id.holdsAggregateAddress());
     EXPECT_TRUE(id.isArrayObjectType());
-    EXPECT_TRUE(id.hasDecayedArrayValue());
+    EXPECT_TRUE(id.hasDecayedArrayValue(store));
+    EXPECT_TRUE(store.hasResult(&id));
 }
 
 TEST(Expression, setTypeAndResultIsScalar) {
+    symbols::AnnotationStore store;
     ast::IdentifierExpression id("x", ctx());
-    semantic_analyzer::ValueEntry v("x", type::signedInteger(), false, ctx(), 0);
-    id.setTypeAndResult(v);
+    symbols::ValueEntry v("x", type::signedInteger(), false, ctx(), 0);
+    id.setTypeAndResult(store, v);
     EXPECT_EQ(id.valueForm(), ast::ValueForm::Scalar);
     EXPECT_FALSE(id.holdsAggregateAddress());
-    EXPECT_TRUE(id.hasResultSymbol());
+    EXPECT_TRUE(id.hasResultSymbol(store));
+    EXPECT_EQ(store.result(&id)->getName(), "x");
 }
 
 TEST(Expression, isArrayObjectTypeFalseForScalar) {
+    symbols::AnnotationStore store;
     ast::IdentifierExpression id("x", ctx());
     id.setType(type::signedInteger());
     EXPECT_FALSE(id.isArrayObjectType());
-    EXPECT_FALSE(id.hasDecayedArrayValue());
+    EXPECT_FALSE(id.hasDecayedArrayValue(store));
+}
+
+TEST(Expression, valueTypeAndGetResultAreStoreOnly) {
+    symbols::AnnotationStore store;
+    ast::IdentifierExpression id("x", ctx());
+    symbols::ValueEntry v("x", type::signedInteger(), false, ctx(), 0);
+    id.setTypeAndResult(store, v);
+    EXPECT_TRUE(id.valueType(store).isPrimitive());
+    EXPECT_EQ(id.getResultSymbol(store)->getName(), "x");
+    EXPECT_TRUE(id.hasResultSymbol(store));
+    EXPECT_FALSE(id.hasDecayedArrayValue(store));
+}
+
+TEST(Expression, resultGoneWhenStoreCleared) {
+    symbols::AnnotationStore store;
+    ast::IdentifierExpression id("x", ctx());
+    symbols::ValueEntry v("x", type::signedInteger(), false, ctx(), 0);
+    id.setTypeAndResult(store, v);
+    store.clear();
+    // Result is store-only; expression type remains on the node.
+    EXPECT_TRUE(id.valueType(store).isPrimitive());
+    EXPECT_FALSE(id.hasResultSymbol(store));
+    EXPECT_EQ(id.getResultSymbol(store), nullptr);
+    EXPECT_FALSE(id.hasDecayedArrayValue(store));
+}
+
+TEST(Expression, functionDesignatorFormWritesStore) {
+    symbols::AnnotationStore store;
+    ast::IdentifierExpression id("f", ctx());
+    type::Type fn = type::function(type::signedInteger());
+    symbols::ValueEntry addr("t", type::pointer(fn), true, ctx(), 0);
+    id.setFunctionDesignatorResult(store, addr);
+    EXPECT_TRUE(id.holdsFunctionDesignator());
+    EXPECT_TRUE(store.hasResult(&id));
+    EXPECT_EQ(id.getResultSymbol(store)->getName(), "t");
 }
 
 } // namespace

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -126,9 +126,14 @@ TEST(AnnotationStore, lvalueSlot) {
 TEST(AnnotationStore, clearEmptiesAll) {
     symbols::AnnotationStore store;
     int node = 4;
+    translation_unit::Context ctx { "t", 1 };
     store.setCallPlan(&node, symbols::DirectCallPlan { "f" });
+    store.setResult(&node, symbols::ValueEntry("r", type::signedInteger(), true, ctx, 0));
+    store.setLvalue(&node, symbols::ValueEntry("lv", type::pointer(type::signedInteger()), true, ctx, 1));
     store.clear();
     EXPECT_EQ(store.callPlan(&node), nullptr);
+    EXPECT_FALSE(store.hasResult(&node));
+    EXPECT_EQ(store.lvalue(&node), nullptr);
 }
 
 TEST(AnnotationStore, indexPlanVariant) {

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -1,6 +1,9 @@
 #include "gtest/gtest.h"
 
 #include "symbols/AnnotationStore.h"
+#include "symbols/ValueEntry.h"
+#include "types/Type.h"
+#include "translation_unit/Context.h"
 
 namespace {
 
@@ -87,6 +90,37 @@ TEST(AnnotationStore, structFieldInits) {
     store.setStructFieldInits(&node, std::move(replaced));
     EXPECT_EQ(store.structFieldInits(&node).size(), 1u);
     EXPECT_EQ(store.structFieldInits(&node)[0].offsetBytes, 8);
+}
+
+TEST(AnnotationStore, resultSlotRoundTrip) {
+    symbols::AnnotationStore store;
+    int node = 7;
+    translation_unit::Context ctx { "t", 1 };
+    symbols::ValueEntry v("tmp", type::signedInteger(), true, ctx, 0);
+    store.setResult(&node, v);
+    ASSERT_TRUE(store.hasResult(&node));
+    EXPECT_EQ(store.result(&node)->getName(), "tmp");
+    const symbols::AnnotationStore& cstore = store;
+    EXPECT_EQ(cstore.result(&node)->getName(), "tmp");
+    EXPECT_FALSE(store.hasResult(&node + 1));
+    EXPECT_EQ(store.value(&node + 1, symbols::ValueSlot::Result), nullptr);
+    EXPECT_EQ(cstore.value(&node + 1, symbols::ValueSlot::Result), nullptr);
+    // Node exists but slot empty.
+    store.setAddressPlan(&node, symbols::AddressPlan { symbols::IndexPlan {} });
+    EXPECT_EQ(store.value(&node, symbols::ValueSlot::Lvalue), nullptr);
+    EXPECT_EQ(cstore.value(&node, symbols::ValueSlot::Lvalue), nullptr);
+}
+
+TEST(AnnotationStore, lvalueSlot) {
+    symbols::AnnotationStore store;
+    int node = 8;
+    translation_unit::Context ctx { "t", 1 };
+    symbols::ValueEntry lv("lv", type::pointer(type::signedInteger()), true, ctx, 1);
+    store.setLvalue(&node, lv);
+    ASSERT_NE(store.lvalue(&node), nullptr);
+    EXPECT_EQ(store.lvalue(&node)->getName(), "lv");
+    const symbols::AnnotationStore& cstore = store;
+    EXPECT_EQ(cstore.lvalue(&node)->getName(), "lv");
 }
 
 TEST(AnnotationStore, clearEmptiesAll) {


### PR DESCRIPTION
## Summary
- `ValueEntry` lives in `symbols/` (re-export from `semantic_analyzer/ValueEntry.h`)
- `AnnotationStore` owns `ValueSlot::Result` / `Lvalue` (no dual-write node cache)
- Expression Result API is store-only: setters/getters/`valueType` take `AnnotationStore&`
- Operand / initializer / lvalue helpers pass the store through SA and CG
- Drop unused `PreOperation` slot

## Stack
Phase A PR 3/3 — base: #77 AddressBaseMode → #76 CallPlan

## Test plan
- [x] Full suite (astTest, symbolsTest, functional shards)
- [ ] CI + Coveralls