### PR TITLE
fix(types,sa,codegen): signed idiv, multi-decl init, pointer arithmetic

### DIFF
--- a/src/ast/Declaration.cpp
+++ b/src/ast/Declaration.cpp
@@ -15,10 +15,14 @@ void Declaration::accept(AbstractSyntaxTreeVisitor& visitor) {
 }
 
 void Declaration::visitChildren(AbstractSyntaxTreeVisitor& visitor) {
-    declarationSpecifiers.accept(visitor);
+    visitSpecifiers(visitor);
     for (auto& declarator : declarators) {
         declarator->accept(visitor);
     }
+}
+
+void Declaration::visitSpecifiers(AbstractSyntaxTreeVisitor& visitor) {
+    declarationSpecifiers.accept(visitor);
 }
 
 DeclarationSpecifiers ast::Declaration::getDeclarationSpecifiers() const {

--- a/src/ast/Declaration.h
+++ b/src/ast/Declaration.h
@@ -16,6 +16,7 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor);
     void visitChildren(AbstractSyntaxTreeVisitor& visitor);
+    void visitSpecifiers(AbstractSyntaxTreeVisitor& visitor);
 
     DeclarationSpecifiers getDeclarationSpecifiers() const;
     const std::vector<std::unique_ptr<InitializedDeclarator>>& getDeclarators() const;

--- a/src/ast/InitializedDeclarator.cpp
+++ b/src/ast/InitializedDeclarator.cpp
@@ -15,7 +15,15 @@ void InitializedDeclarator::accept(AbstractSyntaxTreeVisitor& visitor) {
 }
 
 void InitializedDeclarator::visitChildren(AbstractSyntaxTreeVisitor& visitor) {
+    visitDeclarator(visitor);
+    visitInitializer(visitor);
+}
+
+void InitializedDeclarator::visitDeclarator(AbstractSyntaxTreeVisitor& visitor) {
     declarator->accept(visitor);
+}
+
+void InitializedDeclarator::visitInitializer(AbstractSyntaxTreeVisitor& visitor) {
     if (initializer) {
         initializer->accept(visitor);
     }

--- a/src/ast/InitializedDeclarator.h
+++ b/src/ast/InitializedDeclarator.h
@@ -16,6 +16,9 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
     void visitChildren(AbstractSyntaxTreeVisitor& visitor);
+    // Split so SA can insert the name before analyzing a later initializer in the same declaration.
+    void visitDeclarator(AbstractSyntaxTreeVisitor& visitor);
+    void visitInitializer(AbstractSyntaxTreeVisitor& visitor);
 
     std::string getName() const;
     type::Type getFundamentalType(const type::Type& baseType);

--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -236,6 +236,10 @@ std::string ATandTInstructionSet::idiv(const MemoryOperand& operand) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::idiv(MemoryOperand)" };
 }
 
+std::string ATandTInstructionSet::cqo() const {
+    return "cqo";
+}
+
 std::string ATandTInstructionSet::inc(const Register& operand) const {
     throw std::runtime_error { "not implemented ATandTInstructionSet::inc(const Register& operand)" };
 }

--- a/src/codegen/ATandTInstructionSet.h
+++ b/src/codegen/ATandTInstructionSet.h
@@ -74,6 +74,7 @@ public:
 
     std::string idiv(const Register& operand) const override;
     std::string idiv(const MemoryOperand& operand) const override;
+    std::string cqo() const override;
 
     std::string inc(const Register& operand) const override;
     std::string inc(const MemoryOperand& operand) const override;

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -57,6 +57,16 @@ void AssemblyGenerator::generateCodeFor(const IndexAddress& indexAddress) {
             indexAddress.getResult(), indexAddress.baseMode());
 }
 
