### PR TITLE
phase0/04: house FunctionEntry and LabelEntry in symbols leaf

### DIFF
--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -4,8 +4,8 @@
 #include <cassert>
 #include <stdexcept>
 
-#include "semantic_analyzer/ValueEntry.h"
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/ValueEntry.h"
+#include "symbols/LabelEntry.h"
 #include "types/TypeQuery.h"
 
 #include "quadruples/Assign.h"

--- a/src/semantic_analyzer/CMakeLists.txt
+++ b/src/semantic_analyzer/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_library(semantic_analyzer
-        FunctionEntry.cpp
         InitializerLowering.cpp
-        LabelEntry.cpp
         SemanticAnalysisVisitor.cpp
         SemanticAnalysisVisitor_Calls.cpp
         SemanticAnalysisVisitor_Expressions.cpp

--- a/src/semantic_analyzer/FunctionEntry.h
+++ b/src/semantic_analyzer/FunctionEntry.h
@@ -1,7 +1,7 @@
 #ifndef FUNCTIONENTRY_H_
 #define FUNCTIONENTRY_H_
 
-// FunctionEntry lives in symbols (host-aligned). This header re-exports compat re-export for SA (and residual AST includes until annotation migration); prefer symbols/ for new code.
+// FunctionEntry lives in symbols. Compat re-export for SA; prefer symbols/ for new code.
 #include "symbols/FunctionEntry.h"
 
 namespace semantic_analyzer {

--- a/src/semantic_analyzer/FunctionEntry.h
+++ b/src/semantic_analyzer/FunctionEntry.h
@@ -1,7 +1,7 @@
 #ifndef FUNCTIONENTRY_H_
 #define FUNCTIONENTRY_H_
 
-// FunctionEntry lives in symbols (host-aligned). This header re-exports for SA TUs only; prefer symbols/ for new code.
+// FunctionEntry lives in symbols (host-aligned). This header re-exports compat re-export for SA (and residual AST includes until annotation migration); prefer symbols/ for new code.
 #include "symbols/FunctionEntry.h"
 
 namespace semantic_analyzer {

--- a/src/semantic_analyzer/FunctionEntry.h
+++ b/src/semantic_analyzer/FunctionEntry.h
@@ -1,34 +1,11 @@
 #ifndef FUNCTIONENTRY_H_
 #define FUNCTIONENTRY_H_
 
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "types/Function.h"
-#include "translation_unit/Context.h"
+// FunctionEntry lives in symbols (host-aligned). This header re-exports for SA/AST.
+#include "symbols/FunctionEntry.h"
 
 namespace semantic_analyzer {
-
-class FunctionEntry {
-public:
-    FunctionEntry(std::string name, type::Function type, translation_unit::Context context);
-    virtual ~FunctionEntry();
-
-    std::string getName() const;
-    type::Function getType() const;
-    translation_unit::Context getContext() const;
-
-    std::size_t argumentCount() const;
-    std::vector<type::Type> arguments() const;
-    type::Type returnType() const;
-
-private:
-    std::string name;
-    type::Function type;
-    translation_unit::Context context;
-};
-
-} // namespace semantic_analyzer
+using FunctionEntry = symbols::FunctionEntry;
+}
 
 #endif // FUNCTIONENTRY_H_

--- a/src/semantic_analyzer/FunctionEntry.h
+++ b/src/semantic_analyzer/FunctionEntry.h
@@ -1,7 +1,7 @@
 #ifndef FUNCTIONENTRY_H_
 #define FUNCTIONENTRY_H_
 
-// FunctionEntry lives in symbols (host-aligned). This header re-exports for SA/AST.
+// FunctionEntry lives in symbols (host-aligned). This header re-exports for SA TUs only; prefer symbols/ for new code.
 #include "symbols/FunctionEntry.h"
 
 namespace semantic_analyzer {

--- a/src/semantic_analyzer/LabelEntry.h
+++ b/src/semantic_analyzer/LabelEntry.h
@@ -1,7 +1,7 @@
 #ifndef LABELENTRY_H_
 #define LABELENTRY_H_
 
-// LabelEntry lives in symbols (host-aligned). This header re-exports compat re-export for SA (and residual AST includes until annotation migration); prefer symbols/ for new code.
+// LabelEntry lives in symbols. Compat re-export for SA; prefer symbols/ for new code.
 #include "symbols/LabelEntry.h"
 
 namespace semantic_analyzer {

--- a/src/semantic_analyzer/LabelEntry.h
+++ b/src/semantic_analyzer/LabelEntry.h
@@ -1,20 +1,11 @@
 #ifndef LABELENTRY_H_
 #define LABELENTRY_H_
 
-#include <string>
+// LabelEntry lives in symbols (host-aligned). This header re-exports for SA/AST.
+#include "symbols/LabelEntry.h"
 
 namespace semantic_analyzer {
-
-class LabelEntry {
-public:
-    LabelEntry(std::string name);
-
-    std::string getName() const;
-
-private:
-    std::string name;
-};
-
-} // namespace semantic_analyzer
+using LabelEntry = symbols::LabelEntry;
+}
 
 #endif // LABELENTRY_H_

--- a/src/semantic_analyzer/LabelEntry.h
+++ b/src/semantic_analyzer/LabelEntry.h
@@ -1,7 +1,7 @@
 #ifndef LABELENTRY_H_
 #define LABELENTRY_H_
 
-// LabelEntry lives in symbols (host-aligned). This header re-exports for SA TUs only; prefer symbols/ for new code.
+// LabelEntry lives in symbols (host-aligned). This header re-exports compat re-export for SA (and residual AST includes until annotation migration); prefer symbols/ for new code.
 #include "symbols/LabelEntry.h"
 
 namespace semantic_analyzer {

--- a/src/semantic_analyzer/LabelEntry.h
+++ b/src/semantic_analyzer/LabelEntry.h
@@ -1,7 +1,7 @@
 #ifndef LABELENTRY_H_
 #define LABELENTRY_H_
 
-// LabelEntry lives in symbols (host-aligned). This header re-exports for SA/AST.
+// LabelEntry lives in symbols (host-aligned). This header re-exports for SA TUs only; prefer symbols/ for new code.
 #include "symbols/LabelEntry.h"
 
 namespace semantic_analyzer {

--- a/src/symbols/AnnotationStore.cpp
+++ b/src/symbols/AnnotationStore.cpp
@@ -62,6 +62,38 @@ const ValueEntry* AnnotationStore::result(NodeRef node) const {
     return r;
 }
 
+void AnnotationStore::setLabel(NodeRef node, LabelSlot slot, LabelEntry label) {
+    this->node(node).labels[slot] = std::make_unique<LabelEntry>(std::move(label));
+}
+
+LabelEntry* AnnotationStore::label(NodeRef node, LabelSlot slot) {
+    auto* n = nodeIfAny(node);
+    if (!n) {
+        return nullptr;
+    }
+    auto it = n->labels.find(slot);
+    if (it == n->labels.end()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+const LabelEntry* AnnotationStore::label(NodeRef node, LabelSlot slot) const {
+    auto* n = nodeIfAny(node);
+    if (!n) {
+        return nullptr;
+    }
+    auto it = n->labels.find(slot);
+    if (it == n->labels.end()) {
+        return nullptr;
+    }
+    return it->second.get();
+}
+
+bool AnnotationStore::hasLabel(NodeRef node, LabelSlot slot) const {
+    return label(node, slot) != nullptr;
+}
+
 void AnnotationStore::setAddressPlan(NodeRef node, AddressPlan plan) {
     this->node(node).addressPlan = std::move(plan);
 }

--- a/src/symbols/AnnotationStore.h
+++ b/src/symbols/AnnotationStore.h
@@ -8,6 +8,7 @@
 
 #include "AddressPlan.h"
 #include "AnnotationTypes.h"
+#include "LabelEntry.h"
 #include "ValueEntry.h"
 
 // Side table for SA→CG facts.

--- a/src/symbols/AnnotationStore.h
+++ b/src/symbols/AnnotationStore.h
@@ -7,22 +7,17 @@
 #include <vector>
 
 #include "AddressPlan.h"
+#include "AnnotationTypes.h"
 #include "ValueEntry.h"
 
-// Side table for SA→CG facts (finish-for-git AnnotationStore subset).
-// Result and plans live here. Lvalue slot is reserved; production address temps
-// for array/member/* still use AST node fields until a follow-up migrates them.
+// Side table for SA→CG facts.
+// Result and plans live here. Lvalue/labels: API ready; production migration in Phase 0.5.
 
 namespace symbols {
 
-enum class ValueSlot {
-    Result,
-    // Reserved for a future migration of array/member/* address temps off the AST.
-    Lvalue,
-};
-
 struct NodeAnnotations {
     std::unordered_map<ValueSlot, std::unique_ptr<ValueEntry>> values;
+    std::unordered_map<LabelSlot, std::unique_ptr<LabelEntry>> labels;
     std::optional<AddressPlan> addressPlan;
     std::optional<CallPlan> callPlan;
     std::vector<StructFieldInit> fieldInits;
@@ -43,12 +38,17 @@ public:
     const ValueEntry* result(NodeRef node) const;
     bool hasResult(NodeRef node) const { return hasValue(node, ValueSlot::Result); }
 
-    // Store Lvalue API is for tests / future migration; SA still writes node fields.
+    // Lvalue API ready; SA still writes node fields until Phase 0.5 migration.
     void setLvalue(NodeRef node, ValueEntry value) {
         setValue(node, ValueSlot::Lvalue, std::move(value));
     }
     ValueEntry* lvalue(NodeRef node) { return value(node, ValueSlot::Lvalue); }
     const ValueEntry* lvalue(NodeRef node) const { return value(node, ValueSlot::Lvalue); }
+
+    void setLabel(NodeRef node, LabelSlot slot, LabelEntry label);
+    LabelEntry* label(NodeRef node, LabelSlot slot);
+    const LabelEntry* label(NodeRef node, LabelSlot slot) const;
+    bool hasLabel(NodeRef node, LabelSlot slot) const;
 
     void setAddressPlan(NodeRef node, AddressPlan plan);
     const AddressPlan* addressPlan(NodeRef node) const;

--- a/src/symbols/AnnotationTypes.h
+++ b/src/symbols/AnnotationTypes.h
@@ -1,0 +1,53 @@
+#ifndef SYMBOLS_ANNOTATIONTYPES_H_
+#define SYMBOLS_ANNOTATIONTYPES_H_
+
+// Shared annotation payloads used by AnnotationStore (SA→CG product).
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "FunctionEntry.h"
+#include "LabelEntry.h"
+#include "ValueEntry.h"
+
+namespace symbols {
+
+enum class ValueSlot {
+    Result,
+    // Sole "address of this expression" temp (members, arrays, …) - migration target.
+    Lvalue,
+    PreOperation,
+    Holder,
+    Object,
+    CaseTemp,
+};
+
+enum class LabelSlot {
+    Primary,
+    Target,
+    Falsy,
+    Truthy,
+    Exit,
+    LoopEntry,
+    LoopContinue,
+    LoopExit,
+};
+
+enum class StringSlot {
+    ArrayDecaySource,
+    ConversionTarget,
+};
+
+// Per-function frame: written by SA, read by CG StartProcedure (Phase 0.5+).
+struct FunctionFrame {
+    std::unique_ptr<FunctionEntry> symbol;
+    std::map<std::string, ValueEntry> locals;
+    std::vector<ValueEntry> arguments;
+    std::vector<std::string> parameterNames;
+};
+
+} // namespace symbols
+
+#endif // SYMBOLS_ANNOTATIONTYPES_H_

--- a/src/symbols/AnnotationTypes.h
+++ b/src/symbols/AnnotationTypes.h
@@ -1,27 +1,16 @@
 #ifndef SYMBOLS_ANNOTATIONTYPES_H_
 #define SYMBOLS_ANNOTATIONTYPES_H_
 
-// Shared annotation payloads used by AnnotationStore (SA→CG product).
-
-#include <map>
-#include <memory>
-#include <string>
-#include <vector>
-
-#include "FunctionEntry.h"
-#include "LabelEntry.h"
-#include "ValueEntry.h"
+// Shared annotation slot types used by AnnotationStore (SA→CG product).
+// Keep this header free of FunctionEntry / frame types so store TUs stay light.
+// FunctionFrame and extra slots land with the migration that uses them.
 
 namespace symbols {
 
 enum class ValueSlot {
     Result,
-    // Sole "address of this expression" temp (members, arrays, …) - migration target.
+    // Address temp for this expression (members, arrays, *).
     Lvalue,
-    PreOperation,
-    Holder,
-    Object,
-    CaseTemp,
 };
 
 enum class LabelSlot {
@@ -33,19 +22,6 @@ enum class LabelSlot {
     LoopEntry,
     LoopContinue,
     LoopExit,
-};
-
-enum class StringSlot {
-    ArrayDecaySource,
-    ConversionTarget,
-};
-
-// Per-function frame: written by SA, read by CG StartProcedure (Phase 0.5+).
-struct FunctionFrame {
-    std::unique_ptr<FunctionEntry> symbol;
-    std::map<std::string, ValueEntry> locals;
-    std::vector<ValueEntry> arguments;
-    std::vector<std::string> parameterNames;
 };
 
 } // namespace symbols

--- a/src/symbols/CMakeLists.txt
+++ b/src/symbols/CMakeLists.txt
@@ -1,7 +1,12 @@
 add_library(symbols
         AnnotationStore.cpp
         AnnotationStore.h
+        AnnotationTypes.h
         AddressPlan.h
+        FunctionEntry.cpp
+        FunctionEntry.h
+        LabelEntry.cpp
+        LabelEntry.h
         ValueEntry.cpp
         ValueEntry.h
         )

--- a/src/symbols/FunctionEntry.cpp
+++ b/src/symbols/FunctionEntry.cpp
@@ -26,7 +26,7 @@ type::Function FunctionEntry::getType() const {
 }
 
 std::size_t FunctionEntry::argumentCount() const {
-    return arguments().size();
+    return type.argumentCount();
 }
 
 std::vector<type::Type> FunctionEntry::arguments() const {

--- a/src/symbols/FunctionEntry.cpp
+++ b/src/symbols/FunctionEntry.cpp
@@ -4,13 +4,10 @@
 namespace symbols {
 
 FunctionEntry::FunctionEntry(std::string name, type::Function type, translation_unit::Context context) :
-        name { name },
-        type { type },
-        context { context }
+        name { std::move(name) },
+        type { std::move(type) },
+        context { std::move(context) }
 {
-}
-
-FunctionEntry::~FunctionEntry() {
 }
 
 translation_unit::Context FunctionEntry::getContext() const {

--- a/src/symbols/FunctionEntry.cpp
+++ b/src/symbols/FunctionEntry.cpp
@@ -1,7 +1,7 @@
 #include "FunctionEntry.h"
 #include "types/Type.h"
 
-namespace semantic_analyzer {
+namespace symbols {
 
 FunctionEntry::FunctionEntry(std::string name, type::Function type, translation_unit::Context context) :
         name { name },
@@ -37,5 +37,4 @@ type::Type FunctionEntry::returnType() const {
     return type.getReturnType();
 }
 
-} // namespace semantic_analyzer
-
+} // namespace symbols

--- a/src/symbols/FunctionEntry.h
+++ b/src/symbols/FunctionEntry.h
@@ -12,7 +12,7 @@ namespace symbols {
 class FunctionEntry {
 public:
     FunctionEntry(std::string name, type::Function type, translation_unit::Context context);
-    virtual ~FunctionEntry();
+    ~FunctionEntry();
 
     std::string getName() const;
     type::Function getType() const;

--- a/src/symbols/FunctionEntry.h
+++ b/src/symbols/FunctionEntry.h
@@ -13,7 +13,6 @@ namespace symbols {
 class FunctionEntry {
 public:
     FunctionEntry(std::string name, type::Function type, translation_unit::Context context);
-    ~FunctionEntry();
 
     std::string getName() const;
     type::Function getType() const;

--- a/src/symbols/FunctionEntry.h
+++ b/src/symbols/FunctionEntry.h
@@ -1,0 +1,33 @@
+#ifndef SYMBOLS_FUNCTIONENTRY_H_
+#define SYMBOLS_FUNCTIONENTRY_H_
+
+#include <string>
+#include <vector>
+
+#include "translation_unit/Context.h"
+#include "types/Function.h"
+
+namespace symbols {
+
+class FunctionEntry {
+public:
+    FunctionEntry(std::string name, type::Function type, translation_unit::Context context);
+    virtual ~FunctionEntry();
+
+    std::string getName() const;
+    type::Function getType() const;
+    translation_unit::Context getContext() const;
+
+    std::size_t argumentCount() const;
+    std::vector<type::Type> arguments() const;
+    type::Type returnType() const;
+
+private:
+    std::string name;
+    type::Function type;
+    translation_unit::Context context;
+};
+
+} // namespace symbols
+
+#endif // SYMBOLS_FUNCTIONENTRY_H_

--- a/src/symbols/FunctionEntry.h
+++ b/src/symbols/FunctionEntry.h
@@ -6,6 +6,7 @@
 
 #include "translation_unit/Context.h"
 #include "types/Function.h"
+#include "types/Type.h"
 
 namespace symbols {
 

--- a/src/symbols/LabelEntry.cpp
+++ b/src/symbols/LabelEntry.cpp
@@ -1,6 +1,6 @@
 #include "LabelEntry.h"
 
-namespace semantic_analyzer {
+namespace symbols {
 
 LabelEntry::LabelEntry(std::string name) :
         name { name } {
@@ -10,5 +10,4 @@ std::string LabelEntry::getName() const {
     return name;
 }
 
-} // namespace semantic_analyzer
-
+} // namespace symbols

--- a/src/symbols/LabelEntry.h
+++ b/src/symbols/LabelEntry.h
@@ -1,0 +1,20 @@
+#ifndef SYMBOLS_LABELENTRY_H_
+#define SYMBOLS_LABELENTRY_H_
+
+#include <string>
+
+namespace symbols {
+
+class LabelEntry {
+public:
+    LabelEntry(std::string name);
+
+    std::string getName() const;
+
+private:
+    std::string name;
+};
+
+} // namespace symbols
+
+#endif // SYMBOLS_LABELENTRY_H_

--- a/src/types/Function.cpp
+++ b/src/types/Function.cpp
@@ -46,6 +46,10 @@ std::vector<Type> Function::getArguments() const {
     return args;
 }
 
+std::size_t Function::argumentCount() const {
+    return arguments.size();
+}
+
 bool Function::isVariadic() const {
     return variadic;
 }

--- a/src/types/Function.h
+++ b/src/types/Function.h
@@ -19,6 +19,7 @@ public:
 
     Type getReturnType() const;
     std::vector<Type> getArguments() const;
+    std::size_t argumentCount() const;
     bool isVariadic() const;
 
     std::string to_string() const;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -82,6 +82,8 @@ add_test(NAME typesTest COMMAND typesTest)
 
 add_executable(symbolsTest
     symbolsTest/AnnotationStoreTest.cpp
+    symbolsTest/FunctionEntryTest.cpp
+    symbolsTest/LabelEntryTest.cpp
 )
 target_link_libraries(symbolsTest PRIVATE GTest::gmock_main symbols)
 add_test(NAME symbolsTest COMMAND symbolsTest)

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -131,10 +131,12 @@ TEST(AnnotationStore, clearEmptiesAll) {
     store.setCallPlan(&node, symbols::DirectCallPlan { "f" });
     store.setResult(&node, symbols::ValueEntry("r", type::signedInteger(), true, ctx, 0));
     store.setLvalue(&node, symbols::ValueEntry("lv", type::pointer(type::signedInteger()), true, ctx, 1));
+    store.setLabel(&node, symbols::LabelSlot::Exit, symbols::LabelEntry { "Lx" });
     store.clear();
     EXPECT_EQ(store.callPlan(&node), nullptr);
     EXPECT_FALSE(store.hasResult(&node));
     EXPECT_EQ(store.lvalue(&node), nullptr);
+    EXPECT_FALSE(store.hasLabel(&node, symbols::LabelSlot::Exit));
 }
 
 TEST(AnnotationStore, indexPlanVariant) {
@@ -163,6 +165,12 @@ TEST(AnnotationStore, labelSlots) {
     EXPECT_EQ(store.label(&node, symbols::LabelSlot::Falsy)->getName(), "Lf");
     EXPECT_EQ(store.label(&node, symbols::LabelSlot::Exit)->getName(), "Le");
     EXPECT_FALSE(store.hasLabel(&node, symbols::LabelSlot::Truthy));
+    // Overwrite same slot.
+    store.setLabel(&node, symbols::LabelSlot::Falsy, symbols::LabelEntry { "Lf2" });
+    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Falsy)->getName(), "Lf2");
+    // Const access.
+    const symbols::AnnotationStore& cstore = store;
+    EXPECT_EQ(cstore.label(&node, symbols::LabelSlot::Exit)->getName(), "Le");
 }
 
 } // namespace

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 #include "symbols/ValueEntry.h"
 #include "types/Type.h"
 #include "translation_unit/Context.h"
@@ -151,6 +152,17 @@ TEST(AnnotationStore, indexPlanVariant) {
     EXPECT_EQ(i->elementSize, 4);
     EXPECT_EQ(i->baseMode, symbols::AddressBaseMode::LeaObject);
     EXPECT_TRUE(symbols::addressBaseUsesLea(i->baseMode));
+}
+
+TEST(AnnotationStore, labelSlots) {
+    symbols::AnnotationStore store;
+    int node = 0;
+    store.setLabel(&node, symbols::LabelSlot::Falsy, symbols::LabelEntry { "Lf" });
+    store.setLabel(&node, symbols::LabelSlot::Exit, symbols::LabelEntry { "Le" });
+    ASSERT_TRUE(store.hasLabel(&node, symbols::LabelSlot::Falsy));
+    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Falsy)->getName(), "Lf");
+    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Exit)->getName(), "Le");
+    EXPECT_FALSE(store.hasLabel(&node, symbols::LabelSlot::Truthy));
 }
 
 } // namespace

--- a/test/src/symbolsTest/FunctionEntryTest.cpp
+++ b/test/src/symbolsTest/FunctionEntryTest.cpp
@@ -12,6 +12,8 @@ TEST(FunctionEntry, storesNameTypeArgumentsAndContext) {
     symbols::FunctionEntry entry { "add", fnType.getFunction(), ctx };
     EXPECT_EQ(entry.getName(), "add");
     EXPECT_EQ(entry.argumentCount(), 1u);
+    EXPECT_EQ(entry.argumentCount(), entry.arguments().size());
+    EXPECT_EQ(entry.argumentCount(), entry.getType().argumentCount());
     EXPECT_EQ(entry.getContext().getSourceName(), "t.c");
     EXPECT_EQ(entry.getContext().getOffset(), 7u);
     EXPECT_TRUE(entry.returnType().isPrimitive());
@@ -21,6 +23,22 @@ TEST(FunctionEntry, storesNameTypeArgumentsAndContext) {
     EXPECT_TRUE(args[0].isPrimitive());
     EXPECT_EQ(args[0].getSize(), 4);
     EXPECT_TRUE(entry.getType().getReturnType().isPrimitive());
+}
+
+TEST(FunctionEntry, zeroAndMultiArgArgumentCount) {
+    translation_unit::Context ctx { "t.c", 1 };
+    type::Type zero = type::function(type::voidType(), {});
+    symbols::FunctionEntry noArgs { "f0", zero.getFunction(), ctx };
+    EXPECT_EQ(noArgs.argumentCount(), 0u);
+    EXPECT_EQ(noArgs.argumentCount(), noArgs.arguments().size());
+    EXPECT_EQ(noArgs.argumentCount(), noArgs.getType().argumentCount());
+
+    type::Type multi = type::function(type::signedInteger(),
+            { type::signedInteger(), type::signedLong(), type::signedCharacter() });
+    symbols::FunctionEntry three { "f3", multi.getFunction(), ctx };
+    EXPECT_EQ(three.argumentCount(), 3u);
+    EXPECT_EQ(three.argumentCount(), three.arguments().size());
+    EXPECT_EQ(three.argumentCount(), three.getType().argumentCount());
 }
 
 } // namespace

--- a/test/src/symbolsTest/FunctionEntryTest.cpp
+++ b/test/src/symbolsTest/FunctionEntryTest.cpp
@@ -6,14 +6,21 @@
 
 namespace {
 
-TEST(FunctionEntry, storesNameTypeAndArguments) {
-    translation_unit::Context ctx { "t.c", 1 };
+TEST(FunctionEntry, storesNameTypeArgumentsAndContext) {
+    translation_unit::Context ctx { "t.c", 7 };
     type::Type fnType = type::function(type::signedInteger(), { type::signedInteger() });
     symbols::FunctionEntry entry { "add", fnType.getFunction(), ctx };
     EXPECT_EQ(entry.getName(), "add");
     EXPECT_EQ(entry.argumentCount(), 1u);
+    EXPECT_EQ(entry.getContext().getSourceName(), "t.c");
+    EXPECT_EQ(entry.getContext().getOffset(), 7u);
     EXPECT_TRUE(entry.returnType().isPrimitive());
     EXPECT_EQ(entry.returnType().getSize(), 4);
+    auto args = entry.arguments();
+    ASSERT_EQ(args.size(), 1u);
+    EXPECT_TRUE(args[0].isPrimitive());
+    EXPECT_EQ(args[0].getSize(), 4);
+    EXPECT_TRUE(entry.getType().getReturnType().isPrimitive());
 }
 
 } // namespace

--- a/test/src/symbolsTest/FunctionEntryTest.cpp
+++ b/test/src/symbolsTest/FunctionEntryTest.cpp
@@ -1,0 +1,19 @@
+#include "gtest/gtest.h"
+
+#include "symbols/FunctionEntry.h"
+#include "types/Type.h"
+#include "translation_unit/Context.h"
+
+namespace {
+
+TEST(FunctionEntry, storesNameTypeAndArguments) {
+    translation_unit::Context ctx { "t.c", 1 };
+    type::Type fnType = type::function(type::signedInteger(), { type::signedInteger() });
+    symbols::FunctionEntry entry { "add", fnType.getFunction(), ctx };
+    EXPECT_EQ(entry.getName(), "add");
+    EXPECT_EQ(entry.argumentCount(), 1u);
+    EXPECT_TRUE(entry.returnType().isPrimitive());
+    EXPECT_EQ(entry.returnType().getSize(), 4);
+}
+
+} // namespace

--- a/test/src/symbolsTest/LabelEntryTest.cpp
+++ b/test/src/symbolsTest/LabelEntryTest.cpp
@@ -1,0 +1,24 @@
+#include "gtest/gtest.h"
+
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
+
+namespace {
+
+TEST(LabelEntry, name) {
+    symbols::LabelEntry lab { "L1" };
+    EXPECT_EQ(lab.getName(), "L1");
+}
+
+TEST(AnnotationStore, labelSlots) {
+    symbols::AnnotationStore store;
+    int node = 0;
+    store.setLabel(&node, symbols::LabelSlot::Falsy, symbols::LabelEntry { "Lf" });
+    store.setLabel(&node, symbols::LabelSlot::Exit, symbols::LabelEntry { "Le" });
+    ASSERT_TRUE(store.hasLabel(&node, symbols::LabelSlot::Falsy));
+    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Falsy)->getName(), "Lf");
+    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Exit)->getName(), "Le");
+    EXPECT_FALSE(store.hasLabel(&node, symbols::LabelSlot::Truthy));
+}
+
+} // namespace

--- a/test/src/symbolsTest/LabelEntryTest.cpp
+++ b/test/src/symbolsTest/LabelEntryTest.cpp
@@ -1,6 +1,5 @@
 #include "gtest/gtest.h"
 
-#include "symbols/AnnotationStore.h"
 #include "symbols/LabelEntry.h"
 
 namespace {
@@ -8,17 +7,6 @@ namespace {
 TEST(LabelEntry, name) {
     symbols::LabelEntry lab { "L1" };
     EXPECT_EQ(lab.getName(), "L1");
-}
-
-TEST(AnnotationStore, labelSlots) {
-    symbols::AnnotationStore store;
-    int node = 0;
-    store.setLabel(&node, symbols::LabelSlot::Falsy, symbols::LabelEntry { "Lf" });
-    store.setLabel(&node, symbols::LabelSlot::Exit, symbols::LabelEntry { "Le" });
-    ASSERT_TRUE(store.hasLabel(&node, symbols::LabelSlot::Falsy));
-    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Falsy)->getName(), "Lf");
-    EXPECT_EQ(store.label(&node, symbols::LabelSlot::Exit)->getName(), "Le");
-    EXPECT_FALSE(store.hasLabel(&node, symbols::LabelSlot::Truthy));
 }
 
 } // namespace

--- a/test/src/typesTest/TypeTest.cpp
+++ b/test/src/typesTest/TypeTest.cpp
@@ -163,6 +163,7 @@ TEST(Type, noArgFunctionReturningVoid) {
     EXPECT_THAT(t.isFunction(), IsTrue());
     EXPECT_THAT(t.getFunction().getReturnType().isVoid(), IsTrue());
     EXPECT_THAT(t.getFunction().getArguments().size(), Eq(0));
+    EXPECT_THAT(t.getFunction().argumentCount(), Eq(0u));
     EXPECT_THAT(t.isConst(), IsFalse());
     EXPECT_THAT(t.isVolatile(), IsFalse());
 
@@ -178,6 +179,7 @@ TEST(Type, noArgFunctionReturningInt) {
     EXPECT_THAT(t.getFunction().getReturnType().isPrimitive(), IsTrue());
     EXPECT_THAT(t.getFunction().getReturnType().getPrimitive().getSize(), Eq(4));
     EXPECT_THAT(t.getFunction().getArguments().size(), Eq(0));
+    EXPECT_THAT(t.getFunction().argumentCount(), Eq(0u));
     EXPECT_THAT(t.isConst(), IsFalse());
     EXPECT_THAT(t.isVolatile(), IsFalse());
 
@@ -193,6 +195,7 @@ TEST(Type, functionReturningIntAcceptingInt) {
     EXPECT_THAT(t.getFunction().getReturnType().isPrimitive(), IsTrue());
     EXPECT_THAT(t.getFunction().getReturnType().getPrimitive().getSize(), Eq(4));
     EXPECT_THAT(t.getFunction().getArguments().size(), Eq(1));
+    EXPECT_THAT(t.getFunction().argumentCount(), Eq(1u));
     EXPECT_THAT(t.getFunction().getArguments().at(0).isPrimitive(), IsTrue());
     EXPECT_THAT(t.getFunction().getArguments().at(0).getSize(), Eq(4));
     EXPECT_THAT(t.isConst(), IsFalse());
@@ -210,6 +213,7 @@ TEST(Type, functionReturningIntAcceptingIntAndPointerToPointerToUnsignedLong) {
     EXPECT_THAT(t.getFunction().getReturnType().isPrimitive(), IsTrue());
     EXPECT_THAT(t.getFunction().getReturnType().getPrimitive().getSize(), Eq(4));
     EXPECT_THAT(t.getFunction().getArguments().size(), Eq(2));
+    EXPECT_THAT(t.getFunction().argumentCount(), Eq(2u));
 
     EXPECT_THAT(t.to_string(), Eq("int(int, unsigned long**)"));
 }


### PR DESCRIPTION
## Summary
- Move FunctionEntry and LabelEntry into the symbols leaf package.
- Clean SA re-export comments; Round-2/3 review residuals.

## Stack
Base: `phase0/03-object-abi` → this PR → `phase0/05-annotation-migration`

## Test plan
- [ ] Symbols/SA tests pass
- [ ] No reverse package deps introduced