### PR TITLE
phase0/02: TypeQuery product policy pack and short primitives

### DIFF
--- a/src/types/Primitive.cpp
+++ b/src/types/Primitive.cpp
@@ -12,6 +12,14 @@ Primitive Primitive::unsignedCharacter() {
     return Primitive{1, false, false};
 }
 
+Primitive Primitive::signedShort() {
+    return Primitive{2, true, false};
+}
+
+Primitive Primitive::unsignedShort() {
+    return Primitive{2, false, false};
+}
+
 Primitive Primitive::signedInteger() {
     return Primitive{4, true, false};
 }
@@ -59,10 +67,16 @@ bool Primitive::isFloating() const {
     return _float;
 }
 
+bool Primitive::equivalentTo(const Primitive& other) const {
+    return _size == other._size && _signed == other._signed && _float == other._float;
+}
+
 std::string Primitive::base_primitive_string() const {
     switch (_size) {
         case 1:
             return "char";
+        case 2:
+            return "short";
         case 4:
             return isFloating() ? "float" : "int";
         case 8:

--- a/src/types/Primitive.h
+++ b/src/types/Primitive.h
@@ -9,6 +9,8 @@ class Primitive {
 public:
     static Primitive signedCharacter();
     static Primitive unsignedCharacter();
+    static Primitive signedShort();
+    static Primitive unsignedShort();
     static Primitive signedInteger();
     static Primitive unsignedInteger();
     static Primitive signedLong();
@@ -22,7 +24,7 @@ public:
     bool isSigned() const;
     bool isFloating() const;
 
-    bool canAssignFrom(const Primitive& other) const;
+    bool equivalentTo(const Primitive& other) const;
 
     std::string to_string() const;
 

--- a/src/types/Type.cpp
+++ b/src/types/Type.cpp
@@ -177,6 +177,12 @@ Type signedCharacter(const std::vector<Qualifier>& qualifiers) {
 Type unsignedCharacter(const std::vector<Qualifier>& qualifiers) {
     return primitive(Primitive::unsignedCharacter(), qualifiers);
 }
+Type signedShort(const std::vector<Qualifier>& qualifiers) {
+    return primitive(Primitive::signedShort(), qualifiers);
+}
+Type unsignedShort(const std::vector<Qualifier>& qualifiers) {
+    return primitive(Primitive::unsignedShort(), qualifiers);
+}
 Type signedInteger(const std::vector<Qualifier>& qualifiers) {
     return primitive(Primitive::signedInteger(), qualifiers);
 }
@@ -294,9 +300,7 @@ bool Type::equivalentTo(const Type& other) const {
     case TypeKind::Void:
         return true;
     case TypeKind::Primitive:
-        return a.getPrimitive().getSize() == b.getPrimitive().getSize()
-                && a.getPrimitive().isSigned() == b.getPrimitive().isSigned()
-                && a.getPrimitive().isFloating() == b.getPrimitive().isFloating();
+        return a.getPrimitive().equivalentTo(b.getPrimitive());
     case TypeKind::Array:
         return a.getArraySize() == b.getArraySize()
                 && a.getElementType().equivalentTo(b.getElementType());

--- a/src/types/Type.h
+++ b/src/types/Type.h
@@ -196,6 +196,8 @@ void completeUnion(Type& unionType,
 
 Type signedCharacter(const std::vector<Qualifier>& qualifiers = {});
 Type unsignedCharacter(const std::vector<Qualifier>& qualifiers = {});
+Type signedShort(const std::vector<Qualifier>& qualifiers = {});
+Type unsignedShort(const std::vector<Qualifier>& qualifiers = {});
 Type signedInteger(const std::vector<Qualifier>& qualifiers = {});
 Type unsignedInteger(const std::vector<Qualifier>& qualifiers = {});
 Type signedLong(const std::vector<Qualifier>& qualifiers = {});

--- a/src/types/TypeQuery.cpp
+++ b/src/types/TypeQuery.cpp
@@ -14,6 +14,15 @@ Type productDecay(Type t) {
     return t;
 }
 
+bool recordsCompatible(const Type& a, const Type& b) {
+    return a.isRecord() && b.isRecord();
+}
+
+// Product-loose null constant: integral (including null pointer constant 0).
+bool isNullConstantCandidate(const Type& t) {
+    return isIntegral(t);
+}
+
 } // namespace
 
 bool productValueCompatible(const Type& a, const Type& b) {
@@ -22,22 +31,16 @@ bool productValueCompatible(const Type& a, const Type& b) {
     if (la.isVoid() || ra.isVoid()) {
         return false;
     }
-    // Product-loose record-to-record (master policy; spike tightens by body identity later).
+    // Product-loose record-to-record (struct/union); pin tests cover structure pairs
+    // and union pairs intentionally.
     if (la.isRecord() || ra.isRecord()) {
-        return la.isRecord() && ra.isRecord();
+        return recordsCompatible(la, ra);
     }
-    if (isProductScalar(la) && isProductScalar(ra)) {
-        return true;
-    }
-    return false;
+    return isProductScalar(la) && isProductScalar(ra);
 }
 
 bool productAssignFrom(const Type& dest, const Type& source) {
-    // Product assign (git-shaped). Keep master rejections that functional/unit tests pin:
-    // - no bare-function destination
-    // - no incomplete record destination
-    // - no array assign
-    // - no function designator / fp into non-fp destination
+    // Own gate (not "valueCompatible plus ..."): see TypeQuery.h.
     if (dest.isVoid() || isBareFunction(dest)) {
         return false;
     }
@@ -52,36 +55,25 @@ bool productAssignFrom(const Type& dest, const Type& source) {
         if (isBareFunction(source) || isPointerToFunction(source)) {
             return true;
         }
-        return source.isPrimitive() && !source.getPrimitive().isFloating();
+        return isNullConstantCandidate(source);
     }
     if (dest.isPointer()) {
         if (source.isPointer()) {
             return true;
         }
-        return source.isPrimitive() && !source.getPrimitive().isFloating();
+        return isNullConstantCandidate(source);
     }
     if (isBareFunction(source) || isPointerToFunction(source)) {
         return false;
     }
-    if (dest.isRecord()) {
-        return source.isRecord();
-    }
-    if (source.isRecord()) {
-        return false;
+    if (dest.isRecord() || source.isRecord()) {
+        return recordsCompatible(dest, source);
     }
     return isProductScalar(dest) && isProductScalar(source);
 }
 
 bool productArithmeticCompatible(const Type& a, const Type& b) {
-    Type la = productDecay(a);
-    Type ra = productDecay(b);
-    if (la.isPointer() || ra.isPointer() || la.isRecord() || ra.isRecord()) {
-        return false;
-    }
-    if (la.isVoid() || ra.isVoid()) {
-        return false;
-    }
-    return (isIntegral(la) || isFloating(la)) && (isIntegral(ra) || isFloating(ra));
+    return isArithmeticType(a) && isArithmeticType(b);
 }
 
 std::string productAssignFailureMessage(const Type& dest, const Type& source) {

--- a/src/types/TypeQuery.cpp
+++ b/src/types/TypeQuery.cpp
@@ -4,13 +4,40 @@ namespace type {
 
 namespace {
 
-bool isProductScalar(const Type& t) {
-    return t.isPrimitive() || t.isPointer();
+Type productDecay(Type t) {
+    if (t.isArray()) {
+        return t.decayArray();
+    }
+    if (isBareFunction(t)) {
+        return pointer(t);
+    }
+    return t;
 }
 
 } // namespace
 
-bool productCanAssignFrom(const Type& dest, const Type& source) {
+bool productValueCompatible(const Type& a, const Type& b) {
+    Type la = productDecay(a);
+    Type ra = productDecay(b);
+    if (la.isVoid() || ra.isVoid()) {
+        return false;
+    }
+    // Product-loose record-to-record (master policy; spike tightens by body identity later).
+    if (la.isRecord() || ra.isRecord()) {
+        return la.isRecord() && ra.isRecord();
+    }
+    if (isProductScalar(la) && isProductScalar(ra)) {
+        return true;
+    }
+    return false;
+}
+
+bool productAssignFrom(const Type& dest, const Type& source) {
+    // Product assign (git-shaped). Keep master rejections that functional/unit tests pin:
+    // - no bare-function destination
+    // - no incomplete record destination
+    // - no array assign
+    // - no function designator / fp into non-fp destination
     if (dest.isVoid() || isBareFunction(dest)) {
         return false;
     }
@@ -21,44 +48,43 @@ bool productCanAssignFrom(const Type& dest, const Type& source) {
         return false;
     }
 
-    // Function-pointer destination: designator, pointer-to-function, or integer
-    // (null pointer constant 0 — product does not require constant-expression proof).
     if (isPointerToFunction(dest)) {
         if (isBareFunction(source) || isPointerToFunction(source)) {
             return true;
         }
         return source.isPrimitive() && !source.getPrimitive().isFloating();
     }
-    // Other pointers: accept integer null constant or compatible pointers.
     if (dest.isPointer()) {
         if (source.isPointer()) {
             return true;
         }
         return source.isPrimitive() && !source.getPrimitive().isFloating();
     }
-    // Function-pointer / designator source into non-fp: reject.
     if (isBareFunction(source) || isPointerToFunction(source)) {
         return false;
     }
-
-    // Structures: only structure-to-structure (not pointer address temps).
-    if (dest.isStructure()) {
-        return source.isStructure();
+    if (dest.isRecord()) {
+        return source.isRecord();
     }
-    if (source.isStructure()) {
+    if (source.isRecord()) {
         return false;
     }
+    return isProductScalar(dest) && isProductScalar(source);
+}
 
-    // Scalars and non-function pointers.
-    if (isProductScalar(dest) && isProductScalar(source)) {
-        return true;
+bool productArithmeticCompatible(const Type& a, const Type& b) {
+    Type la = productDecay(a);
+    Type ra = productDecay(b);
+    if (la.isPointer() || ra.isPointer() || la.isRecord() || ra.isRecord()) {
+        return false;
     }
-
-    return false;
+    if (la.isVoid() || ra.isVoid()) {
+        return false;
+    }
+    return (isIntegral(la) || isFloating(la)) && (isIntegral(ra) || isFloating(ra));
 }
 
 std::string productAssignFailureMessage(const Type& dest, const Type& source) {
-    // Same predicates as productCanAssignFrom — presentation only.
     if ((isBareFunction(source) || isPointerToFunction(source)) && !isPointerToFunction(dest)) {
         return "function designator used as a value is not supported";
     }

--- a/src/types/TypeQuery.cpp
+++ b/src/types/TypeQuery.cpp
@@ -44,7 +44,7 @@ bool productAssignFrom(const Type& dest, const Type& source) {
     if (dest.isVoid() || isBareFunction(dest)) {
         return false;
     }
-    if (dest.isIncompleteStructure()) {
+    if (dest.isIncompleteRecord()) {
         return false;
     }
     if (dest.isArray() || source.isArray()) {

--- a/src/types/TypeQuery.h
+++ b/src/types/TypeQuery.h
@@ -195,8 +195,8 @@ struct ArraySubscriptInfo {
 // Byte size of one index step through a value of type t (at least 1).
 // For array types this is the whole array size (e.g. sizeof(int[3]) for p where p is int(*)[3]).
 inline int objectStrideBytes(const Type& t) {
-    int size = t.getSize();
-    return size < 1 ? 1 : size;
+    // Index step / packing size (0 allowed for empty complete records).
+    return t.getSize();
 }
 
 // Given the C type of the subscript base (array or pointer).

--- a/src/types/TypeQuery.h
+++ b/src/types/TypeQuery.h
@@ -97,12 +97,89 @@ inline bool isIncompleteMemberOrElementType(const Type& t) {
     return t.isVoid() || isBareFunction(t) || t.isIncompleteRecord();
 }
 
-bool productCanAssignFrom(const Type& dest, const Type& source);
+inline bool isFloating(const Type& t) {
+    return t.isPrimitive() && t.getPrimitive().isFloating();
+}
 
-// Diagnostic text for a failed productCanAssignFrom (call only when canAssign is false).
+inline bool isIntegral(const Type& t) {
+    return t.isPrimitive() && !t.getPrimitive().isFloating();
+}
+
+// True when arithmetic / shifts should treat `t` as unsigned (pointers/arrays
+// are address values; unsigned integrals; floats are not).
+inline bool isUnsignedSide(const Type& t) {
+    if (t.kind() == TypeKind::Pointer || t.kind() == TypeKind::Array) {
+        return true;
+    }
+    if (isIntegral(t)) {
+        return !t.getPrimitive().isSigned();
+    }
+    return false;
+}
+
+// Signedness for live Values / stack homes (SAR default).
+inline bool valueIsSigned(const Type& t) {
+    if (isIntegral(t)) {
+        return t.getPrimitive().isSigned();
+    }
+    return true;
+}
+
+// Integer promotions (C 6.3.1.1): types narrower than int convert to int.
+inline Type integerPromote(const Type& t) {
+    if (!isIntegral(t)) {
+        return t;
+    }
+    if (t.getSize() > 0 && t.getSize() < 4) {
+        return signedInteger();
+    }
+    return t;
+}
+
+// Usual arithmetic conversions (product subset): floating -> double;
+// otherwise integer promotions then wider (and unsigned-over-signed) wins.
+inline Type usualArithmeticResult(const Type& left, const Type& right) {
+    if (isFloating(left) || isFloating(right)) {
+        return doubleFloating();
+    }
+    Type leftP = integerPromote(left);
+    Type rightP = integerPromote(right);
+    if (rightP.getSize() > leftP.getSize()) {
+        return rightP;
+    }
+    if (rightP.getSize() == leftP.getSize()
+            && isIntegral(rightP) && isIntegral(leftP)
+            && !valueIsSigned(rightP) && valueIsSigned(leftP)) {
+        return rightP;
+    }
+    return leftP;
+}
+
+// Product-loose scalar (primitive or pointer) after array/function decay.
+inline bool isProductScalar(const Type& t) {
+    return t.kind() == TypeKind::Primitive || t.isPointer();
+}
+
+// Operand compatibility after array/function decay (not assignment).
+bool productValueCompatible(const Type& a, const Type& b);
+
+// Permanent product assign policy (git-shaped C), not ISO can_assign.
+// productValueCompatible plus reject bare function destination (before decay).
+// Use for assignment, initialization, and call arguments.
+bool productAssignFrom(const Type& dest, const Type& source);
+
+// Alias kept for existing call sites (same policy as productAssignFrom).
+inline bool productCanAssignFrom(const Type& dest, const Type& source) {
+    return productAssignFrom(dest, source);
+}
+
+// Non-pointer arithmetic (* / % and scalar +/-): both arithmetic types.
+bool productArithmeticCompatible(const Type& a, const Type& b);
+
+// Diagnostic text for a failed product assign (call only when canAssign is false).
 std::string productAssignFailureMessage(const Type& dest, const Type& source);
 
-// Array subscript element info for SA (shared policy — finish-for-git TypeQuery).
+// Array subscript element info for SA (shared policy).
 struct ArraySubscriptInfo {
     Type elementType { voidType() };
     int elementStride { 8 };
@@ -116,16 +193,17 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& baseType) {
     ArraySubscriptInfo info;
     if (baseType.isArray()) {
         info.elementType = baseType.getElementType();
-        info.elementStride = info.elementType.getSize();
-        if (info.elementStride < 1) {
-            info.elementStride = 1;
-        }
+        info.elementStride = baseType.getElementStride();
         info.baseIsArray = true;
     } else if (baseType.isPointer()) {
         info.elementType = baseType.dereference();
         info.elementStride = info.elementType.getSize();
         if (info.elementStride < 1) {
             info.elementStride = 1;
+        }
+        if (info.elementType.isArray()) {
+            // p is T(*)[N]: stride is sizeof(T[N]) for p[i].
+            info.elementStride = info.elementType.getSize();
         }
         info.baseIsArray = false;
     } else {
@@ -136,8 +214,9 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& baseType) {
     return info;
 }
 
-// Dual-type: expression type may still be T[N] while value is a decayed pointer
-// (multi-dim row / array-of-struct address). Prefer expression type for element/stride.
+// Dual-type subscript: expression type may still be T[N] while value type is
+// already a decayed pointer. Prefer expression type for element/stride when it
+// is array|pointer; fall back to value-type pointer.
 inline ArraySubscriptInfo arraySubscriptInfo(const Type& expressionType, const Type& valueType) {
     if (expressionType.isArray() && valueType.isPointer()) {
         ArraySubscriptInfo info;

--- a/src/types/TypeQuery.h
+++ b/src/types/TypeQuery.h
@@ -105,6 +105,10 @@ inline bool isIntegral(const Type& t) {
     return t.isPrimitive() && !t.getPrimitive().isFloating();
 }
 
+inline bool isArithmeticType(const Type& t) {
+    return isIntegral(t) || isFloating(t);
+}
+
 // True when arithmetic / shifts should treat `t` as unsigned (pointers/arrays
 // are address values; unsigned integrals; floats are not).
 inline bool isUnsignedSide(const Type& t) {
@@ -155,7 +159,7 @@ inline Type usualArithmeticResult(const Type& left, const Type& right) {
     return leftP;
 }
 
-// Product-loose scalar (primitive or pointer) after array/function decay.
+// Primitive or pointer (caller must decay arrays/functions if desired).
 inline bool isProductScalar(const Type& t) {
     return t.kind() == TypeKind::Primitive || t.isPointer();
 }
@@ -163,9 +167,9 @@ inline bool isProductScalar(const Type& t) {
 // Operand compatibility after array/function decay (not assignment).
 bool productValueCompatible(const Type& a, const Type& b);
 
-// Permanent product assign policy (git-shaped C), not ISO can_assign.
-// productValueCompatible plus reject bare function destination (before decay).
-// Use for assignment, initialization, and call arguments.
+// Git-shaped assign gate (assignment / init / call args). Not a pure subset of
+// productValueCompatible: arrays never assign; incomplete dest rejected;
+// function designators only into function-pointer dest; null-integer into pointers.
 bool productAssignFrom(const Type& dest, const Type& source);
 
 // Alias kept for existing call sites (same policy as productAssignFrom).
@@ -173,7 +177,7 @@ inline bool productCanAssignFrom(const Type& dest, const Type& source) {
     return productAssignFrom(dest, source);
 }
 
-// Non-pointer arithmetic (* / % and scalar +/-): both arithmetic types.
+// Scalar arithmetic (* / % and non-pointer +/-): both arithmetic types.
 bool productArithmeticCompatible(const Type& a, const Type& b);
 
 // Diagnostic text for a failed product assign (call only when canAssign is false).
@@ -188,23 +192,24 @@ struct ArraySubscriptInfo {
     bool valid() const { return elementStride > 0; }
 };
 
+// Byte size of one index step through a value of type t (at least 1).
+// For array types this is the whole array size (e.g. sizeof(int[3]) for p where p is int(*)[3]).
+inline int objectStrideBytes(const Type& t) {
+    int size = t.getSize();
+    return size < 1 ? 1 : size;
+}
+
 // Given the C type of the subscript base (array or pointer).
 inline ArraySubscriptInfo arraySubscriptInfo(const Type& baseType) {
     ArraySubscriptInfo info;
     if (baseType.isArray()) {
         info.elementType = baseType.getElementType();
-        info.elementStride = baseType.getElementStride();
+        info.elementStride = objectStrideBytes(baseType);
         info.baseIsArray = true;
     } else if (baseType.isPointer()) {
         info.elementType = baseType.dereference();
-        info.elementStride = info.elementType.getSize();
-        if (info.elementStride < 1) {
-            info.elementStride = 1;
-        }
-        if (info.elementType.isArray()) {
-            // p is T(*)[N]: stride is sizeof(T[N]) for p[i].
-            info.elementStride = info.elementType.getSize();
-        }
+        // p is T(*)[N]: stride is sizeof(T[N]); otherwise sizeof(pointee).
+        info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = false;
     } else {
         info.elementType = voidType();
@@ -215,16 +220,12 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& baseType) {
 }
 
 // Dual-type subscript: expression type may still be T[N] while value type is
-// already a decayed pointer. Prefer expression type for element/stride when it
-// is array|pointer; fall back to value-type pointer.
+// already a decayed pointer.
 inline ArraySubscriptInfo arraySubscriptInfo(const Type& expressionType, const Type& valueType) {
     if (expressionType.isArray() && valueType.isPointer()) {
         ArraySubscriptInfo info;
         info.elementType = expressionType.getElementType();
-        info.elementStride = info.elementType.getSize();
-        if (info.elementStride < 1) {
-            info.elementStride = 1;
-        }
+        info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = false;
         return info;
     }
@@ -232,10 +233,7 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& expressionType, const T
     if (!sub.valid() && valueType.isPointer()) {
         ArraySubscriptInfo info;
         info.elementType = valueType.dereference();
-        info.elementStride = info.elementType.getSize();
-        if (info.elementStride < 1) {
-            info.elementStride = 1;
-        }
+        info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = false;
         return info;
     }

--- a/src/types/TypeQuery.h
+++ b/src/types/TypeQuery.h
@@ -88,13 +88,15 @@ inline bool isPointerToBareFunction(const Type& t) {
     return isPointerToFunction(t);
 }
 
+// Void, bare function, or incomplete record (not pointer-to-incomplete).
+// Shared definition used by sizeof and member/element completeness checks.
 inline bool isIncompleteObjectType(const Type& t) {
     return t.isVoid() || isBareFunction(t) || t.isIncompleteRecord();
 }
 
-// Void, bare function, or incomplete record (not pointer-to-incomplete).
+// Same predicate as isIncompleteObjectType; name documents member/element sites.
 inline bool isIncompleteMemberOrElementType(const Type& t) {
-    return t.isVoid() || isBareFunction(t) || t.isIncompleteRecord();
+    return isIncompleteObjectType(t);
 }
 
 inline bool isFloating(const Type& t) {
@@ -188,14 +190,15 @@ struct ArraySubscriptInfo {
     Type elementType { voidType() };
     int elementStride { 8 };
     bool baseIsArray { false };
+    // True when base is array or pointer (stride may be 0 for empty complete records).
+    bool ok { false };
 
-    bool valid() const { return elementStride > 0; }
+    bool valid() const { return ok; }
 };
 
-// Byte size of one index step through a value of type t (at least 1).
+// Byte size of one index step through a value of type t (0 for empty complete records).
 // For array types this is the whole array size (e.g. sizeof(int[3]) for p where p is int(*)[3]).
 inline int objectStrideBytes(const Type& t) {
-    // Index step / packing size (0 allowed for empty complete records).
     return t.getSize();
 }
 
@@ -207,15 +210,18 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& baseType) {
         // Index steps by sizeof(element), not sizeof(the whole array).
         info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = true;
+        info.ok = true;
     } else if (baseType.isPointer()) {
         info.elementType = baseType.dereference();
         // p is T(*)[N]: stride is sizeof(T[N]); otherwise sizeof(pointee).
         info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = false;
+        info.ok = true;
     } else {
         info.elementType = voidType();
         info.elementStride = 0;
         info.baseIsArray = false;
+        info.ok = false;
     }
     return info;
 }
@@ -228,6 +234,7 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& expressionType, const T
         info.elementType = expressionType.getElementType();
         info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = false;
+        info.ok = true;
         return info;
     }
     ArraySubscriptInfo sub = arraySubscriptInfo(expressionType);
@@ -236,6 +243,7 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& expressionType, const T
         info.elementType = valueType.dereference();
         info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = false;
+        info.ok = true;
         return info;
     }
     return sub;

--- a/src/types/TypeQuery.h
+++ b/src/types/TypeQuery.h
@@ -204,7 +204,8 @@ inline ArraySubscriptInfo arraySubscriptInfo(const Type& baseType) {
     ArraySubscriptInfo info;
     if (baseType.isArray()) {
         info.elementType = baseType.getElementType();
-        info.elementStride = objectStrideBytes(baseType);
+        // Index steps by sizeof(element), not sizeof(the whole array).
+        info.elementStride = objectStrideBytes(info.elementType);
         info.baseIsArray = true;
     } else if (baseType.isPointer()) {
         info.elementType = baseType.dereference();

--- a/test/src/typesTest/PrimitiveTest.cpp
+++ b/test/src/typesTest/PrimitiveTest.cpp
@@ -90,3 +90,21 @@ TEST(Primitive, longDoubleFloating) {
 
 } // namespace
 
+
+TEST(Primitive, signedShort) {
+    auto t = type::signedShort().getPrimitive();
+
+    EXPECT_THAT(t.getSize(), Eq(2));
+    EXPECT_THAT(t.isSigned(), IsTrue());
+    EXPECT_THAT(t.isFloating(), IsFalse());
+    EXPECT_THAT(t.to_string(), Eq("short"));
+}
+
+TEST(Primitive, unsignedShort) {
+    auto t = type::unsignedShort().getPrimitive();
+
+    EXPECT_THAT(t.getSize(), Eq(2));
+    EXPECT_THAT(t.isSigned(), IsFalse());
+    EXPECT_THAT(t.isFloating(), IsFalse());
+    EXPECT_THAT(t.to_string(), Eq("unsigned short"));
+}

--- a/test/src/typesTest/TypeQueryTest.cpp
+++ b/test/src/typesTest/TypeQueryTest.cpp
@@ -76,11 +76,14 @@ TEST(TypeQuery, arraySubscriptInfoArrayAndPointer) {
     EXPECT_TRUE(info.valid());
     EXPECT_TRUE(info.baseIsArray);
     EXPECT_TRUE(info.elementType.isPrimitive());
+    // Array-base index steps by sizeof(element), not sizeof(the whole array).
+    EXPECT_EQ(info.elementStride, 4);
 
     type::Type ptr = type::pointer(type::signedInteger());
     auto pinfo = type::arraySubscriptInfo(ptr);
     EXPECT_TRUE(pinfo.valid());
     EXPECT_FALSE(pinfo.baseIsArray);
+    EXPECT_EQ(pinfo.elementStride, 4);
 }
 
 TEST(TypeQuery, arraySubscriptInfoDualTypeRow) {
@@ -90,6 +93,7 @@ TEST(TypeQuery, arraySubscriptInfoDualTypeRow) {
     EXPECT_TRUE(info.valid());
     EXPECT_FALSE(info.baseIsArray);
     EXPECT_TRUE(info.elementType.isPrimitive());
+    EXPECT_EQ(info.elementStride, 4);
 }
 
 TEST(TypeQuery, arraySubscriptInfoInvalidBase) {
@@ -155,13 +159,6 @@ TEST(TypeQuery, productAssignFailureMessageTypeMismatch) {
     EXPECT_NE(msg.find("type mismatch"), std::string::npos);
 }
 
-TEST(TypeQuery, productAssignFromMatchesCanAssignAlias) {
-    type::Type i = type::signedInteger();
-    type::Type pi = type::pointer(i);
-    EXPECT_EQ(type::productAssignFrom(i, i), type::productCanAssignFrom(i, i));
-    EXPECT_EQ(type::productAssignFrom(pi, i), type::productCanAssignFrom(pi, i));
-    EXPECT_EQ(type::productAssignFrom(i, pi), type::productCanAssignFrom(i, pi));
-}
 
 TEST(TypeQuery, productValueCompatibleScalarsAndPointers) {
     type::Type i = type::signedInteger();

--- a/test/src/typesTest/TypeQueryTest.cpp
+++ b/test/src/typesTest/TypeQueryTest.cpp
@@ -206,4 +206,21 @@ TEST(TypeQuery, arraySubscriptPointerToArrayStride) {
     EXPECT_TRUE(info.elementType.isArray());
     EXPECT_EQ(info.elementStride, 12);
 }
+
+TEST(TypeQuery, productAssignRecordsIncludeUnions) {
+    auto s = type::structure({ { "x", type::signedInteger() } });
+    auto u = type::unionType({ { "y", type::signedInteger() } });
+    // Product-loose record-to-record (same policy as structure-to-structure).
+    EXPECT_TRUE(type::productAssignFrom(s, s));
+    EXPECT_TRUE(type::productAssignFrom(u, u));
+    EXPECT_TRUE(type::productAssignFrom(s, u));
+    EXPECT_TRUE(type::productAssignFrom(u, s));
+    EXPECT_FALSE(type::productAssignFrom(s, type::signedInteger()));
+}
+
+TEST(TypeQuery, productArithmeticIsScalarOnly) {
+    EXPECT_TRUE(type::productArithmeticCompatible(type::signedInteger(), type::signedLong()));
+    EXPECT_FALSE(type::productArithmeticCompatible(type::signedInteger(), type::array(type::signedInteger(), 2)));
+}
+
 } // namespace

--- a/test/src/typesTest/TypeQueryTest.cpp
+++ b/test/src/typesTest/TypeQueryTest.cpp
@@ -220,4 +220,16 @@ TEST(TypeQuery, productArithmeticIsScalarOnly) {
     EXPECT_FALSE(type::productArithmeticCompatible(type::signedInteger(), type::array(type::signedInteger(), 2)));
 }
 
+TEST(TypeQuery, signednessHelpersAreNotDualsOutsideIntegrals) {
+    type::Type p = type::pointer(type::signedInteger());
+    EXPECT_TRUE(type::isUnsignedSide(p));
+    EXPECT_TRUE(type::valueIsSigned(p));
+    auto uar = type::usualArithmeticResult(type::signedInteger(), type::unsignedInteger());
+    EXPECT_EQ(uar.getSize(), 4);
+    EXPECT_FALSE(type::valueIsSigned(uar));
+    auto prom = type::integerPromote(type::unsignedShort());
+    EXPECT_EQ(prom.getSize(), 4);
+    EXPECT_TRUE(prom.getPrimitive().isSigned());
+}
+
 } // namespace

--- a/test/src/typesTest/TypeQueryTest.cpp
+++ b/test/src/typesTest/TypeQueryTest.cpp
@@ -99,6 +99,32 @@ TEST(TypeQuery, arraySubscriptInfoDualTypeRow) {
 TEST(TypeQuery, arraySubscriptInfoInvalidBase) {
     auto info = type::arraySubscriptInfo(type::signedInteger());
     EXPECT_FALSE(info.valid());
+    EXPECT_EQ(info.elementStride, 0);
+}
+
+TEST(TypeQuery, arraySubscriptInfoEmptyCompleteElementIsValid) {
+    // Empty complete records have size 0; subscript base must still be valid.
+    type::Type empty = type::structure({});
+    type::Type arr = type::array(empty, 3);
+    auto info = type::arraySubscriptInfo(arr);
+    EXPECT_TRUE(info.valid());
+    EXPECT_TRUE(info.baseIsArray);
+    EXPECT_EQ(info.elementStride, 0);
+
+    type::Type ptr = type::pointer(empty);
+    auto pinfo = type::arraySubscriptInfo(ptr);
+    EXPECT_TRUE(pinfo.valid());
+    EXPECT_FALSE(pinfo.baseIsArray);
+    EXPECT_EQ(pinfo.elementStride, 0);
+}
+
+TEST(TypeQuery, incompletePredicatesShareDefinition) {
+    type::Type inc = type::incompleteStructure();
+    EXPECT_EQ(type::isIncompleteObjectType(inc), type::isIncompleteMemberOrElementType(inc));
+    EXPECT_EQ(type::isIncompleteObjectType(type::voidType()),
+            type::isIncompleteMemberOrElementType(type::voidType()));
+    EXPECT_EQ(type::isIncompleteObjectType(type::signedInteger()),
+            type::isIncompleteMemberOrElementType(type::signedInteger()));
 }
 
 

--- a/test/src/typesTest/TypeQueryTest.cpp
+++ b/test/src/typesTest/TypeQueryTest.cpp
@@ -155,4 +155,55 @@ TEST(TypeQuery, productAssignFailureMessageTypeMismatch) {
     EXPECT_NE(msg.find("type mismatch"), std::string::npos);
 }
 
+TEST(TypeQuery, productAssignFromMatchesCanAssignAlias) {
+    type::Type i = type::signedInteger();
+    type::Type pi = type::pointer(i);
+    EXPECT_EQ(type::productAssignFrom(i, i), type::productCanAssignFrom(i, i));
+    EXPECT_EQ(type::productAssignFrom(pi, i), type::productCanAssignFrom(pi, i));
+    EXPECT_EQ(type::productAssignFrom(i, pi), type::productCanAssignFrom(i, pi));
+}
+
+TEST(TypeQuery, productValueCompatibleScalarsAndPointers) {
+    type::Type i = type::signedInteger();
+    type::Type u = type::unsignedInteger();
+    type::Type pi = type::pointer(i);
+    EXPECT_TRUE(type::productValueCompatible(i, u));
+    EXPECT_TRUE(type::productValueCompatible(pi, pi));
+    EXPECT_TRUE(type::productValueCompatible(i, pi)); // decay not required for product-loose
+    EXPECT_FALSE(type::productValueCompatible(i, type::voidType()));
+}
+
+TEST(TypeQuery, productArithmeticCompatible) {
+    EXPECT_TRUE(type::productArithmeticCompatible(type::signedInteger(), type::signedLong()));
+    EXPECT_TRUE(type::productArithmeticCompatible(type::floating(), type::doubleFloating()));
+    EXPECT_FALSE(type::productArithmeticCompatible(type::pointer(type::signedInteger()), type::signedInteger()));
+    EXPECT_FALSE(type::productArithmeticCompatible(type::signedInteger(), type::voidType()));
+}
+
+TEST(TypeQuery, isFloatingAndIntegral) {
+    EXPECT_TRUE(type::isIntegral(type::signedInteger()));
+    EXPECT_TRUE(type::isFloating(type::floating()));
+    EXPECT_FALSE(type::isFloating(type::signedInteger()));
+    EXPECT_FALSE(type::isIntegral(type::floating()));
+}
+
+TEST(TypeQuery, usualArithmeticResult) {
+    auto r = type::usualArithmeticResult(type::signedCharacter(), type::signedInteger());
+    EXPECT_TRUE(r.isPrimitive());
+    EXPECT_EQ(r.getSize(), 4);
+    auto rf = type::usualArithmeticResult(type::floating(), type::signedInteger());
+    EXPECT_TRUE(type::isFloating(rf));
+    EXPECT_EQ(rf.getSize(), 8); // product promotes to double
+}
+
+TEST(TypeQuery, arraySubscriptPointerToArrayStride) {
+    // p is int (*)[3]: p[i] steps by sizeof(int[3])
+    type::Type row = type::array(type::signedInteger(), 3);
+    type::Type p = type::pointer(row);
+    auto info = type::arraySubscriptInfo(p);
+    EXPECT_TRUE(info.valid());
+    EXPECT_FALSE(info.baseIsArray);
+    EXPECT_TRUE(info.elementType.isArray());
+    EXPECT_EQ(info.elementStride, 12);
+}
 } // namespace

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -559,5 +559,22 @@ TEST(Type, structureNamedPredicatesAreStructOnly) {
     EXPECT_THAT(inc.isIncompleteRecord(), IsTrue());
 }
 
+TEST(Type, equivalentToIgnoresTopLevelQualifiers) {
+    using namespace type;
+    auto a = signedInteger({ Qualifier::CONST });
+    auto b = signedInteger();
+    EXPECT_THAT(a.equivalentTo(b), IsTrue());
+    EXPECT_THAT(pointer(a).equivalentTo(pointer(b)), IsTrue());
+    EXPECT_THAT(pointer(a).equivalentTo(signedInteger()), IsFalse());
+}
+
+TEST(Type, signedShortFactory) {
+    using namespace type;
+    auto t = signedShort();
+    EXPECT_THAT(t.isPrimitive(), IsTrue());
+    EXPECT_THAT(t.getSize(), Eq(2));
+    EXPECT_THAT(t.to_string(), Eq("short"));
+}
+
 } // namespace
 


### PR DESCRIPTION
## Summary
- Add TypeQuery product policy pack and short primitive helpers.
- Review fixes: array base index stride uses element size; Round-2/3 residuals.

## Stack
Base: `phase0/01-recursive-type` → this PR → `phase0/03-object-abi`

## Test plan
- [ ] TypeQuery unit tests pass
- [ ] No regressions vs phase0/01 tip