+void AssemblyGenerator::generateCodeFor(const PointerOffset& pointerOffset) {
+    stackMachine->pointerOffset(pointerOffset.getBase(), pointerOffset.getIndex(),
+            pointerOffset.getElementSizeBytes(), pointerOffset.getResult(), pointerOffset.isSubtract());
+}
+
+void AssemblyGenerator::generateCodeFor(const PointerDiff& pointerDiff) {
+    stackMachine->pointerDifference(pointerDiff.getLeft(), pointerDiff.getRight(),
+            pointerDiff.getElementSizeBytes(), pointerDiff.getResult());
+}
+
 void AssemblyGenerator::generateCodeFor(const FieldAddress& fieldAddress) {
     stackMachine->fieldAddress(fieldAddress.getBase(), fieldAddress.getOffsetBytes(), fieldAddress.getResult(),
             fieldAddress.baseMode());
@@ -143,11 +153,11 @@ void AssemblyGenerator::generateCodeFor(const Mod& mod) {
 }
 
 void AssemblyGenerator::generateCodeFor(const Inc& inc) {
-    stackMachine->inc(inc.getOperandName());
+    stackMachine->inc(inc.getOperandName(), inc.getStep());
 }
 
 void AssemblyGenerator::generateCodeFor(const Dec& dec) {
-    stackMachine->dec(dec.getOperandName());
+    stackMachine->dec(dec.getOperandName(), dec.getStep());
 }
 
 void AssemblyGenerator::generateCodeFor(const Shl& shl) {

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -14,6 +14,8 @@
 #include "quadruples/AddressOf.h"
 #include "quadruples/Dereference.h"
 #include "quadruples/IndexAddress.h"
+#include "quadruples/PointerDiff.h"
+#include "quadruples/PointerOffset.h"
 #include "quadruples/FieldAddress.h"
 #include "quadruples/FunctionAddress.h"
 #include "quadruples/UnaryMinus.h"
@@ -58,6 +60,8 @@ public:
     void generateCodeFor(const AddressOf& addressOf);
     void generateCodeFor(const Dereference& dereference);
     void generateCodeFor(const IndexAddress& indexAddress);
+    void generateCodeFor(const PointerOffset& pointerOffset);
+    void generateCodeFor(const PointerDiff& pointerDiff);
     void generateCodeFor(const FieldAddress& fieldAddress);
     void generateCodeFor(const FunctionAddress& functionAddress);
     void generateCodeFor(const UnaryMinus& unaryMinus);

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(backend
         quadruples/Mod.cpp
         quadruples/Mul.cpp
         quadruples/Or.cpp
+        quadruples/PointerDiff.cpp
+        quadruples/PointerOffset.cpp
         quadruples/Retrieve.cpp
         quadruples/Return.cpp
         quadruples/VoidReturn.cpp
@@ -45,6 +47,7 @@ add_library(backend
         QuadrupleGenerator.cpp
         Register.cpp
         StackMachine.cpp
+        StackMachine_Addressing.cpp
         Value.cpp
         Assembly.cpp
         quadruples/Add.h
@@ -70,6 +73,8 @@ add_library(backend
         quadruples/Mod.h
         quadruples/Mul.h
         quadruples/Or.h
+        quadruples/PointerDiff.h
+        quadruples/PointerOffset.h
         quadruples/Quadruple.h
         quadruples/Retrieve.h
         quadruples/Return.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -15,6 +15,8 @@
 #include "quadruples/AssignConstant.h"
 #include "quadruples/Inc.h"
 #include "quadruples/IndexAddress.h"
+#include "quadruples/PointerDiff.h"
+#include "quadruples/PointerOffset.h"
 #include "quadruples/FieldAddress.h"
 #include "quadruples/Dec.h"
 #include "quadruples/AddressOf.h"
@@ -184,6 +186,18 @@ void CodeGeneratingVisitor::visit(ast::StringLiteralExpression& stringLiteral) {
     );
 }
 
+namespace {
+
+// Scalar ++/-- steps by 1; pointer ++/-- steps by pointee size in bytes.
+int incDecStepBytes(const type::Type& valueType) {
+    if (valueType.isPointer()) {
+        return type::pointerElementStride(valueType);
+    }
+    return 1;
+}
+
+} // namespace
+
 void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
     expression.visitOperand(*this);
 
@@ -191,10 +205,11 @@ void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
     auto preOperationSymbol = expression.getPreOperationSymbol()->getName();
     instructions.push_back(std::make_unique<Assign>(resultSymbolName, preOperationSymbol));
 
+    const int step = incDecStepBytes(expression.getResultSymbol(store_)->getType());
     if (expression.getOperator()->getLexeme() == "++") {
-        instructions.push_back(std::make_unique<Inc>(resultSymbolName));
+        instructions.push_back(std::make_unique<Inc>(resultSymbolName, step));
     } else if (expression.getOperator()->getLexeme() == "--") {
-        instructions.push_back(std::make_unique<Dec>(resultSymbolName));
+        instructions.push_back(std::make_unique<Dec>(resultSymbolName, step));
     }
 
     // Dereference (and similar) lvalues: value lives in a temp; store new value through the pointer.
@@ -209,10 +224,11 @@ void CodeGeneratingVisitor::visit(ast::PrefixExpression& expression) {
     expression.visitOperand(*this);
 
     auto resultSymbolName = expression.getResultSymbol(store_)->getName();
+    const int step = incDecStepBytes(expression.getResultSymbol(store_)->getType());
     if (expression.getOperator()->getLexeme() == "++") {
-        instructions.push_back(std::make_unique<Inc>(resultSymbolName));
+        instructions.push_back(std::make_unique<Inc>(resultSymbolName, step));
     } else if (expression.getOperator()->getLexeme() == "--") {
-        instructions.push_back(std::make_unique<Dec>(resultSymbolName));
+        instructions.push_back(std::make_unique<Dec>(resultSymbolName, step));
     }
 
     if (auto* lvalue = expression.operandLvalueSymbol(store_)) {
@@ -323,26 +339,57 @@ void CodeGeneratingVisitor::visit(ast::ArithmeticExpression& expression) {
     expression.visitLeftOperand(*this);
     expression.visitRightOperand(*this);
 
-    switch (expression.getOperator()->getLexeme().front()) {
+    const auto* leftSym = expression.leftOperandSymbol(store_);
+    const auto* rightSym = expression.rightOperandSymbol(store_);
+    const auto* resultSym = expression.getResultSymbol(store_);
+    if (!leftSym || !rightSym || !resultSym) {
+        return;
+    }
+    const type::Type leftType = leftSym->getType();
+    const type::Type rightType = rightSym->getType();
+    const char op = expression.getOperator()->getLexeme().front();
+
+    // Same classification as SA (TypeQuery); pointer math is not integer Add/Sub.
+    const type::PointerArithmeticInfo ptrArith = type::classifyPointerArithmetic(leftType, rightType, op);
+    switch (ptrArith.form) {
+    case type::PointerArithmeticForm::None:
+        break;
+    case type::PointerArithmeticForm::PtrPlusInt:
+    case type::PointerArithmeticForm::IntPlusPtr:
+    case type::PointerArithmeticForm::PtrMinusInt: {
+        // PointerOffset is always base=pointer, index=integer; swap for int+ptr.
+        const bool intLeft = ptrArith.form == type::PointerArithmeticForm::IntPlusPtr;
+        const bool subtract = ptrArith.form == type::PointerArithmeticForm::PtrMinusInt;
+        const auto* base = intLeft ? rightSym : leftSym;
+        const auto* index = intLeft ? leftSym : rightSym;
+        instructions.push_back(std::make_unique<PointerOffset>(
+                base->getName(), index->getName(), ptrArith.strideBytes, resultSym->getName(), subtract));
+        return;
+    }
+    case type::PointerArithmeticForm::PtrMinusPtr:
+        instructions.push_back(std::make_unique<PointerDiff>(
+                leftSym->getName(), rightSym->getName(), ptrArith.strideBytes, resultSym->getName()));
+        return;
+    case type::PointerArithmeticForm::Invalid:
+        // SA must diagnose; never silent no-IR in release (NDEBUG).
+        throw std::logic_error("pointer arithmetic Invalid should not reach codegen");
+    }
+
+    switch (op) {
     case '+':
-        instructions.push_back(std::make_unique<Add>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
-                                                     expression.getResultSymbol(store_)->getName()));
+        instructions.push_back(std::make_unique<Add>(leftSym->getName(), rightSym->getName(), resultSym->getName()));
         break;
     case '-':
-        instructions.push_back(std::make_unique<Sub>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
-                                                     expression.getResultSymbol(store_)->getName()));
+        instructions.push_back(std::make_unique<Sub>(leftSym->getName(), rightSym->getName(), resultSym->getName()));
         break;
     case '*':
-        instructions.push_back(std::make_unique<Mul>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
-                                                     expression.getResultSymbol(store_)->getName()));
+        instructions.push_back(std::make_unique<Mul>(leftSym->getName(), rightSym->getName(), resultSym->getName()));
         break;
     case '/':
-        instructions.push_back(std::make_unique<Div>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
-                                                     expression.getResultSymbol(store_)->getName()));
+        instructions.push_back(std::make_unique<Div>(leftSym->getName(), rightSym->getName(), resultSym->getName()));
         break;
     case '%':
-        instructions.push_back(std::make_unique<Mod>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName(),
-                                                     expression.getResultSymbol(store_)->getName()));
+        instructions.push_back(std::make_unique<Mod>(leftSym->getName(), rightSym->getName(), resultSym->getName()));
         break;
     default:
         throw std::runtime_error { "unidentified arithmetic operator: " + expression.getOperator()->getLexeme() };

--- a/src/codegen/InstructionSet.h
+++ b/src/codegen/InstructionSet.h
@@ -82,6 +82,9 @@ public:
     virtual std::string idiv(const Register& operand) const = 0;
     virtual std::string idiv(const MemoryOperand& operand) const = 0;
 
+    // Sign-extend RAX into RDX:RAX before signed idiv (not xor rdx,rdx).
+    virtual std::string cqo() const = 0;
+
     virtual std::string inc(const Register& operand) const = 0;
     virtual std::string inc(const MemoryOperand& operand) const = 0;
 

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -251,6 +251,10 @@ std::string IntelInstructionSet::idiv(const MemoryOperand& operand) const {
     return "idiv qword " + memoryReference(operand);
 }
 
+std::string IntelInstructionSet::cqo() const {
+    return "cqo";
+}
+
 std::string IntelInstructionSet::inc(const Register& operand) const {
     return "inc " + operand.getName();
 }

--- a/src/codegen/IntelInstructionSet.h
+++ b/src/codegen/IntelInstructionSet.h
@@ -76,6 +76,7 @@ public:
 
     std::string idiv(const Register& operand) const override;
     std::string idiv(const MemoryOperand& operand) const override;
+    std::string cqo() const override;
 
     std::string inc(const Register& operand) const override;
     std::string inc(const MemoryOperand& operand) const override;

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -223,69 +223,6 @@ void StackMachine::functionAddress(std::string functionName, std::string resultN
     bindResult(resultRegister, resolve(resultName));
 }
 
-void StackMachine::indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
-        symbols::AddressBaseMode baseMode) {
-    auto& base = resolve(baseName);
-    auto& index = resolve(indexName);
-
-    // One-operand imul writes RDX:RAX. Scale index first, then form base in another reg.
-    Register& mulReg = registers->getMultiplicationRegister();
-    Register& rdx = registers->getRemainderRegister();
-    storeRegisterValue(mulReg);
-    storeRegisterValue(rdx);
-
-    if (elementSizeBytes != 1) {
-        // Never leave the index Value bound to RAX across one-operand imul (which overwrites RAX).
-        storeInMemory(index);
-        storeRegisterValue(mulReg);
-        loadWithoutBinding(index, mulReg);
-        Register& scaleReg = get64BitRegisterExcluding(mulReg);
-        assembly << instructionSet->mov(std::to_string(elementSizeBytes), scaleReg);
-        assembly << instructionSet->imul(scaleReg);
-    }
-
-    Register& addr = get64BitRegisterExcluding(mulReg);
-    if (symbols::addressBaseUsesLea(baseMode)) {
-        storeInMemory(base);
-        assembly << instructionSet->lea(memoryOperand(base), addr);
-    } else if (residesInMemory(base)) {
-        emitLoad(base, addr);
-    } else {
-        assembly << instructionSet->mov(base.getAssignedRegister(), addr);
-    }
-
-    if (elementSizeBytes == 1) {
-        if (residesInMemory(index)) {
-            assembly << instructionSet->add(memoryOperand(index), addr);
-        } else {
-            assembly << instructionSet->add(index.getAssignedRegister(), addr);
-        }
-    } else {
-        assembly << instructionSet->add(mulReg, addr);
-    }
-    bindResult(addr, resolve(resultName));
-}
-
-void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName,
-        symbols::AddressBaseMode baseMode) {
-    auto& base = resolve(baseName);
-    Register& addr = get64BitRegister();
-    if (symbols::addressBaseIsPointerValue(baseMode)) {
-        if (residesInMemory(base)) {
-            emitLoad(base, addr);
-        } else {
-            assembly << instructionSet->mov(base.getAssignedRegister(), addr);
-        }
-    } else {
-        storeInMemory(base);
-        assembly << instructionSet->lea(memoryOperand(base), addr);
-    }
-    if (offsetBytes != 0) {
-        assembly << instructionSet->add(addr, offsetBytes);
-    }
-    bindResult(addr, resolve(resultName));
-}
-
 namespace {
 // Low-byte name for NASM size-qualified stores (rax→al, r8→r8b, …).
 std::string lowByteName(const Register& reg) {
@@ -647,7 +584,8 @@ void StackMachine::div(std::string leftOperandName, std::string rightOperandName
     Register& multiplicationRegister = registers->getMultiplicationRegister();
     assignRegisterToSymbol(multiplicationRegister, leftOperand);
     storeRegisterValue(registers->getRemainderRegister());
-    assembly << instructionSet->xor_(registers->getRemainderRegister(), registers->getRemainderRegister());
+    // Signed divide: sign-extend dividend in RAX into RDX:RAX (xor rdx,rdx breaks negatives).
+    assembly << instructionSet->cqo();
     if (residesInMemory(rightOperand)) {
         assembly << instructionSet->idiv(memoryOperand(rightOperand));
     } else {
@@ -668,7 +606,7 @@ void StackMachine::mod(std::string leftOperandName, std::string rightOperandName
     Register& multiplicationRegister = registers->getMultiplicationRegister();
     assignRegisterToSymbol(multiplicationRegister, leftOperand);
     storeRegisterValue(registers->getRemainderRegister());
-    assembly << instructionSet->xor_(registers->getRemainderRegister(), registers->getRemainderRegister());
+    assembly << instructionSet->cqo();
     if (residesInMemory(rightOperand)) {
         assembly << instructionSet->idiv(memoryOperand(rightOperand));
     } else {
@@ -677,22 +615,40 @@ void StackMachine::mod(std::string leftOperandName, std::string rightOperandName
     bindResult(registers->getRemainderRegister(), result);
 }
 
-void StackMachine::inc(std::string operandName) {
+void StackMachine::inc(std::string operandName, int step) {
     Value& operand = resolve(operandName);
-    if (residesInMemory(operand)) {
-        assembly << instructionSet->inc(memoryOperand(operand));
-    } else {
-        assembly << instructionSet->inc(operand.getAssignedRegister());
+    if (step == 1) {
+        if (residesInMemory(operand)) {
+            assembly << instructionSet->inc(memoryOperand(operand));
+        } else {
+            assembly << instructionSet->inc(operand.getAssignedRegister());
+        }
+        return;
     }
+    // Non-unit step: pointer ++ (byte stride = sizeof *p), not scalar +1.
+    Register& reg = get64BitRegister();
+    assignRegisterToSymbol(reg, operand);
+    assembly << instructionSet->add(reg, step);
+    emitStore(reg, operand);
+    bindResult(reg, operand);
 }
 
-void StackMachine::dec(std::string operandName) {
+void StackMachine::dec(std::string operandName, int step) {
     Value& operand = resolve(operandName);
-    if (residesInMemory(operand)) {
-        assembly << instructionSet->dec(memoryOperand(operand));
-    } else {
-        assembly << instructionSet->dec(operand.getAssignedRegister());
+    if (step == 1) {
+        if (residesInMemory(operand)) {
+            assembly << instructionSet->dec(memoryOperand(operand));
+        } else {
+            assembly << instructionSet->dec(operand.getAssignedRegister());
+        }
+        return;
     }
+    // Non-unit step: pointer -- (byte stride = sizeof *p).
+    Register& reg = get64BitRegister();
+    assignRegisterToSymbol(reg, operand);
+    assembly << instructionSet->sub(reg, step);
+    emitStore(reg, operand);
+    bindResult(reg, operand);
 }
 
 void StackMachine::shiftBy(std::string leftOperandName, std::string rightOperandName, std::string resultName,

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -45,6 +45,11 @@ public:
     void dereference(std::string operandName, std::string lvalueName, std::string resultName);
     void indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
             symbols::AddressBaseMode baseMode = symbols::AddressBaseMode::LeaObject);
+    // Pointer value +/- integer: result = base +/- index * elementSizeBytes.
+    void pointerOffset(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+            bool subtract);
+    // Pointer - pointer: result = (left - right) / elementSizeBytes (element count).
+    void pointerDifference(std::string leftName, std::string rightName, int elementSizeBytes, std::string resultName);
     void fieldAddress(std::string baseName, int offsetBytes, std::string resultName,
             symbols::AddressBaseMode baseMode = symbols::AddressBaseMode::LeaObject);
 
@@ -72,8 +77,9 @@ public:
     void div(std::string leftOperandName, std::string rightOperandName, std::string resultName);
     void mod(std::string leftOperandName, std::string rightOperandName, std::string resultName);
 
-    void inc(std::string operandName);
-    void dec(std::string operandName);
+    // step: 1 for scalar ++/--; sizeof(*p) bytes for pointer ++/--.
+    void inc(std::string operandName, int step = 1);
+    void dec(std::string operandName, int step = 1);
 
     void shl(std::string leftOperandName, std::string rightOperandName, std::string resultName);
     void shr(std::string leftOperandName, std::string rightOperandName, std::string resultName);
@@ -81,6 +87,14 @@ public:
     void setScope(std::vector<Value> variables);
 
 private:
+    // Shared by indexAddress and pointerOffset: scale index into RAX (imul), spill RDX.
+    void scaleIntegerIntoRax(Value& index, int elementSizeBytes);
+    // LEA object home or load/mov pointer value into dest.
+    void materializeBaseAddress(Value& base, symbols::AddressBaseMode baseMode, Register& dest);
+    // result = base +/- index * elementSizeBytes (LEA object home or pointer value).
+    void scaledBaseIndex(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+            symbols::AddressBaseMode baseMode, bool subtract);
+
     void shiftBy(std::string leftOperandName, std::string rightOperandName, std::string resultName,
             std::string (InstructionSet::*emitShift)(const Register&) const);
 

--- a/src/codegen/StackMachine_Addressing.cpp
+++ b/src/codegen/StackMachine_Addressing.cpp
@@ -1,0 +1,132 @@
+#include "StackMachine.h"
+
+#include <stdexcept>
+
+namespace codegen {
+
+void StackMachine::scaleIntegerIntoRax(Value& index, int elementSizeBytes) {
+    // One-operand imul writes RDX:RAX; free both first.
+    Register& mulReg = registers->getMultiplicationRegister();
+    Register& rdx = registers->getRemainderRegister();
+    storeInMemory(index);
+    storeRegisterValue(mulReg);
+    storeRegisterValue(rdx);
+    loadWithoutBinding(index, mulReg);
+    if (elementSizeBytes != 1) {
+        Register& scaleReg = get64BitRegisterExcluding(mulReg);
+        assembly << instructionSet->mov(std::to_string(elementSizeBytes), scaleReg);
+        assembly << instructionSet->imul(scaleReg);
+    }
+}
+
+void StackMachine::materializeBaseAddress(Value& base, symbols::AddressBaseMode baseMode, Register& dest) {
+    if (symbols::addressBaseUsesLea(baseMode)) {
+        storeInMemory(base);
+        assembly << instructionSet->lea(memoryOperand(base), dest);
+    } else if (residesInMemory(base)) {
+        emitLoad(base, dest);
+    } else {
+        assembly << instructionSet->mov(base.getAssignedRegister(), dest);
+    }
+}
+
+void StackMachine::scaledBaseIndex(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+        symbols::AddressBaseMode baseMode, bool subtract) {
+    auto& base = resolve(baseName);
+    auto& index = resolve(indexName);
+    Register& mulReg = registers->getMultiplicationRegister();
+
+    if (elementSizeBytes != 1) {
+        scaleIntegerIntoRax(index, elementSizeBytes);
+    }
+
+    Register& addr = get64BitRegisterExcluding(mulReg);
+    materializeBaseAddress(base, baseMode, addr);
+
+    auto applyOffset = [&](const auto& scaledIndex) {
+        if (subtract) {
+            assembly << instructionSet->sub(scaledIndex, addr);
+        } else {
+            assembly << instructionSet->add(scaledIndex, addr);
+        }
+    };
+    if (elementSizeBytes == 1) {
+        if (residesInMemory(index)) {
+            applyOffset(memoryOperand(index));
+        } else {
+            applyOffset(index.getAssignedRegister());
+        }
+    } else {
+        applyOffset(mulReg);
+    }
+    bindResult(addr, resolve(resultName));
+}
+
+void StackMachine::indexAddress(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+        symbols::AddressBaseMode baseMode) {
+    scaledBaseIndex(baseName, indexName, elementSizeBytes, resultName, baseMode, false);
+}
+
+void StackMachine::pointerOffset(std::string baseName, std::string indexName, int elementSizeBytes, std::string resultName,
+        bool subtract) {
+    scaledBaseIndex(baseName, indexName, elementSizeBytes, resultName, symbols::AddressBaseMode::PointerValue, subtract);
+}
+
+void StackMachine::pointerDifference(std::string leftName, std::string rightName, int elementSizeBytes,
+        std::string resultName) {
+    auto& left = resolve(leftName);
+    auto& right = resolve(rightName);
+    Register& mulReg = registers->getMultiplicationRegister();
+    Register& rdx = registers->getRemainderRegister();
+
+    Register& addr = get64BitRegisterExcluding(mulReg);
+    if (residesInMemory(left)) {
+        emitLoad(left, addr);
+    } else {
+        assembly << instructionSet->mov(left.getAssignedRegister(), addr);
+    }
+    if (residesInMemory(right)) {
+        assembly << instructionSet->sub(memoryOperand(right), addr);
+    } else {
+        assembly << instructionSet->sub(right.getAssignedRegister(), addr);
+    }
+
+    if (elementSizeBytes == 1) {
+        bindResult(addr, resolve(resultName));
+        return;
+    }
+
+    // Signed element count: byte_diff / stride. idiv uses RDX:RAX; divisor not RAX/RDX.
+    storeRegisterValue(mulReg);
+    storeRegisterValue(rdx);
+    assembly << instructionSet->mov(addr, mulReg);
+    assembly << instructionSet->cqo();
+    Register* divisor = nullptr;
+    for (auto& reg : registers->getGeneralPurposeRegisters()) {
+        if (reg != &mulReg && reg != &rdx) {
+            storeRegisterValue(*reg);
+            divisor = reg;
+            break;
+        }
+    }
+    if (!divisor) {
+        throw std::runtime_error { "no free register for pointer difference divisor" };
+    }
+    assembly << instructionSet->mov(std::to_string(elementSizeBytes), *divisor);
+    assembly << instructionSet->idiv(*divisor);
+    assembly << instructionSet->mov(mulReg, addr);
+    bindResult(addr, resolve(resultName));
+}
+
+void StackMachine::fieldAddress(std::string baseName, int offsetBytes, std::string resultName,
+        symbols::AddressBaseMode baseMode) {
+    auto& base = resolve(baseName);
+    Register& addr = get64BitRegister();
+    materializeBaseAddress(base, baseMode, addr);
+    if (offsetBytes != 0) {
+        assembly << instructionSet->add(addr, offsetBytes);
+    }
+    bindResult(addr, resolve(resultName));
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/Add.cpp
+++ b/src/codegen/quadruples/Add.cpp
@@ -18,4 +18,3 @@ void Add::print(std::ostream& stream) const {
 }
 
 } // namespace codegen
-

--- a/src/codegen/quadruples/Dec.cpp
+++ b/src/codegen/quadruples/Dec.cpp
@@ -4,8 +4,9 @@
 
 namespace codegen {
 
-Dec::Dec(std::string operandName) :
-        operandName { operandName }
+Dec::Dec(std::string operandName, int step) :
+        operandName { operandName },
+        step { step }
 {
 }
 
@@ -18,7 +19,11 @@ std::string Dec::getOperandName() const {
 }
 
 void Dec::print(std::ostream& stream) const {
-    stream << "\tDEC " << getOperandName() << "\n";
+    if (step == 1) {
+        stream << "\tDEC " << getOperandName() << "\n";
+    } else {
+        stream << "\t" << getOperandName() << " := " << getOperandName() << " - " << step << "\n";
+    }
 }
 
 } // namespace codegen

--- a/src/codegen/quadruples/Dec.h
+++ b/src/codegen/quadruples/Dec.h
@@ -7,19 +7,22 @@
 
 namespace codegen {
 
+// step is in addressable units for the value: 1 for scalar --, sizeof(*p) bytes for pointer --.
 class Dec: public Quadruple {
 public:
-    Dec(std::string operandName);
+    Dec(std::string operandName, int step = 1);
     virtual ~Dec() = default;
 
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getOperandName() const;
+    int getStep() const { return step; }
 
 private:
     void print(std::ostream& stream) const override;
 
     std::string operandName;
+    int step;
 };
 
 } // namespace codegen

--- a/src/codegen/quadruples/Inc.cpp
+++ b/src/codegen/quadruples/Inc.cpp
@@ -4,8 +4,9 @@
 
 namespace codegen {
 
-Inc::Inc(std::string operandName) :
-        operandName { operandName }
+Inc::Inc(std::string operandName, int step) :
+        operandName { operandName },
+        step { step }
 {
 }
 
@@ -18,8 +19,11 @@ std::string Inc::getOperandName() const {
 }
 
 void Inc::print(std::ostream& stream) const {
-    stream << "\tINC " << getOperandName() << "\n";
+    if (step == 1) {
+        stream << "\tINC " << getOperandName() << "\n";
+    } else {
+        stream << "\t" << getOperandName() << " := " << getOperandName() << " + " << step << "\n";
+    }
 }
 
 } // namespace codegen
-

--- a/src/codegen/quadruples/Inc.h
+++ b/src/codegen/quadruples/Inc.h
@@ -7,19 +7,22 @@
 
 namespace codegen {
 
+// step is in addressable units for the value: 1 for scalar ++, sizeof(*p) bytes for pointer ++.
 class Inc: public Quadruple {
 public:
-    Inc(std::string operand);
+    Inc(std::string operand, int step = 1);
     virtual ~Inc() = default;
 
     void generateCode(AssemblyGenerator& generator) const override;
 
     std::string getOperandName() const;
+    int getStep() const { return step; }
 
 private:
     void print(std::ostream& stream) const override;
 
     std::string operandName;
+    int step;
 };
 
 } // namespace codegen

--- a/src/codegen/quadruples/PointerDiff.cpp
+++ b/src/codegen/quadruples/PointerDiff.cpp
@@ -1,0 +1,26 @@
+#include "PointerDiff.h"
+
+#include "codegen/AssemblyGenerator.h"
+
+namespace codegen {
+
+PointerDiff::PointerDiff(std::string left, std::string right, int elementSizeBytes, std::string result) :
+        left { std::move(left) },
+        right { std::move(right) },
+        elementSizeBytes { elementSizeBytes },
+        result { std::move(result) } {
+}
+
+void PointerDiff::generateCode(AssemblyGenerator& generator) const {
+    generator.generateCodeFor(*this);
+}
+
+void PointerDiff::print(std::ostream& stream) const {
+    stream << "\t" << result << " := (" << left << " - " << right << ")";
+    if (elementSizeBytes != 1) {
+        stream << " /" << elementSizeBytes;
+    }
+    stream << " (ptrdiff)\n";
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/PointerDiff.h
+++ b/src/codegen/quadruples/PointerDiff.h
@@ -1,0 +1,31 @@
+#ifndef POINTERDIFF_QUADRUPLE_H_
+#define POINTERDIFF_QUADRUPLE_H_
+
+#include <string>
+
+#include "Quadruple.h"
+
+namespace codegen {
+
+// result = (left - right) / elementSizeBytes  (pointer difference, element count).
+class PointerDiff: public Quadruple {
+public:
+    PointerDiff(std::string left, std::string right, int elementSizeBytes, std::string result);
+    void generateCode(AssemblyGenerator& generator) const override;
+
+    std::string getLeft() const { return left; }
+    std::string getRight() const { return right; }
+    int getElementSizeBytes() const { return elementSizeBytes; }
+    std::string getResult() const { return result; }
+
+private:
+    void print(std::ostream& stream) const override;
+    std::string left;
+    std::string right;
+    int elementSizeBytes;
+    std::string result;
+};
+
+} // namespace codegen
+
+#endif

--- a/src/codegen/quadruples/PointerOffset.cpp
+++ b/src/codegen/quadruples/PointerOffset.cpp
@@ -1,0 +1,28 @@
+#include "PointerOffset.h"
+
+#include "codegen/AssemblyGenerator.h"
+
+namespace codegen {
+
+PointerOffset::PointerOffset(std::string base, std::string index, int elementSizeBytes, std::string result,
+        bool subtract) :
+        base { std::move(base) },
+        index { std::move(index) },
+        elementSizeBytes { elementSizeBytes },
+        result { std::move(result) },
+        subtract { subtract } {
+}
+
+void PointerOffset::generateCode(AssemblyGenerator& generator) const {
+    generator.generateCodeFor(*this);
+}
+
+void PointerOffset::print(std::ostream& stream) const {
+    stream << "\t" << result << " := " << base << (subtract ? " - " : " + ") << index;
+    if (elementSizeBytes != 1) {
+        stream << "*" << elementSizeBytes;
+    }
+    stream << " (ptr)\n";
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/PointerOffset.h
+++ b/src/codegen/quadruples/PointerOffset.h
@@ -1,0 +1,35 @@
+#ifndef POINTEROFFSET_QUADRUPLE_H_
+#define POINTEROFFSET_QUADRUPLE_H_
+
+#include <string>
+
+#include "Quadruple.h"
+
+namespace codegen {
+
+// result = base +/- index * elementSizeBytes  (pointer +/- integer, scaled).
+// Base holds a pointer value (not an array object home).
+class PointerOffset: public Quadruple {
+public:
+    PointerOffset(std::string base, std::string index, int elementSizeBytes, std::string result,
+            bool subtract);
+    void generateCode(AssemblyGenerator& generator) const override;
+
+    std::string getBase() const { return base; }
+    std::string getIndex() const { return index; }
+    int getElementSizeBytes() const { return elementSizeBytes; }
+    std::string getResult() const { return result; }
+    bool isSubtract() const { return subtract; }
+
+private:
+    void print(std::ostream& stream) const override;
+    std::string base;
+    std::string index;
+    int elementSizeBytes;
+    std::string result;
+    bool subtract;
+};
+
+} // namespace codegen
+
+#endif

--- a/src/codegen/quadruples/Sub.cpp
+++ b/src/codegen/quadruples/Sub.cpp
@@ -18,4 +18,3 @@ void Sub::print(std::ostream& stream) const {
 }
 
 } // namespace codegen
-

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -30,37 +30,14 @@ void SemanticAnalysisVisitor::visit(ast::DeclarationSpecifiers& declarationSpeci
 }
 
 void SemanticAnalysisVisitor::visit(ast::Declaration& declaration) {
-    declaration.visitChildren(*this);
+    declaration.visitSpecifiers(*this);
 
-    auto baseType = declaration.getDeclarationSpecifiers().getTypeSpecifiers().at(0).getType();
+    const type::Type baseType =
+            declaration.getDeclarationSpecifiers().getTypeSpecifiers().at(0).getType();
+    // C: each declarator is visible to later initializers in the same declaration
+    // (`int a = 1, b = a;`). Insert before walking the initializer.
     for (const auto& declarator : declaration.getDeclarators()) {
-        type::Type type { type::voidType() };
-        try {
-            type = declarator->getFundamentalType(baseType);
-        } catch (const std::invalid_argument& ex) {
-            // array size overflow, array of incomplete type, etc.
-            semanticError(ex.what(), declarator->getContext());
-            continue;
-        }
-        if (type.isVoid()) {
-            semanticError("variable `" + declarator->getName() + "` declared void", declarator->getContext());
-        } else if (type.isIncompleteStructure()) {
-            semanticError("variable `" + declarator->getName() + "` has incomplete type", declarator->getContext());
-        } else if (symbolTable.isAtFileScope() && symbolTable.hasFunction(declarator->getName())) {
-            semanticError("symbol `" + declarator->getName() + "` declaration conflicts with function of the same name",
-                    declarator->getContext());
-        } else if (symbolTable.insertSymbol(declarator->getName(), type, declarator->getContext())) {
-            declarator->setHolder(symbolTable.lookup(declarator->getName()));
-            if (declarator->hasInitializer()) {
-                lowerLocalInitializer(*declarator, type);
-            }
-        } else {
-            semanticError(
-                    "symbol `" + declarator->getName() +
-                            "` declaration conflicts with previous declaration on " +
-                            to_string(symbolTable.lookup(declarator->getName()).getContext()),
-                    declarator->getContext());
-        }
+        analyzeInitializedDeclarator(*declarator, baseType);
     }
 }
 
@@ -68,8 +45,54 @@ void SemanticAnalysisVisitor::visit(ast::Declarator& declarator) {
     declarator.visitChildren(*this);
 }
 
-void SemanticAnalysisVisitor::visit(ast::InitializedDeclarator& declarator) {
-    declarator.visitChildren(*this);
+void SemanticAnalysisVisitor::visit(ast::InitializedDeclarator&) {
+    // Bare accept cannot supply the Declaration's base type; use analyzeInitializedDeclarator.
+    throw std::logic_error(
+            "InitializedDeclarator: use analyzeInitializedDeclarator(baseType), not bare accept");
+}
+
+void SemanticAnalysisVisitor::analyzeInitializedDeclarator(ast::InitializedDeclarator& declarator,
+        const type::Type& baseType) {
+    declarator.visitDeclarator(*this);
+
+    type::Type type { type::voidType() };
+    bool typeOk = true;
+    try {
+        type = declarator.getFundamentalType(baseType);
+    } catch (const std::invalid_argument& ex) {
+        // array size overflow, array of incomplete type, etc.
+        semanticError(ex.what(), declarator.getContext());
+        typeOk = false;
+    }
+
+    bool inserted = false;
+    if (typeOk) {
+        if (type.isVoid()) {
+            semanticError("variable `" + declarator.getName() + "` declared void", declarator.getContext());
+        } else if (type.isIncompleteStructure()) {
+            semanticError("variable `" + declarator.getName() + "` has incomplete type", declarator.getContext());
+        } else if (symbolTable.isAtFileScope() && symbolTable.hasFunction(declarator.getName())) {
+            semanticError("symbol `" + declarator.getName() + "` declaration conflicts with function of the same name",
+                    declarator.getContext());
+        } else if (symbolTable.insertSymbol(declarator.getName(), type, declarator.getContext())) {
+            declarator.setHolder(symbolTable.lookup(declarator.getName()));
+            inserted = true;
+        } else {
+            semanticError(
+                    "symbol `" + declarator.getName() +
+                            "` declaration conflicts with previous declaration on " +
+                            to_string(symbolTable.lookup(declarator.getName()).getContext()),
+                    declarator.getContext());
+        }
+    }
+
+    // Always walk initializers (including error recovery); lower only when the name was inserted.
+    if (declarator.hasInitializer()) {
+        declarator.visitInitializer(*this);
+        if (inserted) {
+            lowerLocalInitializer(declarator, type);
+        }
+    }
 }
 
 void SemanticAnalysisVisitor::visit(ast::Pointer&) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.h
@@ -91,6 +91,8 @@ public:
 
 private:
     void typeCheck(const type::Type& typeFrom, const type::Type& typeTo, const translation_unit::Context& context);
+    // Insert-before-init for one declarator; baseType is the enclosing Declaration's specifier type.
+    void analyzeInitializedDeclarator(ast::InitializedDeclarator& declarator, const type::Type& baseType);
     void lowerLocalInitializer(ast::InitializedDeclarator& declarator, const type::Type& objectType);
     void semanticError(std::string message, const translation_unit::Context& context);
     void rejectFunctionValue(const type::Type& type, const translation_unit::Context& context);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -284,15 +284,26 @@ void SemanticAnalysisVisitor::visit(ast::ArithmeticExpression& expression) {
     if (!expression.hasLeftOperandSymbol(annotations()) || !expression.hasRightOperandSymbol(annotations())) {
         return;
     }
-    rejectFunctionValue(expression.leftOperandType(), expression.getContext());
-    rejectFunctionValue(expression.rightOperandType(), expression.getContext());
+    // Prefer Result symbol types (dual-type expressions may differ from expressionType()).
+    const type::Type left = expression.leftOperandSymbol(annotations())->getType();
+    const type::Type right = expression.rightOperandSymbol(annotations())->getType();
+    rejectFunctionValue(left, expression.getContext());
+    rejectFunctionValue(right, expression.getContext());
 
-    typeCheck(
-            expression.leftOperandType(),
-            expression.rightOperandType(),
-            expression.getContext());
+    const char op = expression.getOperator()->getLexeme().front();
+    const type::PointerArithmeticInfo ptrArith = type::classifyPointerArithmetic(left, right, op);
+    if (ptrArith.form != type::PointerArithmeticForm::None) {
+        if (ptrArith.form == type::PointerArithmeticForm::Invalid) {
+            semanticError("invalid operands to pointer arithmetic", expression.getContext());
+            return;
+        }
+        expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(ptrArith.resultType));
+        return;
+    }
+
+    typeCheck(left, right, expression.getContext());
     // FIXME: type conversion
-    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(expression.leftOperandType()));
+    expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(left));
 }
 
 void SemanticAnalysisVisitor::visit(ast::ShiftExpression& expression) {

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -245,7 +245,9 @@ bool Type::isVoid() const {
 }
 
 bool Type::isPrimitive() const {
-    return _primitive.has_value();
+    // pointer() copies the pointee payload (including _primitive). Indirection
+    // means "pointer", not a primitive scalar — peel with dereference() first.
+    return _primitive.has_value() && !isPointer();
 }
 
 Primitive Type::getPrimitive() const {

--- a/src/types/TypeQuery.h
+++ b/src/types/TypeQuery.h
@@ -14,6 +14,70 @@ inline bool isBareFunction(const Type& t) {
     return t.isFunction() && !t.isPointer();
 }
 
+// Non-floating primitive scalar (not a pointer — isPrimitive already excludes indirection).
+inline bool isIntegralScalar(const Type& t) {
+    return t.isPrimitive() && !t.getPrimitive().isFloating();
+}
+
+// Pointee size for pointer arithmetic / indexing (at least 1).
+inline int pointerElementStride(const Type& ptrType) {
+    int size = ptrType.dereference().getSize();
+    return size > 0 ? size : 1;
+}
+
+// Closed classification of C pointer additive ops (shared by SA result typing and CG IR choice).
+enum class PointerArithmeticForm {
+    None,        // no pointer operand involved
+    PtrPlusInt,  // ptr + int
+    IntPlusPtr,  // int + ptr
+    PtrMinusInt, // ptr - int
+    PtrMinusPtr, // ptr - ptr
+    Invalid,     // pointer involved but not a legal form
+};
+
+struct PointerArithmeticInfo {
+    PointerArithmeticForm form { PointerArithmeticForm::None };
+    Type resultType { voidType() };
+    int strideBytes { 1 };
+};
+
+// Classify `left op right` for op in {+, -}. Result type is the pointer type or int (ptrdiff).
+inline PointerArithmeticInfo classifyPointerArithmetic(const Type& left, const Type& right, char op) {
+    PointerArithmeticInfo info;
+    if (op != '+' && op != '-') {
+        return info;
+    }
+    if (!left.isPointer() && !right.isPointer()) {
+        return info;
+    }
+    if (op == '+' && left.isPointer() && isIntegralScalar(right)) {
+        info.form = PointerArithmeticForm::PtrPlusInt;
+        info.resultType = left;
+        info.strideBytes = pointerElementStride(left);
+        return info;
+    }
+    if (op == '+' && isIntegralScalar(left) && right.isPointer()) {
+        info.form = PointerArithmeticForm::IntPlusPtr;
+        info.resultType = right;
+        info.strideBytes = pointerElementStride(right);
+        return info;
+    }
+    if (op == '-' && left.isPointer() && isIntegralScalar(right)) {
+        info.form = PointerArithmeticForm::PtrMinusInt;
+        info.resultType = left;
+        info.strideBytes = pointerElementStride(left);
+        return info;
+    }
+    if (op == '-' && left.isPointer() && right.isPointer()) {
+        info.form = PointerArithmeticForm::PtrMinusPtr;
+        info.resultType = signedInteger();
+        info.strideBytes = pointerElementStride(left);
+        return info;
+    }
+    info.form = PointerArithmeticForm::Invalid;
+    return info;
+}
+
 inline bool isPointerToFunction(const Type& t) {
     return t.isPointer() && t.dereference().isFunction();
 }

--- a/test/src/codegenTest/ATandTInstructionSetTests.cpp
+++ b/test/src/codegenTest/ATandTInstructionSetTests.cpp
@@ -41,4 +41,8 @@ TEST(ATandTInstructionSet, emitsQuadSubtract) {
     EXPECT_THAT(instructions.sub(reg, 42), Eq("subq $42, %reg"));
 }
 
+TEST(ATandTInstructionSet, emitsCqo) {
+    EXPECT_THAT(instructions.cqo(), Eq("cqo"));
+}
+
 }

--- a/test/src/codegenTest/BasicBlockTests.cpp
+++ b/test/src/codegenTest/BasicBlockTests.cpp
@@ -74,6 +74,17 @@ TEST(BasicBlock, identifiesSingleBasicBlock) {
     EXPECT_THAT(basicBlocks[0]->terminates(), Eq(true));
 }
 
+TEST(BasicBlock, printsNonUnitIncDecSteps) {
+    std::vector<std::unique_ptr<Quadruple>> instructions{};
+    instructions.push_back(std::make_unique<Inc>("p", 4));
+    instructions.push_back(std::make_unique<Dec>("p", 4));
+
+    auto basicBlocks = toBasicBlocks(std::move(instructions));
+
+    EXPECT_THAT(basicBlocks, SizeIs(1));
+    assertBasicBlockEquals(*basicBlocks[0], "\tp := p + 4\n\tp := p - 4\n");
+}
+
 TEST(BasicBlock, identifiesEmptyBasicBlock) {
     std::vector<std::unique_ptr<Quadruple>> instructions{};
 

--- a/test/src/functionalTest/BasicMathTest.cpp
+++ b/test/src/functionalTest/BasicMathTest.cpp
@@ -78,6 +78,32 @@ TEST(Compiler, simpleDivision) {
     program.runAndExpect("5 2", "2");
 }
 
+// Signed idiv must CQO (sign-extend RAX into RDX:RAX), not zero RDX.
+// Fuzzer oracle: (-1)/(-1) SIGFPE'd with xor rdx,rdx (rdx:rax became a huge positive).
+TEST(Compiler, signedDivisionOfNegatives) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            int b;
+            a = -1;
+            b = -1;
+            printf("%d ", a / b);
+            a = -20;
+            b = 6;
+            printf("%d ", a / b);
+            a = 20;
+            b = -6;
+            printf("%d ", a / b);
+            a = -20;
+            b = -6;
+            printf("%d", a / b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 -3 -3 3");
+}
+
 // FIXME: %ld - ints treated as longs for now
 TEST(Compiler, simpleModulus) {
     SourceProgram program{R"prg(
@@ -100,6 +126,31 @@ TEST(Compiler, simpleModulus) {
     program.runAndExpect("2 3", "2");
     program.runAndExpect("3 2", "1");
     program.runAndExpect("5 2", "1");
+}
+
+// C99 toward-zero remainder for negatives: a%b == a - (a/b)*b
+TEST(Compiler, signedModuloOfNegatives) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a;
+            int b;
+            a = -20;
+            b = 6;
+            printf("%d ", a % b);
+            a = 20;
+            b = -6;
+            printf("%d ", a % b);
+            a = -20;
+            b = -6;
+            printf("%d ", a % b);
+            a = -1;
+            b = -1;
+            printf("%d", a % b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("-2 2 -2 0");
 }
 
 }

--- a/test/src/functionalTest/FuzzCrashRegressionTest.cpp
+++ b/test/src/functionalTest/FuzzCrashRegressionTest.cpp
@@ -266,7 +266,9 @@ TEST(Compiler, abstractPointerParameter) {
 }
 
 // Expressions whose operands failed to resolve must not assert on resultSymbol.
-// Repro: `int a = (+a) = 1` uses `a` before it is declared.
+// Repro: `int a = (+a) = 1` - with declarator-before-initializer order, `a` is in
+// scope for the initializer, so the diagnostic is lvalue on the assignment, not
+// undefined. Still must be a clean semantic error (no abort).
 
 TEST(Compiler, useInOwnInitializerIsSemanticErrorNotAbort) {
     SourceProgram program{R"prg(
@@ -276,7 +278,7 @@ TEST(Compiler, useInOwnInitializerIsSemanticErrorNotAbort) {
         }
     )prg"};
     program.compile();
-    program.assertCompilationErrors("is not defined");
+    program.assertCompilationErrors("lvalue required");
 }
 
 TEST(Compiler, undefinedInUnaryPlusIsSemanticError) {

--- a/test/src/functionalTest/GlobalVariablesTest.cpp
+++ b/test/src/functionalTest/GlobalVariablesTest.cpp
@@ -345,9 +345,7 @@ TEST(Compiler, globalWrittenAfterBeingUsedAsShiftCountIsVisibleInCaller) {
 }
 
 // Signed division/modulo must sign-extend the dividend; a negative global dividend must work.
-// DISABLED: this is a pre-existing signed-division bug (idiv setup uses `xor rdx,rdx` instead of
-// `cqo`), not a globals issue. It fails identically for locals/registers. Enable when that is fixed.
-TEST(Compiler, DISABLED_signedDivisionAndModuloOfNegativeGlobal) {
+TEST(Compiler, signedDivisionAndModuloOfNegativeGlobal) {
     SourceProgram program{R"prg(
         int a;
         int b;

--- a/test/src/functionalTest/LanguageSurfaceTest.cpp
+++ b/test/src/functionalTest/LanguageSurfaceTest.cpp
@@ -44,6 +44,32 @@ TEST(Compiler, multiDeclaratorWithInitializers) {
     program.runAndExpect("2 3 5");
 }
 
+// Later initializers in one declaration may reference earlier names (C99 6.2.1).
+// SA used to analyze all initializers before any insert — `b = a` saw a as undefined.
+TEST(Compiler, multiDeclaratorInitializerSeesEarlierName) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a = 1, b = a, c = a + b;
+            printf("%d %d %d", a, b, c);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 1 2");
+}
+
+TEST(Compiler, multiDeclaratorPointerInitFromEarlierName) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a = 1, b = 2, *p = &a;
+            printf("%d %d", *p, b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 2");
+}
+
 TEST(Compiler, multiGlobalDeclaratorsWithInitializers) {
     SourceProgram program{R"prg(
         int a = 10, b = 32;

--- a/test/src/functionalTest/PointersTest.cpp
+++ b/test/src/functionalTest/PointersTest.cpp
@@ -105,4 +105,142 @@ TEST(Compiler, pointerToPointer) {
 }
 */
 
+// Pointer arithmetic must scale by pointee size (int stride 4). Found by targeted probing
+// during mutfuzz campaign: p+1 / p-q used raw byte math.
+
+TEST(Compiler, pointerPlusIntScalesByElementSize) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int *p;
+            a[0] = 10;
+            a[1] = 20;
+            a[2] = 30;
+            p = &a[0];
+            printf("%d ", *(p + 1));
+            printf("%d", *(p + 2));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20 30");
+}
+
+TEST(Compiler, pointerMinusPointerIsElementCount) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int *p;
+            int *q;
+            a[0] = 1;
+            a[1] = 2;
+            a[2] = 3;
+            p = &a[2];
+            q = &a[0];
+            printf("%d", p - q);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2");
+}
+
+TEST(Compiler, pointerIncrementScalesByElementSize) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int *p;
+            a[0] = 10;
+            a[1] = 20;
+            a[2] = 30;
+            p = &a[0];
+            p++;
+            printf("%d ", *p);
+            ++p;
+            printf("%d", *p);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20 30");
+}
+
+// int + ptr is commutative with ptr + int (IntPlusPtr IR form).
+TEST(Compiler, intPlusPointerScalesByElementSize) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int *p;
+            a[0] = 10;
+            a[1] = 20;
+            a[2] = 30;
+            p = &a[0];
+            printf("%d ", *(1 + p));
+            printf("%d", *(2 + p));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20 30");
+}
+
+// ptr - int scales the index (PtrMinusInt IR form).
+TEST(Compiler, pointerMinusIntScalesByElementSize) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int *p;
+            a[0] = 10;
+            a[1] = 20;
+            a[2] = 30;
+            p = &a[2];
+            printf("%d ", *(p - 1));
+            printf("%d", *(p - 2));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20 10");
+}
+
+// Pointer -- / prefix -- step by pointee size (non-unit Dec quad).
+TEST(Compiler, pointerDecrementScalesByElementSize) {
+    SourceProgram program{R"prg(
+        int main() {
+            int a[3];
+            int *p;
+            a[0] = 10;
+            a[1] = 20;
+            a[2] = 30;
+            p = &a[2];
+            p--;
+            printf("%d ", *p);
+            --p;
+            printf("%d", *p);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20 10");
+}
+
+TEST(Compiler, charPointerDifferenceIsBytes) {
+    SourceProgram program{R"prg(
+        int main() {
+            char a[3];
+            char *p;
+            char *q;
+            a[0] = 1;
+            a[1] = 2;
+            a[2] = 3;
+            p = &a[2];
+            q = &a[0];
+            printf("%d", p - q);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("2");
+}
+
 } // namespace

--- a/test/src/functionalTest/SemanticErrorsTest.cpp
+++ b/test/src/functionalTest/SemanticErrorsTest.cpp
@@ -178,6 +178,21 @@ INSTANTIATE_TEST_SUITE_P(Compiler, SemanticErrorCatalog,
                                  "invalid type for operator[]",
                              },
                              SemanticErrorCase{
+                                 "pointerPlusPointer",
+                                 R"prg(
+        int main() {
+            int a;
+            int *p;
+            int *q;
+            p = &a;
+            q = &a;
+            p = p + q;
+            return 0;
+        }
+    )prg",
+                                 "invalid operands to pointer arithmetic",
+                             },
+                             SemanticErrorCase{
                                  "abstractArrayDeclarator",
                                  R"prg(
         int main() {

--- a/test/src/typesTest/TypeQueryTest.cpp
+++ b/test/src/typesTest/TypeQueryTest.cpp
@@ -93,7 +93,32 @@ TEST(TypeQuery, arraySubscriptInfoInvalidBase) {
     EXPECT_FALSE(info.valid());
 }
 
-} // namespace
+
+TEST(TypeQuery, classifyPointerArithmeticForms) {
+    type::Type i = type::signedInteger();
+    type::Type pi = type::pointer(i);
+
+    auto none = type::classifyPointerArithmetic(i, i, '+');
+    EXPECT_EQ(none.form, type::PointerArithmeticForm::None);
+
+    auto ppi = type::classifyPointerArithmetic(pi, i, '+');
+    EXPECT_EQ(ppi.form, type::PointerArithmeticForm::PtrPlusInt);
+    EXPECT_TRUE(ppi.resultType.isPointer());
+    EXPECT_EQ(ppi.strideBytes, 4);
+
+    auto ipp = type::classifyPointerArithmetic(i, pi, '+');
+    EXPECT_EQ(ipp.form, type::PointerArithmeticForm::IntPlusPtr);
+
+    auto pmi = type::classifyPointerArithmetic(pi, i, '-');
+    EXPECT_EQ(pmi.form, type::PointerArithmeticForm::PtrMinusInt);
+
+    auto pmp = type::classifyPointerArithmetic(pi, pi, '-');
+    EXPECT_EQ(pmp.form, type::PointerArithmeticForm::PtrMinusPtr);
+    EXPECT_TRUE(pmp.resultType.isPrimitive());
+
+    auto inv = type::classifyPointerArithmetic(pi, pi, '+');
+    EXPECT_EQ(inv.form, type::PointerArithmeticForm::Invalid);
+}
 
 TEST(TypeQuery, arraySubscriptInfoDualFallbackToValuePointer) {
     // Non-array/non-pointer expression type, pointer value type.
@@ -124,3 +149,5 @@ TEST(TypeQuery, productAssignFailureMessageTypeMismatch) {
             type::structure({ { "x", type::signedInteger() } }));
     EXPECT_NE(msg.find("type mismatch"), std::string::npos);
 }
+
+} // namespace

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -97,6 +97,7 @@ TEST(Type, pointerToSignedInteger) {
 
     EXPECT_THAT(t.getSize(), Eq(8));
     EXPECT_THAT(t.isPointer(), IsTrue());
+    EXPECT_THAT(t.isPrimitive(), IsFalse());
     EXPECT_THAT(t.isConst(), IsFalse());
     EXPECT_THAT(t.isVolatile(), IsFalse());
 
@@ -104,6 +105,7 @@ TEST(Type, pointerToSignedInteger) {
 
     auto pointsTo = t.dereference();
     EXPECT_THAT(pointsTo.getSize(), Eq(4));
+    EXPECT_THAT(pointsTo.isPrimitive(), IsTrue());
 }
 
 TEST(Type, pointerToPointerToSignedInteger) {


### PR DESCRIPTION
## Summary

Fixes three correctness bugs found by mutation fuzzing of the master language surface:

1. **Signed division/modulo** – `idiv` was preceded by `xor rdx,rdx` instead of `cqo`, so negative dividends could SIGFPE or yield wrong quotients/remainders.
2. **Multi-declarator initializers** – all initializers were analyzed before any name was inserted, so forms like `int a = 1, b = a` / `int a = 1, *p = &a` falsely reported undefined symbols.
3. **Pointer arithmetic** – `p+i`, `p-i`, `p-q`, and pointer `++`/`--` did not scale by pointee size (byte math instead of element math).

## Design

- `Type::isPrimitive()` excludes indirection so `int*` is not treated as a scalar.
- Shared `type::classifyPointerArithmetic` (TypeQuery) for SA result typing and CG IR selection.
- New IR: `PointerOffset` / `PointerDiff`; shared backend `scaledBaseIndex` with array indexing.
- Integer `Add`/`Sub` stay unscaled; pointer `++`/`--` use a documented byte `step` on `Inc`/`Dec`.
- Declarations: visit each declarator, insert, then analyze initializer (C visibility).

## Test plan

- [x] Functional: signed div/mod (locals + global), multi-declarator cross-init, pointer scale/diff/++, char ptrdiff
- [x] Unit: `Type.pointerToSignedInteger` not primitive; `TypeQuery.classifyPointerArithmeticForms`
- [x] Array indexing still green (shared `scaledBaseIndex`)
- [ ] CI full `make test` / ctest