### PR TITLE
phase0/03: ObjectAbi shared word/sret policy

### DIFF
--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -1,5 +1,7 @@
 #include "StackMachine.h"
 
+#include "types/ObjectAbi.h"
+
 #include <cassert>
 #include <cctype>
 #include <stdexcept>
@@ -7,8 +9,8 @@
 #include "InstructionSet.h"
 
 namespace {
-const int MACHINE_WORD_SIZE = 8;
-const int STACK_ALIGNMENT = 2 * MACHINE_WORD_SIZE;
+const int MACHINE_WORD_SIZE = type::object_abi::MACHINE_WORD_SIZE;
+const int STACK_ALIGNMENT = type::object_abi::STACK_ALIGNMENT;
 } // namespace
 
 namespace codegen {
@@ -37,11 +39,7 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
     assembly << instructionSet->mov(registers->getStackPointer(), registers->getBasePointer());
 
     auto wordSlots = [](const Value& v) {
-        const int size = v.getSizeInBytes();
-        if (size <= 0) {
-            return 1;
-        }
-        return (size + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
+        return type::object_abi::valueWords(v.getSizeInBytes());
     };
     // Highest exclusive word index among multi-word locals (index is a word offset).
     int nextLocalWord = 0;

--- a/src/semantic_analyzer/ValueScope.cpp
+++ b/src/semantic_analyzer/ValueScope.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "translation_unit/Context.h"
+#include "types/ObjectAbi.h"
 
 const std::string TEMP_PREFIX = "$t";
 
@@ -34,12 +35,7 @@ private:
 namespace semantic_analyzer {
 
 int ValueScope::wordSlotsFor(const type::Type& type) {
-    const int size = type.getSize();
-    if (size <= 0) {
-        return 1;
-    }
-    // Round up to 8-byte stack slots (MACHINE_WORD_SIZE).
-    return (size + 7) / 8;
+    return type::object_abi::valueWords(type.getSize());
 }
 
 bool ValueScope::insertSymbol(std::string name, const type::Type& type, translation_unit::Context context, bool global) {

--- a/src/semantic_analyzer/ValueScope.h
+++ b/src/semantic_analyzer/ValueScope.h
@@ -24,8 +24,9 @@ public:
     std::vector<ValueEntry> getArguments() const;
 
 private:
-    // Next free stack-slot index in machine words (8-byte units). Multi-word
-    // objects (arrays, future aggregates) reserve consecutive slots.
+    // Next free stack-slot index in machine words
+    // (type::object_abi::MACHINE_WORD_SIZE). Multi-word objects (arrays,
+    // future aggregates) reserve consecutive slots.
     int nextLocalWordIndex { 0 };
 
     std::vector<ValueEntry> arguments;

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(types
         TypeQuery.cpp
         TypeQuery.h
         ObjectAbi.h
+        ObjectAbiType.h
         Primitive.h
         Primitive.cpp
         Function.h

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(types
         Type.cpp
         TypeQuery.cpp
         TypeQuery.h
+        ObjectAbi.h
         Primitive.h
         Primitive.cpp
         Function.h

--- a/src/types/ObjectAbi.h
+++ b/src/types/ObjectAbi.h
@@ -1,0 +1,69 @@
+#ifndef TYPES_OBJECTABI_H_
+#define TYPES_OBJECTABI_H_
+
+// System V AMD64 object sizing and aggregate return policy shared by
+// StackMachine (live Values), CodeGeneratingVisitor (call/return quads),
+// and semantic global multi-word .data flattening.
+// Lives under types/ (namespace type::object_abi) so SA and codegen share policy.
+
+#include "Type.h"
+
+namespace type {
+namespace object_abi {
+
+constexpr int MACHINE_WORD_SIZE = 8;
+// SysV requires 16-byte stack alignment at call sites.
+constexpr int STACK_ALIGNMENT = 2 * MACHINE_WORD_SIZE;
+// Aggregates larger than two integer registers return via hidden pointer (sret).
+constexpr int REGISTER_RETURN_MAX_BYTES = 2 * MACHINE_WORD_SIZE;
+constexpr int REGISTER_RETURN_MAX_WORDS = 2;
+
+// Callee-local name for the hidden memory-return pointer (first integer arg).
+constexpr const char* SRET_SYMBOL_NAME = "__sret";
+
+// Words occupied by a live Value / stack slot. At least 1 so empty-ish slots
+// still get a home (matches historical StackMachine::wordCount).
+inline int valueWords(int sizeInBytes) {
+    int words = (sizeInBytes + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
+    return words < 1 ? 1 : words;
+}
+
+// Words in a .data multi-word blob. Zero when size is non-positive (no storage).
+inline int dataWords(int sizeInBytes) {
+    if (sizeInBytes <= 0) {
+        return 0;
+    }
+    return (sizeInBytes + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
+}
+
+// Byte offset of word index (word 0 at the lowest address).
+inline int wordByteOffset(int wordIndex) {
+    return wordIndex * MACHINE_WORD_SIZE;
+}
+
+// Word index containing byteOffset (truncating division).
+inline int wordIndexAt(int byteOffset) {
+    return byteOffset / MACHINE_WORD_SIZE;
+}
+
+// True when an object of this size cannot fit in RAX+RDX (size > 16).
+inline bool needsMemoryReturn(int sizeInBytes) {
+    return sizeInBytes > REGISTER_RETURN_MAX_BYTES;
+}
+
+// Single sret policy: aggregates larger than two integer registers (size > 16).
+// Scalars never sret. Use at Call/StartProcedure emission only.
+inline bool typeNeedsMemoryReturn(const type::Type& t) {
+    return t.isAggregate() && needsMemoryReturn(t.getSize());
+}
+
+// Call/definition agreement: product skips sret for variadic functions (reg
+// save area / first-arg conflict). Both sides must use this.
+inline bool typeNeedsMemoryReturn(const type::Type& t, bool calleeIsVariadic) {
+    return !calleeIsVariadic && typeNeedsMemoryReturn(t);
+}
+
+} // namespace object_abi
+} // namespace type
+
+#endif // TYPES_OBJECTABI_H_

--- a/src/types/ObjectAbi.h
+++ b/src/types/ObjectAbi.h
@@ -1,12 +1,9 @@
 #ifndef TYPES_OBJECTABI_H_
 #define TYPES_OBJECTABI_H_
 
-// System V AMD64 object sizing and aggregate return policy shared by
-// StackMachine (live Values), CodeGeneratingVisitor (call/return quads),
-// and semantic global multi-word .data flattening.
-// Lives under types/ (namespace type::object_abi) so SA and codegen share policy.
-
-#include "Type.h"
+// System V AMD64 word-size helpers for stack/homes/.data packing.
+// Size-only (no Type.h): safe for low-level codegen TUs.
+// Type-aware sret helpers live in ObjectAbiType.h.
 
 namespace type {
 namespace object_abi {
@@ -16,16 +13,18 @@ constexpr int MACHINE_WORD_SIZE = 8;
 constexpr int STACK_ALIGNMENT = 2 * MACHINE_WORD_SIZE;
 // Aggregates larger than two integer registers return via hidden pointer (sret).
 constexpr int REGISTER_RETURN_MAX_BYTES = 2 * MACHINE_WORD_SIZE;
-constexpr int REGISTER_RETURN_MAX_WORDS = 2;
 
 // Callee-local name for the hidden memory-return pointer (first integer arg).
 constexpr const char* SRET_SYMBOL_NAME = "__sret";
 
 // Words occupied by a live Value / stack slot. At least 1 so empty-ish slots
-// still get a home (matches historical StackMachine::wordCount).
+// still get a home (matches historical StackMachine / ValueScope wordSlots).
+// Current consumers: StackMachine, ValueScope (via valueWords).
 inline int valueWords(int sizeInBytes) {
-    int words = (sizeInBytes + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
-    return words < 1 ? 1 : words;
+    if (sizeInBytes <= 0) {
+        return 1;
+    }
+    return (sizeInBytes + MACHINE_WORD_SIZE - 1) / MACHINE_WORD_SIZE;
 }
 
 // Words in a .data multi-word blob. Zero when size is non-positive (no storage).
@@ -49,18 +48,6 @@ inline int wordIndexAt(int byteOffset) {
 // True when an object of this size cannot fit in RAX+RDX (size > 16).
 inline bool needsMemoryReturn(int sizeInBytes) {
     return sizeInBytes > REGISTER_RETURN_MAX_BYTES;
-}
-
-// Single sret policy: aggregates larger than two integer registers (size > 16).
-// Scalars never sret. Use at Call/StartProcedure emission only.
-inline bool typeNeedsMemoryReturn(const type::Type& t) {
-    return t.isAggregate() && needsMemoryReturn(t.getSize());
-}
-
-// Call/definition agreement: product skips sret for variadic functions (reg
-// save area / first-arg conflict). Both sides must use this.
-inline bool typeNeedsMemoryReturn(const type::Type& t, bool calleeIsVariadic) {
-    return !calleeIsVariadic && typeNeedsMemoryReturn(t);
 }
 
 } // namespace object_abi

--- a/src/types/ObjectAbi.h
+++ b/src/types/ObjectAbi.h
@@ -11,7 +11,8 @@ namespace object_abi {
 constexpr int MACHINE_WORD_SIZE = 8;
 // SysV requires 16-byte stack alignment at call sites.
 constexpr int STACK_ALIGNMENT = 2 * MACHINE_WORD_SIZE;
-// Aggregates larger than two integer registers return via hidden pointer (sret).
+// Size threshold used by sret policy (records larger than two integer registers).
+// Type-aware gate is typeNeedsMemoryReturn in ObjectAbiType.h (records only).
 constexpr int REGISTER_RETURN_MAX_BYTES = 2 * MACHINE_WORD_SIZE;
 
 // Callee-local name for the hidden memory-return pointer (first integer arg).

--- a/src/types/ObjectAbi.h
+++ b/src/types/ObjectAbi.h
@@ -11,8 +11,8 @@ namespace object_abi {
 constexpr int MACHINE_WORD_SIZE = 8;
 // SysV requires 16-byte stack alignment at call sites.
 constexpr int STACK_ALIGNMENT = 2 * MACHINE_WORD_SIZE;
-// Size threshold used by sret policy (records larger than two integer registers).
-// Type-aware gate is typeNeedsMemoryReturn in ObjectAbiType.h (records only).
+// Size threshold used by sret policy (larger than two integer registers).
+// Type-aware gate is typeNeedsMemoryReturn in ObjectAbiType.h (complete records only).
 constexpr int REGISTER_RETURN_MAX_BYTES = 2 * MACHINE_WORD_SIZE;
 
 // Callee-local name for the hidden memory-return pointer (first integer arg).

--- a/src/types/ObjectAbiType.h
+++ b/src/types/ObjectAbiType.h
@@ -1,0 +1,27 @@
+#ifndef TYPES_OBJECTABITYPE_H_
+#define TYPES_OBJECTABITYPE_H_
+
+// Type-aware SysV object ABI helpers (requires Type.h).
+// Size/word constants remain in ObjectAbi.h.
+
+#include "ObjectAbi.h"
+#include "Type.h"
+
+namespace type {
+namespace object_abi {
+
+// Single sret policy: complete records larger than two integer registers.
+// Scalars and arrays never sret (C does not return arrays by value).
+inline bool typeNeedsMemoryReturn(const type::Type& t) {
+    return t.isRecord() && needsMemoryReturn(t.getSize());
+}
+
+// Call/definition agreement: product skips sret for variadic functions.
+inline bool typeNeedsMemoryReturn(const type::Type& t, bool calleeIsVariadic) {
+    return !calleeIsVariadic && typeNeedsMemoryReturn(t);
+}
+
+} // namespace object_abi
+} // namespace type
+
+#endif // TYPES_OBJECTABITYPE_H_

--- a/src/types/ObjectAbiType.h
+++ b/src/types/ObjectAbiType.h
@@ -12,8 +12,9 @@ namespace object_abi {
 
 // Single sret policy: complete records larger than two integer registers.
 // Scalars and arrays never sret (C does not return arrays by value).
+// Incomplete records have size 0 and are excluded via isCompleteRecord().
 inline bool typeNeedsMemoryReturn(const type::Type& t) {
-    return t.isRecord() && needsMemoryReturn(t.getSize());
+    return t.isCompleteRecord() && needsMemoryReturn(t.getSize());
 }
 
 // Call/definition agreement: product skips sret for variadic functions.

--- a/src/types/ObjectAbiType.h
+++ b/src/types/ObjectAbiType.h
@@ -10,15 +10,18 @@
 namespace type {
 namespace object_abi {
 
-// Single sret policy: complete records larger than two integer registers.
+// Pure SysV-shaped ABI need: complete records larger than two integer registers.
 // Scalars and arrays never sret (C does not return arrays by value).
 // Incomplete records have size 0 and are excluded via isCompleteRecord().
+// Does not encode product emission policy (see productEmitsMemoryReturn).
 inline bool typeNeedsMemoryReturn(const type::Type& t) {
     return t.isCompleteRecord() && needsMemoryReturn(t.getSize());
 }
 
-// Call/definition agreement: product skips sret for variadic functions.
-inline bool typeNeedsMemoryReturn(const type::Type& t, bool calleeIsVariadic) {
+// Product currently does not emit sret for variadic callees (Phase 3 gap).
+// False means "product will not emit memory-return machinery", not "fits in
+// registers". Prefer typeNeedsMemoryReturn for physical ABI need.
+inline bool productEmitsMemoryReturn(const type::Type& t, bool calleeIsVariadic) {
     return !calleeIsVariadic && typeNeedsMemoryReturn(t);
 }
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(typesTest
     typesTest/TypeTest.cpp
     typesTest/FunctionTest.cpp
     typesTest/TypeQueryTest.cpp
+    typesTest/ObjectAbiTest.cpp
     )
 target_link_libraries(typesTest PRIVATE GTest::gmock_main types)
 add_test(NAME typesTest COMMAND typesTest)

--- a/test/src/typesTest/ObjectAbiTest.cpp
+++ b/test/src/typesTest/ObjectAbiTest.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "types/ObjectAbi.h"
+#include "types/ObjectAbiType.h"
 #include "types/Type.h"
 
 namespace {
@@ -37,23 +38,22 @@ TEST(ObjectAbi, wordIndexHelpers) {
     EXPECT_EQ(wordIndexAt(15), 1);
 }
 
-TEST(ObjectAbi, sretPolicyAggregatesOnly) {
+TEST(ObjectAbi, sretPolicyRecordsOnly) {
     EXPECT_FALSE(needsMemoryReturn(16));
     EXPECT_TRUE(needsMemoryReturn(17));
 
     type::Type i = type::signedInteger();
     EXPECT_FALSE(typeNeedsMemoryReturn(i));
 
-    // 3 x long = 24 bytes aggregate
     type::Type s = type::structure({
             { "a", type::signedLong() },
             { "b", type::signedLong() },
             { "c", type::signedLong() },
     });
-    EXPECT_TRUE(s.isAggregate());
+    EXPECT_TRUE(s.isRecord());
     EXPECT_EQ(s.getSize(), 24);
     EXPECT_TRUE(typeNeedsMemoryReturn(s));
-    EXPECT_FALSE(typeNeedsMemoryReturn(s, true)); // variadic skips sret
+    EXPECT_FALSE(typeNeedsMemoryReturn(s, true));
     EXPECT_TRUE(typeNeedsMemoryReturn(s, false));
 }
 
@@ -64,6 +64,13 @@ TEST(ObjectAbi, smallStructNotSret) {
     });
     EXPECT_EQ(s.getSize(), 16);
     EXPECT_FALSE(typeNeedsMemoryReturn(s));
+}
+
+TEST(ObjectAbi, largeArrayIsNotSret) {
+    // Arrays are aggregates but not memory-returned (C cannot return arrays by value).
+    type::Type arr = type::array(type::signedLong(), 4); // 32 bytes
+    EXPECT_TRUE(arr.isAggregate());
+    EXPECT_FALSE(typeNeedsMemoryReturn(arr));
 }
 
 } // namespace

--- a/test/src/typesTest/ObjectAbiTest.cpp
+++ b/test/src/typesTest/ObjectAbiTest.cpp
@@ -1,0 +1,69 @@
+#include "gtest/gtest.h"
+
+#include "types/ObjectAbi.h"
+#include "types/Type.h"
+
+namespace {
+
+using type::object_abi::dataWords;
+using type::object_abi::needsMemoryReturn;
+using type::object_abi::typeNeedsMemoryReturn;
+using type::object_abi::valueWords;
+using type::object_abi::wordByteOffset;
+using type::object_abi::wordIndexAt;
+
+TEST(ObjectAbi, valueWordsAtLeastOne) {
+    EXPECT_EQ(valueWords(0), 1);
+    EXPECT_EQ(valueWords(-1), 1);
+    EXPECT_EQ(valueWords(1), 1);
+    EXPECT_EQ(valueWords(8), 1);
+    EXPECT_EQ(valueWords(9), 2);
+    EXPECT_EQ(valueWords(16), 2);
+    EXPECT_EQ(valueWords(17), 3);
+}
+
+TEST(ObjectAbi, dataWordsZeroWhenEmpty) {
+    EXPECT_EQ(dataWords(0), 0);
+    EXPECT_EQ(dataWords(-3), 0);
+    EXPECT_EQ(dataWords(8), 1);
+    EXPECT_EQ(dataWords(24), 3);
+}
+
+TEST(ObjectAbi, wordIndexHelpers) {
+    EXPECT_EQ(wordByteOffset(0), 0);
+    EXPECT_EQ(wordByteOffset(2), 16);
+    EXPECT_EQ(wordIndexAt(0), 0);
+    EXPECT_EQ(wordIndexAt(8), 1);
+    EXPECT_EQ(wordIndexAt(15), 1);
+}
+
+TEST(ObjectAbi, sretPolicyAggregatesOnly) {
+    EXPECT_FALSE(needsMemoryReturn(16));
+    EXPECT_TRUE(needsMemoryReturn(17));
+
+    type::Type i = type::signedInteger();
+    EXPECT_FALSE(typeNeedsMemoryReturn(i));
+
+    // 3 x long = 24 bytes aggregate
+    type::Type s = type::structure({
+            { "a", type::signedLong() },
+            { "b", type::signedLong() },
+            { "c", type::signedLong() },
+    });
+    EXPECT_TRUE(s.isAggregate());
+    EXPECT_EQ(s.getSize(), 24);
+    EXPECT_TRUE(typeNeedsMemoryReturn(s));
+    EXPECT_FALSE(typeNeedsMemoryReturn(s, true)); // variadic skips sret
+    EXPECT_TRUE(typeNeedsMemoryReturn(s, false));
+}
+
+TEST(ObjectAbi, smallStructNotSret) {
+    type::Type s = type::structure({
+            { "a", type::signedLong() },
+            { "b", type::signedLong() },
+    });
+    EXPECT_EQ(s.getSize(), 16);
+    EXPECT_FALSE(typeNeedsMemoryReturn(s));
+}
+
+} // namespace

--- a/test/src/typesTest/ObjectAbiTest.cpp
+++ b/test/src/typesTest/ObjectAbiTest.cpp
@@ -75,7 +75,6 @@ TEST(ObjectAbi, largeArrayIsNotSret) {
     EXPECT_FALSE(typeNeedsMemoryReturn(arr));
 }
 
-
 TEST(ObjectAbi, largeUnionNeedsSret) {
     // Union size is max member stride; use a 24-byte arm.
     type::Type u = type::unionType({

--- a/test/src/typesTest/ObjectAbiTest.cpp
+++ b/test/src/typesTest/ObjectAbiTest.cpp
@@ -8,6 +8,7 @@ namespace {
 
 using type::object_abi::dataWords;
 using type::object_abi::needsMemoryReturn;
+using type::object_abi::productEmitsMemoryReturn;
 using type::object_abi::typeNeedsMemoryReturn;
 using type::object_abi::valueWords;
 using type::object_abi::wordByteOffset;
@@ -52,9 +53,10 @@ TEST(ObjectAbi, sretPolicyRecordsOnly) {
     });
     EXPECT_TRUE(s.isRecord());
     EXPECT_EQ(s.getSize(), 24);
+    // Physical ABI need is independent of variadic product policy.
     EXPECT_TRUE(typeNeedsMemoryReturn(s));
-    EXPECT_FALSE(typeNeedsMemoryReturn(s, true));
-    EXPECT_TRUE(typeNeedsMemoryReturn(s, false));
+    EXPECT_FALSE(productEmitsMemoryReturn(s, true));
+    EXPECT_TRUE(productEmitsMemoryReturn(s, false));
 }
 
 TEST(ObjectAbi, smallStructNotSret) {

--- a/test/src/typesTest/ObjectAbiTest.cpp
+++ b/test/src/typesTest/ObjectAbiTest.cpp
@@ -73,4 +73,23 @@ TEST(ObjectAbi, largeArrayIsNotSret) {
     EXPECT_FALSE(typeNeedsMemoryReturn(arr));
 }
 
+
+TEST(ObjectAbi, largeUnionNeedsSret) {
+    // Union size is max member stride; use a 24-byte arm.
+    type::Type u = type::unionType({
+            { "small", type::signedInteger() },
+            { "big", type::array(type::signedLong(), 3) },
+    });
+    EXPECT_TRUE(u.isRecord());
+    EXPECT_EQ(u.getSize(), 24);
+    EXPECT_TRUE(typeNeedsMemoryReturn(u));
+}
+
+TEST(ObjectAbi, incompleteRecordIsNotSret) {
+    type::Type inc = type::incompleteRecord();
+    EXPECT_TRUE(inc.isRecord());
+    EXPECT_FALSE(inc.isCompleteRecord());
+    EXPECT_FALSE(typeNeedsMemoryReturn(inc));
+}
+
 } // namespace


### PR DESCRIPTION
## Summary
- Add shared ObjectAbi word/sret policy for aggregate ABI decisions.
- Review residuals through Round-4 nits.

## Stack
Base: `phase0/02-type-policy` → this PR → `phase0/04-symbols-leaf`

## Test plan
- [ ] ObjectAbi tests pass
- [ ] Stack builds cleanly on this tip