### PR TITLE
phase0/05: store-backed lvalues/labels; drop ast→SA link

### DIFF
--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -15,12 +15,4 @@ void ArrayAccess::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void ArrayAccess::setElementSize(int sizeInBytes) {
-    elementSize = sizeInBytes;
-}
-
-int ArrayAccess::getElementSize() const {
-    return elementSize;
-}
-
 } // namespace ast

--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -1,12 +1,13 @@
 #include "ArrayAccess.h"
 
 #include "AbstractSyntaxTreeVisitor.h"
-#include "Operator.h"
 
 namespace ast {
 
 ArrayAccess::ArrayAccess(std::unique_ptr<Expression> postfixExpression, std::unique_ptr<Expression> subscriptExpression) :
-        DoubleOperandExpression(std::move(postfixExpression), std::move(subscriptExpression), std::unique_ptr<Operator> { new Operator("[]") }) {
+        DoubleOperandExpression(std::move(postfixExpression), std::move(subscriptExpression),
+                std::make_unique<Operator>("[]"))
+{
     // Element access is always an lvalue when the base is addressable (array or pointer).
     lval = true;
 }
@@ -15,17 +16,16 @@ void ArrayAccess::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void ArrayAccess::setLvalue(symbols::ValueEntry lvalue) {
-    this->lvalue = std::make_unique<symbols::ValueEntry>(lvalue);
+void ArrayAccess::setLvalue(symbols::AnnotationStore& store, symbols::ValueEntry lvalue) {
+    setLvalueSymbol(store, std::move(lvalue));
 }
 
-symbols::ValueEntry* ArrayAccess::getLvalue() const {
-    return lvalue.get();
+symbols::ValueEntry* ArrayAccess::getLvalue(symbols::AnnotationStore& store) const {
+    return getLvalueSymbol(store);
 }
 
 symbols::ValueEntry* ArrayAccess::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    (void)store;
-    return getLvalue();
+    return store.lvalue(this);
 }
 
 void ArrayAccess::setElementSize(int sizeInBytes) {

--- a/src/ast/ArrayAccess.cpp
+++ b/src/ast/ArrayAccess.cpp
@@ -8,24 +8,11 @@ ArrayAccess::ArrayAccess(std::unique_ptr<Expression> postfixExpression, std::uni
         DoubleOperandExpression(std::move(postfixExpression), std::move(subscriptExpression),
                 std::make_unique<Operator>("[]"))
 {
-    // Element access is always an lvalue when the base is addressable (array or pointer).
     lval = true;
 }
 
 void ArrayAccess::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
-}
-
-void ArrayAccess::setLvalue(symbols::AnnotationStore& store, symbols::ValueEntry lvalue) {
-    setLvalueSymbol(store, std::move(lvalue));
-}
-
-symbols::ValueEntry* ArrayAccess::getLvalue(symbols::AnnotationStore& store) const {
-    return getLvalueSymbol(store);
-}
-
-symbols::ValueEntry* ArrayAccess::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    return store.lvalue(this);
 }
 
 void ArrayAccess::setElementSize(int sizeInBytes) {

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -13,8 +13,9 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setLvalue(symbols::ValueEntry lvalue);
-    symbols::ValueEntry* getLvalue() const;
+    // Lvalue address temp lives on AnnotationStore (ValueSlot::Lvalue).
+    void setLvalue(symbols::AnnotationStore& store, symbols::ValueEntry lvalue);
+    symbols::ValueEntry* getLvalue(symbols::AnnotationStore& store) const;
     symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
     void setElementSize(int sizeInBytes);
@@ -22,7 +23,6 @@ public:
     // Base LeaObject vs PointerValue is symbols::IndexPlan::baseMode on the store.
 
 private:
-    std::unique_ptr<symbols::ValueEntry> lvalue { nullptr };
     int elementSize { 0 };
 };
 

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -13,13 +13,10 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setElementSize(int sizeInBytes);
-    int getElementSize() const;
     // Lvalue address temp: Expression::setLvalueSymbol / getLvalueSymbol (store).
-    // Base LeaObject vs PointerValue is symbols::IndexPlan::baseMode on the store.
+    // Element size and base mode: symbols::IndexPlan on the store.
 
 private:
-    int elementSize { 0 };
 };
 
 } // namespace ast

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -16,7 +16,6 @@ public:
     // Lvalue address temp: Expression::setLvalueSymbol / getLvalueSymbol (store).
     // Element size and base mode: symbols::IndexPlan on the store.
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/ArrayAccess.h
+++ b/src/ast/ArrayAccess.h
@@ -13,13 +13,9 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    // Lvalue address temp lives on AnnotationStore (ValueSlot::Lvalue).
-    void setLvalue(symbols::AnnotationStore& store, symbols::ValueEntry lvalue);
-    symbols::ValueEntry* getLvalue(symbols::AnnotationStore& store) const;
-    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
-
     void setElementSize(int sizeInBytes);
     int getElementSize() const;
+    // Lvalue address temp: Expression::setLvalueSymbol / getLvalueSymbol (store).
     // Base LeaObject vs PointerValue is symbols::IndexPlan::baseMode on the store.
 
 private:

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -61,7 +61,6 @@ add_library(ast
         TypeCast.cpp
         TypeSpecifier.cpp
         UnaryExpression.cpp
-        VerboseSyntaxTreeBuilder.cpp
         WhileLoopHeader.cpp
         AbstractSyntaxTree.h
         AbstractSyntaxTreeBuilder.h
@@ -126,11 +125,8 @@ add_library(ast
         TypeCast.h
         TypeSpecifier.h
         UnaryExpression.h
-        VerboseSyntaxTreeBuilder.h
         WhileLoopHeader.h
-        LoggingSyntaxTreeVisitor.h
-        LoggingSyntaxTreeVisitor.cpp
     )
 
 trans_target_defaults(ast)
-target_link_libraries(ast PUBLIC parser types semantic_analyzer symbols)
+target_link_libraries(ast PUBLIC parser types symbols)

--- a/src/ast/CaseLabel.cpp
+++ b/src/ast/CaseLabel.cpp
@@ -13,12 +13,12 @@ void CaseLabel::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void CaseLabel::setLabel(semantic_analyzer::LabelEntry label) {
-    this->label = std::make_unique<semantic_analyzer::LabelEntry>(label);
+void CaseLabel::setLabel(symbols::AnnotationStore& store, symbols::LabelEntry label) {
+    store.setLabel(this, symbols::LabelSlot::Primary, std::move(label));
 }
 
-semantic_analyzer::LabelEntry* CaseLabel::getLabel() const {
-    return label.get();
+symbols::LabelEntry* CaseLabel::getLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Primary);
 }
 
 void CaseLabel::setCaseValue(long value) {

--- a/src/ast/CaseLabel.h
+++ b/src/ast/CaseLabel.h
@@ -26,7 +26,8 @@ public:
     const std::unique_ptr<Expression> caseExpression;
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
-private:    long caseValue { 0 };
+private:
+    long caseValue { 0 };
 };
 
 } // namespace ast

--- a/src/ast/CaseLabel.h
+++ b/src/ast/CaseLabel.h
@@ -3,7 +3,8 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/Expression.h"
 
@@ -16,8 +17,8 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setLabel(semantic_analyzer::LabelEntry label);
-    semantic_analyzer::LabelEntry* getLabel() const;
+    void setLabel(symbols::AnnotationStore& store, symbols::LabelEntry label);
+    symbols::LabelEntry* getLabel(symbols::AnnotationStore& store) const;
 
     void setCaseValue(long value);
     long getCaseValue() const;
@@ -25,9 +26,7 @@ public:
     const std::unique_ptr<Expression> caseExpression;
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
-private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> label { nullptr };
-    long caseValue { 0 };
+private:    long caseValue { 0 };
 };
 
 } // namespace ast

--- a/src/ast/ComparisonExpression.cpp
+++ b/src/ast/ComparisonExpression.cpp
@@ -19,20 +19,20 @@ void ComparisonExpression::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-semantic_analyzer::LabelEntry* ComparisonExpression::getFalsyLabel() const {
-    return falsyLabel.get();
+symbols::LabelEntry* ComparisonExpression::getFalsyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Falsy);
 }
 
-void ComparisonExpression::setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel) {
-    this->falsyLabel = std::unique_ptr<semantic_analyzer::LabelEntry> { new semantic_analyzer::LabelEntry { falsyLabel } };
+void ComparisonExpression::setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel) {
+    store.setLabel(this, symbols::LabelSlot::Falsy, std::move(falsyLabel));
 }
 
-semantic_analyzer::LabelEntry* ComparisonExpression::getTruthyLabel() const {
-    return truthyLabel.get();
+symbols::LabelEntry* ComparisonExpression::getTruthyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Truthy);
 }
 
-void ComparisonExpression::setTruthyLabel(semantic_analyzer::LabelEntry truthyLabel) {
-    this->truthyLabel = std::unique_ptr<semantic_analyzer::LabelEntry> { new semantic_analyzer::LabelEntry { truthyLabel } };
+void ComparisonExpression::setTruthyLabel(symbols::AnnotationStore& store, symbols::LabelEntry truthyLabel) {
+    store.setLabel(this, symbols::LabelSlot::Truthy, std::move(truthyLabel));
 }
 
 } // namespace ast

--- a/src/ast/ComparisonExpression.h
+++ b/src/ast/ComparisonExpression.h
@@ -3,7 +3,8 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 #include "DoubleOperandExpression.h"
 
 namespace ast {
@@ -14,14 +15,12 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    semantic_analyzer::LabelEntry* getFalsyLabel() const;
-    void setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel);
-    semantic_analyzer::LabelEntry* getTruthyLabel() const;
-    void setTruthyLabel(semantic_analyzer::LabelEntry truthyLabel);
+    symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
+    void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel);
+    symbols::LabelEntry* getTruthyLabel(symbols::AnnotationStore& store) const;
+    void setTruthyLabel(symbols::AnnotationStore& store, symbols::LabelEntry truthyLabel);
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> truthyLabel { nullptr };
-    std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/ComparisonExpression.h
+++ b/src/ast/ComparisonExpression.h
@@ -20,7 +20,6 @@ public:
     symbols::LabelEntry* getTruthyLabel(symbols::AnnotationStore& store) const;
     void setTruthyLabel(symbols::AnnotationStore& store, symbols::LabelEntry truthyLabel);
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/ConditionalExpression.cpp
+++ b/src/ast/ConditionalExpression.cpp
@@ -44,20 +44,20 @@ translation_unit::Context ConditionalExpression::getContext() const {
     return condition->getContext();
 }
 
-void ConditionalExpression::setFalsyLabel(semantic_analyzer::LabelEntry label) {
-    falsyLabel = std::make_unique<semantic_analyzer::LabelEntry>(label);
+void ConditionalExpression::setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry label) {
+    store.setLabel(this, symbols::LabelSlot::Falsy, std::move(label));
 }
 
-semantic_analyzer::LabelEntry* ConditionalExpression::getFalsyLabel() const {
-    return falsyLabel.get();
+symbols::LabelEntry* ConditionalExpression::getFalsyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Falsy);
 }
 
-void ConditionalExpression::setExitLabel(semantic_analyzer::LabelEntry label) {
-    exitLabel = std::make_unique<semantic_analyzer::LabelEntry>(label);
+void ConditionalExpression::setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry label) {
+    store.setLabel(this, symbols::LabelSlot::Exit, std::move(label));
 }
 
-semantic_analyzer::LabelEntry* ConditionalExpression::getExitLabel() const {
-    return exitLabel.get();
+symbols::LabelEntry* ConditionalExpression::getExitLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Exit);
 }
 
 bool ConditionalExpression::evaluateConstant(long& value) const {

--- a/src/ast/ConditionalExpression.h
+++ b/src/ast/ConditionalExpression.h
@@ -42,7 +42,8 @@ public:
 private:
     std::unique_ptr<Expression> condition;
     std::unique_ptr<Expression> trueExpression;
-    std::unique_ptr<Expression> falseExpression;};
+    std::unique_ptr<Expression> falseExpression;
+};
 
 } // namespace ast
 

--- a/src/ast/ConditionalExpression.h
+++ b/src/ast/ConditionalExpression.h
@@ -4,7 +4,8 @@
 #include <memory>
 
 #include "Expression.h"
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
@@ -31,21 +32,17 @@ public:
 
     translation_unit::Context getContext() const override;
 
-    void setFalsyLabel(semantic_analyzer::LabelEntry label);
-    semantic_analyzer::LabelEntry* getFalsyLabel() const;
-    void setExitLabel(semantic_analyzer::LabelEntry label);
-    semantic_analyzer::LabelEntry* getExitLabel() const;
+    void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry label);
+    symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
+    void setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry label);
+    symbols::LabelEntry* getExitLabel(symbols::AnnotationStore& store) const;
 
     bool evaluateConstant(long& value) const override;
 
 private:
     std::unique_ptr<Expression> condition;
     std::unique_ptr<Expression> trueExpression;
-    std::unique_ptr<Expression> falseExpression;
-
-    std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
-    std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
-};
+    std::unique_ptr<Expression> falseExpression;};
 
 } // namespace ast
 

--- a/src/ast/DefaultLabel.cpp
+++ b/src/ast/DefaultLabel.cpp
@@ -13,12 +13,12 @@ void DefaultLabel::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void DefaultLabel::setLabel(semantic_analyzer::LabelEntry label) {
-    this->label = std::make_unique<semantic_analyzer::LabelEntry>(label);
+void DefaultLabel::setLabel(symbols::AnnotationStore& store, symbols::LabelEntry label) {
+    store.setLabel(this, symbols::LabelSlot::Primary, std::move(label));
 }
 
-semantic_analyzer::LabelEntry* DefaultLabel::getLabel() const {
-    return label.get();
+symbols::LabelEntry* DefaultLabel::getLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Primary);
 }
 
 } // namespace ast

--- a/src/ast/DefaultLabel.h
+++ b/src/ast/DefaultLabel.h
@@ -23,7 +23,6 @@ public:
     const TerminalSymbol defaultKeyword;
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/DefaultLabel.h
+++ b/src/ast/DefaultLabel.h
@@ -3,7 +3,8 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/TerminalSymbol.h"
 
@@ -16,14 +17,13 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setLabel(semantic_analyzer::LabelEntry label);
-    semantic_analyzer::LabelEntry* getLabel() const;
+    void setLabel(symbols::AnnotationStore& store, symbols::LabelEntry label);
+    symbols::LabelEntry* getLabel(symbols::AnnotationStore& store) const;
 
     const TerminalSymbol defaultKeyword;
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> label { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/DirectDeclarator.h
+++ b/src/ast/DirectDeclarator.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "semantic_analyzer/ValueEntry.h"
+#include "symbols/ValueEntry.h"
 #include "ast/Pointer.h"
 #include "types/Type.h"
 

--- a/src/ast/DirectDeclarator.h
+++ b/src/ast/DirectDeclarator.h
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "symbols/ValueEntry.h"
 #include "ast/Pointer.h"
+#include "translation_unit/Context.h"
 #include "types/Type.h"
 
 namespace ast {
@@ -29,7 +29,6 @@ private:
 
     translation_unit::Context context;
 
-    std::unique_ptr<symbols::ValueEntry> holder { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -60,9 +60,12 @@ bool Expression::isLval() const {
     return lval;
 }
 
+void Expression::setLvalueSymbol(symbols::AnnotationStore& store, symbols::ValueEntry address) {
+    store.setLvalue(this, std::move(address));
+}
+
 symbols::ValueEntry* Expression::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    (void)store;
-    return nullptr;
+    return store.lvalue(this);
 }
 
 } // namespace ast

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -44,7 +44,7 @@ public:
     virtual bool isLval() const;
     // Address temp for this expression (ValueSlot::Lvalue on the store).
     void setLvalueSymbol(symbols::AnnotationStore& store, symbols::ValueEntry address);
-    virtual symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const;
+    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const;
 
     virtual bool evaluateConstant(long& value) const { return false; }
 

--- a/src/ast/Expression.h
+++ b/src/ast/Expression.h
@@ -42,6 +42,8 @@ public:
     type::Type valueType(const symbols::AnnotationStore& store) const;
 
     virtual bool isLval() const;
+    // Address temp for this expression (ValueSlot::Lvalue on the store).
+    void setLvalueSymbol(symbols::AnnotationStore& store, symbols::ValueEntry address);
     virtual symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const;
 
     virtual bool evaluateConstant(long& value) const { return false; }

--- a/src/ast/FunctionDefinition.cpp
+++ b/src/ast/FunctionDefinition.cpp
@@ -38,11 +38,11 @@ void FunctionDefinition::visitBodyChildren(AbstractSyntaxTreeVisitor& visitor) {
     body->visitChildren(visitor);
 }
 
-void FunctionDefinition::setSymbol(semantic_analyzer::FunctionEntry symbol) {
-    this->symbol = std::make_unique<semantic_analyzer::FunctionEntry>(symbol);
+void FunctionDefinition::setSymbol(symbols::FunctionEntry symbol) {
+    this->symbol = std::make_unique<symbols::FunctionEntry>(symbol);
 }
 
-semantic_analyzer::FunctionEntry* FunctionDefinition::getSymbol() const {
+symbols::FunctionEntry* FunctionDefinition::getSymbol() const {
     if (!symbol) {
         throw std::runtime_error { "FunctionDefinition::getSymbol() == nullptr" };
     }

--- a/src/ast/FunctionDefinition.h
+++ b/src/ast/FunctionDefinition.h
@@ -6,8 +6,8 @@
 #include <string>
 #include <vector>
 
-#include "semantic_analyzer/ValueEntry.h"
-#include "semantic_analyzer/FunctionEntry.h"
+#include "symbols/ValueEntry.h"
+#include "symbols/FunctionEntry.h"
 #include "ast/DeclarationSpecifiers.h"
 #include "ast/Declarator.h"
 
@@ -25,12 +25,12 @@ public:
     // Visit body block contents without Block::accept (no extra scope enter).
     void visitBodyChildren(AbstractSyntaxTreeVisitor& visitor);
 
-    void setSymbol(semantic_analyzer::FunctionEntry symbol);
+    void setSymbol(symbols::FunctionEntry symbol);
     void setLocalVariables(std::map<std::string, symbols::ValueEntry> localVariables);
     void setArguments(std::vector<symbols::ValueEntry> arguments);
 
     bool hasSymbol() const { return symbol != nullptr; }
-    semantic_analyzer::FunctionEntry* getSymbol() const;
+    symbols::FunctionEntry* getSymbol() const;
     std::map<std::string, symbols::ValueEntry> getLocalVariables() const;
     std::vector<symbols::ValueEntry> getArguments() const;
 
@@ -41,7 +41,7 @@ private:
     std::unique_ptr<Declarator> declarator;
     std::unique_ptr<AbstractSyntaxTreeNode> body;
 
-    std::unique_ptr<semantic_analyzer::FunctionEntry> symbol;
+    std::unique_ptr<symbols::FunctionEntry> symbol;
 
     std::map<std::string, symbols::ValueEntry> localVariables;
     std::vector<symbols::ValueEntry> arguments;

--- a/src/ast/FunctionDefinition.h
+++ b/src/ast/FunctionDefinition.h
@@ -41,6 +41,9 @@ private:
     std::unique_ptr<Declarator> declarator;
     std::unique_ptr<AbstractSyntaxTreeNode> body;
 
+    // Residual SA→CG frame facts still on the node (FunctionEntry + locals/args).
+    // Intentional Phase 0 defer: migrate to store (FunctionFrame / plan) later;
+    // do not introduce a second channel alongside these fields.
     std::unique_ptr<symbols::FunctionEntry> symbol;
 
     std::map<std::string, symbols::ValueEntry> localVariables;

--- a/src/ast/GotoStatement.cpp
+++ b/src/ast/GotoStatement.cpp
@@ -13,12 +13,12 @@ void GotoStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void GotoStatement::setTarget(semantic_analyzer::LabelEntry target) {
-    this->target = std::make_unique<semantic_analyzer::LabelEntry>(target);
+void GotoStatement::setTarget(symbols::AnnotationStore& store, symbols::LabelEntry target) {
+    store.setLabel(this, symbols::LabelSlot::Target, std::move(target));
 }
 
-semantic_analyzer::LabelEntry* GotoStatement::getTarget() const {
-    return target.get();
+symbols::LabelEntry* GotoStatement::getTarget(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Target);
 }
 
 const std::string& GotoStatement::getLabelName() const {

--- a/src/ast/GotoStatement.h
+++ b/src/ast/GotoStatement.h
@@ -25,7 +25,6 @@ public:
     TerminalSymbol gotoKeyword;
     TerminalSymbol label;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/GotoStatement.h
+++ b/src/ast/GotoStatement.h
@@ -6,7 +6,8 @@
 
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/TerminalSymbol.h"
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
@@ -16,8 +17,8 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setTarget(semantic_analyzer::LabelEntry target);
-    semantic_analyzer::LabelEntry* getTarget() const;
+    void setTarget(symbols::AnnotationStore& store, symbols::LabelEntry target);
+    symbols::LabelEntry* getTarget(symbols::AnnotationStore& store) const;
 
     const std::string& getLabelName() const;
 
@@ -25,7 +26,6 @@ public:
     TerminalSymbol label;
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> target { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/IfElseStatement.cpp
+++ b/src/ast/IfElseStatement.cpp
@@ -19,21 +19,20 @@ void IfElseStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-semantic_analyzer::LabelEntry* IfElseStatement::getFalsyLabel() const {
-    return falsyLabel.get();
+symbols::LabelEntry* IfElseStatement::getFalsyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Falsy);
 }
 
-void IfElseStatement::setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel) {
-    this->falsyLabel = std::make_unique<semantic_analyzer::LabelEntry>(falsyLabel);
+void IfElseStatement::setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel) {
+    store.setLabel(this, symbols::LabelSlot::Falsy, std::move(falsyLabel));
 }
 
-semantic_analyzer::LabelEntry* IfElseStatement::getExitLabel() const {
-    return exitLabel.get();
+symbols::LabelEntry* IfElseStatement::getExitLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Exit);
 }
 
-void IfElseStatement::setExitLabel(semantic_analyzer::LabelEntry truthyLabel) {
-    this->exitLabel = std::make_unique<semantic_analyzer::LabelEntry>(truthyLabel);
+void IfElseStatement::setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel) {
+    store.setLabel(this, symbols::LabelSlot::Exit, std::move(exitLabel));
 }
 
 } // namespace ast
-

--- a/src/ast/IfElseStatement.h
+++ b/src/ast/IfElseStatement.h
@@ -3,9 +3,10 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/Expression.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
@@ -17,18 +18,16 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    semantic_analyzer::LabelEntry* getFalsyLabel() const;
-    void setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel);
-    semantic_analyzer::LabelEntry* getExitLabel() const;
-    void setExitLabel(semantic_analyzer::LabelEntry truthyLabel);
+    symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
+    void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel);
+    symbols::LabelEntry* getExitLabel(symbols::AnnotationStore& store) const;
+    void setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel);
 
     const std::unique_ptr<Expression> testExpression;
     const std::unique_ptr<AbstractSyntaxTreeNode> truthyBody;
     const std::unique_ptr<AbstractSyntaxTreeNode> falsyBody;
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
-    std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/IfElseStatement.h
+++ b/src/ast/IfElseStatement.h
@@ -27,7 +27,6 @@ public:
     const std::unique_ptr<AbstractSyntaxTreeNode> truthyBody;
     const std::unique_ptr<AbstractSyntaxTreeNode> falsyBody;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/IfStatement.cpp
+++ b/src/ast/IfStatement.cpp
@@ -10,20 +10,18 @@ IfStatement::IfStatement(std::unique_ptr<Expression> testExpression, std::unique
 {
 }
 
-IfStatement::~IfStatement() {
-}
+IfStatement::~IfStatement() = default;
 
 void IfStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void IfStatement::setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel) {
-    this->falsyLabel = std::make_unique<semantic_analyzer::LabelEntry>(falsyLabel);
+void IfStatement::setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel) {
+    store.setLabel(this, symbols::LabelSlot::Falsy, std::move(falsyLabel));
 }
 
-semantic_analyzer::LabelEntry* IfStatement::getFalsyLabel() const {
-    return falsyLabel.get();
+symbols::LabelEntry* IfStatement::getFalsyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Falsy);
 }
 
 } // namespace ast
-

--- a/src/ast/IfStatement.h
+++ b/src/ast/IfStatement.h
@@ -23,7 +23,6 @@ public:
     const std::unique_ptr<Expression> testExpression;
     const std::unique_ptr<AbstractSyntaxTreeNode> body;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/IfStatement.h
+++ b/src/ast/IfStatement.h
@@ -3,9 +3,10 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/Expression.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
@@ -16,14 +17,13 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel);
-    semantic_analyzer::LabelEntry* getFalsyLabel() const;
+    void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel);
+    symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
 
     const std::unique_ptr<Expression> testExpression;
     const std::unique_ptr<AbstractSyntaxTreeNode> body;
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/InitializedDeclarator.cpp
+++ b/src/ast/InitializedDeclarator.cpp
@@ -54,11 +54,8 @@ void InitializedDeclarator::setHolder(symbols::AnnotationStore& store, symbols::
 }
 
 symbols::ValueEntry* InitializedDeclarator::getHolder(symbols::AnnotationStore& store) const {
-    auto* h = store.holder(this);
-    if (!h) {
-        throw std::runtime_error { "InitializedDeclarator::getHolder() == nullptr" };
-    }
-    return h;
+    // Soft probe (nullptr when missing); CG asserts after successful SA.
+    return store.holder(this);
 }
 
 type::Type InitializedDeclarator::getFundamentalType(const type::Type& baseType) {

--- a/src/ast/InitializedDeclarator.cpp
+++ b/src/ast/InitializedDeclarator.cpp
@@ -49,15 +49,16 @@ translation_unit::Context ast::InitializedDeclarator::getContext() const {
     return declarator->getContext();
 }
 
-void InitializedDeclarator::setHolder(symbols::ValueEntry holder) {
-    this->holder = std::make_unique<symbols::ValueEntry>(holder);
+void InitializedDeclarator::setHolder(symbols::AnnotationStore& store, symbols::ValueEntry holder) {
+    store.setHolder(this, std::move(holder));
 }
 
-symbols::ValueEntry* InitializedDeclarator::getHolder() const {
-    if (!holder) {
+symbols::ValueEntry* InitializedDeclarator::getHolder(symbols::AnnotationStore& store) const {
+    auto* h = store.holder(this);
+    if (!h) {
         throw std::runtime_error { "InitializedDeclarator::getHolder() == nullptr" };
     }
-    return holder.get();
+    return h;
 }
 
 type::Type InitializedDeclarator::getFundamentalType(const type::Type& baseType) {

--- a/src/ast/InitializedDeclarator.h
+++ b/src/ast/InitializedDeclarator.h
@@ -7,6 +7,7 @@
 
 #include "Declarator.h"
 #include "Expression.h"
+#include "symbols/AnnotationStore.h"
 
 namespace ast {
 
@@ -29,13 +30,12 @@ public:
 
     translation_unit::Context getContext() const;
 
-    void setHolder(symbols::ValueEntry holder);
-    symbols::ValueEntry* getHolder() const;
+    void setHolder(symbols::AnnotationStore& store, symbols::ValueEntry holder);
+    symbols::ValueEntry* getHolder(symbols::AnnotationStore& store) const;
 
 private:
     std::unique_ptr<Declarator> declarator;
     std::unique_ptr<Expression> initializer;
-    std::unique_ptr<symbols::ValueEntry> holder;
 };
 
 } // namespace ast

--- a/src/ast/JumpStatement.cpp
+++ b/src/ast/JumpStatement.cpp
@@ -17,12 +17,12 @@ void JumpStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
 	visitor.visit(*this);
 }
 
-void JumpStatement::setJumpTo(semantic_analyzer::LabelEntry label) {
-	jumpTo = std::make_unique<semantic_analyzer::LabelEntry>(label);
+void JumpStatement::setJumpTo(symbols::AnnotationStore& store, symbols::LabelEntry label) {
+    store.setLabel(this, symbols::LabelSlot::Target, std::move(label));
 }
 
-semantic_analyzer::LabelEntry* JumpStatement::getJumpTo() const {
-	return jumpTo.get();
+symbols::LabelEntry* JumpStatement::getJumpTo(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Target);
 }
 
 } // namespace ast

--- a/src/ast/JumpStatement.h
+++ b/src/ast/JumpStatement.h
@@ -21,7 +21,6 @@ public:
 
 	TerminalSymbol jumpKeyword;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/JumpStatement.h
+++ b/src/ast/JumpStatement.h
@@ -5,7 +5,8 @@
 
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/TerminalSymbol.h"
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
@@ -15,13 +16,12 @@ public:
 
 	void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-	void setJumpTo(semantic_analyzer::LabelEntry label);
-	semantic_analyzer::LabelEntry* getJumpTo() const;
+	void setJumpTo(symbols::AnnotationStore& store, symbols::LabelEntry label);
+	symbols::LabelEntry* getJumpTo(symbols::AnnotationStore& store) const;
 
 	TerminalSymbol jumpKeyword;
 
 private:
-	std::unique_ptr<semantic_analyzer::LabelEntry> jumpTo;
 };
 
 } // namespace ast

--- a/src/ast/LabeledStatement.cpp
+++ b/src/ast/LabeledStatement.cpp
@@ -13,12 +13,12 @@ void LabeledStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void LabeledStatement::setLabel(semantic_analyzer::LabelEntry label) {
-    this->label = std::make_unique<semantic_analyzer::LabelEntry>(label);
+void LabeledStatement::setLabel(symbols::AnnotationStore& store, symbols::LabelEntry label) {
+    store.setLabel(this, symbols::LabelSlot::Primary, std::move(label));
 }
 
-semantic_analyzer::LabelEntry* LabeledStatement::getLabel() const {
-    return label.get();
+symbols::LabelEntry* LabeledStatement::getLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Primary);
 }
 
 const std::string& LabeledStatement::getLabelName() const {

--- a/src/ast/LabeledStatement.h
+++ b/src/ast/LabeledStatement.h
@@ -26,7 +26,6 @@ public:
     TerminalSymbol name;
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/LabeledStatement.h
+++ b/src/ast/LabeledStatement.h
@@ -6,7 +6,8 @@
 
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/TerminalSymbol.h"
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
@@ -17,8 +18,8 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setLabel(semantic_analyzer::LabelEntry label);
-    semantic_analyzer::LabelEntry* getLabel() const;
+    void setLabel(symbols::AnnotationStore& store, symbols::LabelEntry label);
+    symbols::LabelEntry* getLabel(symbols::AnnotationStore& store) const;
 
     const std::string& getLabelName() const;
 
@@ -26,7 +27,6 @@ public:
     const std::unique_ptr<AbstractSyntaxTreeNode> statement;
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> label { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/LogicalExpression.cpp
+++ b/src/ast/LogicalExpression.cpp
@@ -12,12 +12,12 @@ LogicalExpression::LogicalExpression(std::unique_ptr<Expression> leftHandSide, s
 LogicalExpression::~LogicalExpression() {
 }
 
-void LogicalExpression::setExitLabel(semantic_analyzer::LabelEntry exitLabel) {
-    this->exitLabel = std::unique_ptr<semantic_analyzer::LabelEntry> { new semantic_analyzer::LabelEntry { exitLabel } };
+void LogicalExpression::setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel) {
+    store.setLabel(this, symbols::LabelSlot::Exit, std::move(exitLabel));
 }
 
-semantic_analyzer::LabelEntry* LogicalExpression::getExitLabel() const {
-    return exitLabel.get();
+symbols::LabelEntry* LogicalExpression::getExitLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Exit);
 }
 
 } // namespace ast

--- a/src/ast/LogicalExpression.h
+++ b/src/ast/LogicalExpression.h
@@ -19,7 +19,6 @@ public:
 protected:
     LogicalExpression(std::unique_ptr<Expression> leftHandSide, std::unique_ptr<Operator> logicalOperator, std::unique_ptr<Expression> rightHandSide);
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/LogicalExpression.h
+++ b/src/ast/LogicalExpression.h
@@ -3,7 +3,8 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 #include "ast/DoubleOperandExpression.h"
 
 namespace ast {
@@ -12,14 +13,13 @@ class LogicalExpression: public DoubleOperandExpression {
 public:
     virtual ~LogicalExpression();
 
-    void setExitLabel(semantic_analyzer::LabelEntry exitLabel);
-    semantic_analyzer::LabelEntry* getExitLabel() const;
+    void setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel);
+    symbols::LabelEntry* getExitLabel(symbols::AnnotationStore& store) const;
 
 protected:
     LogicalExpression(std::unique_ptr<Expression> leftHandSide, std::unique_ptr<Operator> logicalOperator, std::unique_ptr<Expression> rightHandSide);
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/LoopHeader.cpp
+++ b/src/ast/LoopHeader.cpp
@@ -1,5 +1,4 @@
 #include "LoopHeader.h"
-#include "semantic_analyzer/LabelEntry.h"
 
 namespace ast {
 
@@ -10,29 +9,28 @@ LoopHeader::LoopHeader(std::unique_ptr<Expression> increment) :
 {
 }
 
-void LoopHeader::setLoopEntry(semantic_analyzer::LabelEntry loopEntry) {
-    this->loopEntry = std::make_unique<semantic_analyzer::LabelEntry>(loopEntry);
+void LoopHeader::setLoopEntry(symbols::AnnotationStore& store, symbols::LabelEntry loopEntry) {
+    store.setLabel(this, symbols::LabelSlot::LoopEntry, std::move(loopEntry));
 }
 
-semantic_analyzer::LabelEntry* LoopHeader::getLoopEntry() const {
-    return loopEntry.get();
+symbols::LabelEntry* LoopHeader::getLoopEntry(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::LoopEntry);
 }
 
-void LoopHeader::setLoopExit(semantic_analyzer::LabelEntry loopExit) {
-    this->loopExit = std::make_unique<semantic_analyzer::LabelEntry>(loopExit);
+void LoopHeader::setLoopExit(symbols::AnnotationStore& store, symbols::LabelEntry loopExit) {
+    store.setLabel(this, symbols::LabelSlot::LoopExit, std::move(loopExit));
 }
 
-semantic_analyzer::LabelEntry* LoopHeader::getLoopExit() const {
-    return loopExit.get();
+symbols::LabelEntry* LoopHeader::getLoopExit(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::LoopExit);
 }
 
-void LoopHeader::setLoopContinue(semantic_analyzer::LabelEntry loopContinue) {
-    this->loopContinue = std::make_unique<semantic_analyzer::LabelEntry>(loopContinue);
+void LoopHeader::setLoopContinue(symbols::AnnotationStore& store, symbols::LabelEntry loopContinue) {
+    store.setLabel(this, symbols::LabelSlot::LoopContinue, std::move(loopContinue));
 }
 
-semantic_analyzer::LabelEntry* LoopHeader::getLoopContinue() const {
-    return loopContinue.get();
+symbols::LabelEntry* LoopHeader::getLoopContinue(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::LoopContinue);
 }
 
 } // namespace ast
-

--- a/src/ast/LoopHeader.h
+++ b/src/ast/LoopHeader.h
@@ -35,7 +35,6 @@ public:
 protected:
     LoopHeader(std::unique_ptr<Expression> increment = nullptr);
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/LoopHeader.h
+++ b/src/ast/LoopHeader.h
@@ -4,20 +4,21 @@
 #include <memory>
 #include <string>
 
-#include "semantic_analyzer/LabelEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/Expression.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 
 namespace ast {
 
 class LoopHeader: public AbstractSyntaxTreeNode {
 public:
-    void setLoopEntry(semantic_analyzer::LabelEntry loopEntry);
-    semantic_analyzer::LabelEntry* getLoopEntry() const;
-    void setLoopExit(semantic_analyzer::LabelEntry loopExit);
-    semantic_analyzer::LabelEntry* getLoopExit() const;
-    void setLoopContinue(semantic_analyzer::LabelEntry loopContinue);
-    semantic_analyzer::LabelEntry* getLoopContinue() const;
+    void setLoopEntry(symbols::AnnotationStore& store, symbols::LabelEntry loopEntry);
+    symbols::LabelEntry* getLoopEntry(symbols::AnnotationStore& store) const;
+    void setLoopExit(symbols::AnnotationStore& store, symbols::LabelEntry loopExit);
+    symbols::LabelEntry* getLoopExit(symbols::AnnotationStore& store) const;
+    void setLoopContinue(symbols::AnnotationStore& store, symbols::LabelEntry loopContinue);
+    symbols::LabelEntry* getLoopContinue(symbols::AnnotationStore& store) const;
 
     // C99 for-with-declaration scopes the header declaration over the loop body.
     virtual bool opensBlockScope() const { return false; }
@@ -35,9 +36,6 @@ protected:
     LoopHeader(std::unique_ptr<Expression> increment = nullptr);
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> loopEntry { nullptr };
-    std::unique_ptr<semantic_analyzer::LabelEntry> loopExit { nullptr };
-    std::unique_ptr<semantic_analyzer::LabelEntry> loopContinue { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/MemberAccess.cpp
+++ b/src/ast/MemberAccess.cpp
@@ -33,16 +33,5 @@ bool MemberAccess::isArrow() const {
     return arrow;
 }
 
-void MemberAccess::setFieldAddressSymbol(symbols::AnnotationStore& store, symbols::ValueEntry symbol) {
-    setLvalueSymbol(store, std::move(symbol));
-}
-
-symbols::ValueEntry* MemberAccess::getFieldAddressSymbol(symbols::AnnotationStore& store) const {
-    return getLvalueSymbol(store);
-}
-
-symbols::ValueEntry* MemberAccess::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    return store.lvalue(this);
-}
 
 } // namespace ast

--- a/src/ast/MemberAccess.cpp
+++ b/src/ast/MemberAccess.cpp
@@ -33,17 +33,16 @@ bool MemberAccess::isArrow() const {
     return arrow;
 }
 
-void MemberAccess::setFieldAddressSymbol(symbols::ValueEntry symbol) {
-    fieldAddress = std::make_unique<symbols::ValueEntry>(std::move(symbol));
+void MemberAccess::setFieldAddressSymbol(symbols::AnnotationStore& store, symbols::ValueEntry symbol) {
+    setLvalueSymbol(store, std::move(symbol));
 }
 
-symbols::ValueEntry* MemberAccess::getFieldAddressSymbol() const {
-    return fieldAddress.get();
+symbols::ValueEntry* MemberAccess::getFieldAddressSymbol(symbols::AnnotationStore& store) const {
+    return getLvalueSymbol(store);
 }
 
 symbols::ValueEntry* MemberAccess::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    (void)store;
-    return fieldAddress.get();
+    return store.lvalue(this);
 }
 
 } // namespace ast

--- a/src/ast/MemberAccess.h
+++ b/src/ast/MemberAccess.h
@@ -23,8 +23,8 @@ public:
     const std::string& getMemberName() const;
     bool isArrow() const;
 
-    void setFieldAddressSymbol(symbols::ValueEntry symbol);
-    symbols::ValueEntry* getFieldAddressSymbol() const;
+    void setFieldAddressSymbol(symbols::AnnotationStore& store, symbols::ValueEntry symbol);
+    symbols::ValueEntry* getFieldAddressSymbol(symbols::AnnotationStore& store) const;
     symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
 private:
@@ -32,7 +32,6 @@ private:
     std::string memberName;
     bool arrow;
     translation_unit::Context context;
-    std::unique_ptr<symbols::ValueEntry> fieldAddress;
 };
 
 } // namespace ast

--- a/src/ast/MemberAccess.h
+++ b/src/ast/MemberAccess.h
@@ -23,7 +23,6 @@ public:
     const std::string& getMemberName() const;
     bool isArrow() const;
 
-
 private:
     std::unique_ptr<Expression> base;
     std::string memberName;

--- a/src/ast/MemberAccess.h
+++ b/src/ast/MemberAccess.h
@@ -23,9 +23,6 @@ public:
     const std::string& getMemberName() const;
     bool isArrow() const;
 
-    void setFieldAddressSymbol(symbols::AnnotationStore& store, symbols::ValueEntry symbol);
-    symbols::ValueEntry* getFieldAddressSymbol(symbols::AnnotationStore& store) const;
-    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
 private:
     std::unique_ptr<Expression> base;

--- a/src/ast/PostfixExpression.cpp
+++ b/src/ast/PostfixExpression.cpp
@@ -6,23 +6,24 @@
 
 namespace ast {
 
-PostfixExpression::PostfixExpression(std::unique_ptr<Expression> postfixExpression, std::unique_ptr<Operator> postfixOperator) :
-        SingleOperandExpression(std::move(postfixExpression), std::move(postfixOperator)) {
+PostfixExpression::PostfixExpression(std::unique_ptr<Expression> postfixExpression,
+        std::unique_ptr<Operator> postfixOperator) :
+        SingleOperandExpression { std::move(postfixExpression), std::move(postfixOperator) } {
 }
 
 void PostfixExpression::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void PostfixExpression::setPreOperationSymbol(symbols::ValueEntry resultSymbol) {
-    this->preOperationSymbol = std::make_unique<symbols::ValueEntry>(resultSymbol);
-    setType(this->preOperationSymbol->getType());
+void PostfixExpression::setPreOperationSymbol(symbols::AnnotationStore& store, symbols::ValueEntry resultSymbol) {
+    setType(resultSymbol.getType());
+    store.setPreOperation(this, std::move(resultSymbol));
 }
 
-symbols::ValueEntry* PostfixExpression::getPreOperationSymbol() const {
-    assert(preOperationSymbol);
-    return preOperationSymbol.get();
+symbols::ValueEntry* PostfixExpression::getPreOperationSymbol(symbols::AnnotationStore& store) const {
+    auto* pre = store.preOperation(this);
+    assert(pre);
+    return pre;
 }
 
 } // namespace ast
-

--- a/src/ast/PostfixExpression.cpp
+++ b/src/ast/PostfixExpression.cpp
@@ -21,9 +21,8 @@ void PostfixExpression::setPreOperationSymbol(symbols::AnnotationStore& store, s
 }
 
 symbols::ValueEntry* PostfixExpression::getPreOperationSymbol(symbols::AnnotationStore& store) const {
-    auto* pre = store.preOperation(this);
-    assert(pre);
-    return pre;
+    // Soft probe (nullptr when missing); CG asserts after successful SA.
+    return store.preOperation(this);
 }
 
 } // namespace ast

--- a/src/ast/PostfixExpression.h
+++ b/src/ast/PostfixExpression.h
@@ -17,7 +17,6 @@ public:
     void setPreOperationSymbol(symbols::AnnotationStore& store, symbols::ValueEntry resultSymbol);
     symbols::ValueEntry* getPreOperationSymbol(symbols::AnnotationStore& store) const;
 
-private:
 };
 
 } // namespace ast

--- a/src/ast/PostfixExpression.h
+++ b/src/ast/PostfixExpression.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "SingleOperandExpression.h"
+#include "symbols/AnnotationStore.h"
 
 namespace ast {
 
@@ -13,11 +14,10 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setPreOperationSymbol(symbols::ValueEntry resultSymbol);
-    symbols::ValueEntry* getPreOperationSymbol() const;
+    void setPreOperationSymbol(symbols::AnnotationStore& store, symbols::ValueEntry resultSymbol);
+    symbols::ValueEntry* getPreOperationSymbol(symbols::AnnotationStore& store) const;
 
 private:
-    std::unique_ptr<symbols::ValueEntry> preOperationSymbol { nullptr };
 };
 
 } // namespace ast

--- a/src/ast/StringLiteralExpression.h
+++ b/src/ast/StringLiteralExpression.h
@@ -23,6 +23,7 @@ public:
 
 private:
     std::string value;
+    // Residual SA product (rodata label); not dual with store. Optional later store plan.
     std::string constantSymbol;
     translation_unit::Context context;
 };

--- a/src/ast/SwitchStatement.cpp
+++ b/src/ast/SwitchStatement.cpp
@@ -24,11 +24,11 @@ symbols::LabelEntry* SwitchStatement::getExitLabel(symbols::AnnotationStore& sto
 }
 
 void SwitchStatement::setCaseTemp(symbols::AnnotationStore& store, symbols::ValueEntry temp) {
-    store.setValue(this, symbols::ValueSlot::CaseTemp, std::move(temp));
+    store.setCaseTemp(this, std::move(temp));
 }
 
 symbols::ValueEntry* SwitchStatement::getCaseTemp(symbols::AnnotationStore& store) const {
-    return store.value(this, symbols::ValueSlot::CaseTemp);
+    return store.caseTemp(this);
 }
 
 void SwitchStatement::addCase(CaseLabel* caseLabel) {

--- a/src/ast/SwitchStatement.cpp
+++ b/src/ast/SwitchStatement.cpp
@@ -23,12 +23,12 @@ symbols::LabelEntry* SwitchStatement::getExitLabel(symbols::AnnotationStore& sto
     return store.label(this, symbols::LabelSlot::Exit);
 }
 
-void SwitchStatement::setCaseTemp(symbols::ValueEntry temp) {
-    this->caseTemp = std::make_unique<symbols::ValueEntry>(temp);
+void SwitchStatement::setCaseTemp(symbols::AnnotationStore& store, symbols::ValueEntry temp) {
+    store.setValue(this, symbols::ValueSlot::CaseTemp, std::move(temp));
 }
 
-symbols::ValueEntry* SwitchStatement::getCaseTemp() const {
-    return caseTemp.get();
+symbols::ValueEntry* SwitchStatement::getCaseTemp(symbols::AnnotationStore& store) const {
+    return store.value(this, symbols::ValueSlot::CaseTemp);
 }
 
 void SwitchStatement::addCase(CaseLabel* caseLabel) {

--- a/src/ast/SwitchStatement.cpp
+++ b/src/ast/SwitchStatement.cpp
@@ -15,12 +15,12 @@ void SwitchStatement::accept(AbstractSyntaxTreeVisitor& visitor) {
     visitor.visit(*this);
 }
 
-void SwitchStatement::setExitLabel(semantic_analyzer::LabelEntry exitLabel) {
-    this->exitLabel = std::make_unique<semantic_analyzer::LabelEntry>(exitLabel);
+void SwitchStatement::setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel) {
+    store.setLabel(this, symbols::LabelSlot::Exit, std::move(exitLabel));
 }
 
-semantic_analyzer::LabelEntry* SwitchStatement::getExitLabel() const {
-    return exitLabel.get();
+symbols::LabelEntry* SwitchStatement::getExitLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Exit);
 }
 
 void SwitchStatement::setCaseTemp(symbols::ValueEntry temp) {

--- a/src/ast/SwitchStatement.h
+++ b/src/ast/SwitchStatement.h
@@ -25,8 +25,8 @@ public:
     void setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel);
     symbols::LabelEntry* getExitLabel(symbols::AnnotationStore& store) const;
 
-    void setCaseTemp(symbols::ValueEntry temp);
-    symbols::ValueEntry* getCaseTemp() const;
+    void setCaseTemp(symbols::AnnotationStore& store, symbols::ValueEntry temp);
+    symbols::ValueEntry* getCaseTemp(symbols::AnnotationStore& store) const;
 
     void addCase(CaseLabel* caseLabel);
     const std::vector<CaseLabel*>& getCases() const;
@@ -37,7 +37,7 @@ public:
     const std::unique_ptr<Expression> expression;
     const std::unique_ptr<AbstractSyntaxTreeNode> body;
 
-private:    std::unique_ptr<symbols::ValueEntry> caseTemp { nullptr };
+private:
     std::vector<CaseLabel*> cases;
     DefaultLabel* defaultLabelNode { nullptr };
 };

--- a/src/ast/SwitchStatement.h
+++ b/src/ast/SwitchStatement.h
@@ -4,8 +4,9 @@
 #include <memory>
 #include <vector>
 
-#include "semantic_analyzer/LabelEntry.h"
-#include "semantic_analyzer/ValueEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
+#include "symbols/ValueEntry.h"
 #include "ast/AbstractSyntaxTreeNode.h"
 #include "ast/Expression.h"
 
@@ -21,8 +22,8 @@ public:
 
     void accept(AbstractSyntaxTreeVisitor& visitor) override;
 
-    void setExitLabel(semantic_analyzer::LabelEntry exitLabel);
-    semantic_analyzer::LabelEntry* getExitLabel() const;
+    void setExitLabel(symbols::AnnotationStore& store, symbols::LabelEntry exitLabel);
+    symbols::LabelEntry* getExitLabel(symbols::AnnotationStore& store) const;
 
     void setCaseTemp(symbols::ValueEntry temp);
     symbols::ValueEntry* getCaseTemp() const;
@@ -36,9 +37,7 @@ public:
     const std::unique_ptr<Expression> expression;
     const std::unique_ptr<AbstractSyntaxTreeNode> body;
 
-private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> exitLabel { nullptr };
-    std::unique_ptr<symbols::ValueEntry> caseTemp { nullptr };
+private:    std::unique_ptr<symbols::ValueEntry> caseTemp { nullptr };
     std::vector<CaseLabel*> cases;
     DefaultLabel* defaultLabelNode { nullptr };
 };

--- a/src/ast/UnaryExpression.cpp
+++ b/src/ast/UnaryExpression.cpp
@@ -42,31 +42,24 @@ bool UnaryExpression::evaluateConstant(long& value) const {
     return false;
 }
 
-void UnaryExpression::setTruthyLabel(semantic_analyzer::LabelEntry truthyLabel) {
-    this->truthyLabel = std::unique_ptr<semantic_analyzer::LabelEntry> {
-            new semantic_analyzer::LabelEntry { truthyLabel } };
+void UnaryExpression::setTruthyLabel(symbols::AnnotationStore& store, symbols::LabelEntry truthyLabel) {
+    store.setLabel(this, symbols::LabelSlot::Truthy, std::move(truthyLabel));
 }
 
-semantic_analyzer::LabelEntry* UnaryExpression::getTruthyLabel() const {
-    return truthyLabel.get();
+symbols::LabelEntry* UnaryExpression::getTruthyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Truthy);
 }
 
-void UnaryExpression::setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel) {
-    this->falsyLabel =
-            std::unique_ptr<semantic_analyzer::LabelEntry> { new semantic_analyzer::LabelEntry { falsyLabel } };
+void UnaryExpression::setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel) {
+    store.setLabel(this, symbols::LabelSlot::Falsy, std::move(falsyLabel));
 }
 
-semantic_analyzer::LabelEntry* UnaryExpression::getFalsyLabel() const {
-    return falsyLabel.get();
-}
-
-void UnaryExpression::setLvalueSymbol(symbols::ValueEntry lvalueSymbol) {
-    this->lvalueSymbol = std::make_unique<symbols::ValueEntry>(lvalueSymbol);
+symbols::LabelEntry* UnaryExpression::getFalsyLabel(symbols::AnnotationStore& store) const {
+    return store.label(this, symbols::LabelSlot::Falsy);
 }
 
 symbols::ValueEntry* UnaryExpression::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    (void)store;
-    return lvalueSymbol.get();
+    return store.lvalue(this);
 }
 
 } // namespace ast

--- a/src/ast/UnaryExpression.cpp
+++ b/src/ast/UnaryExpression.cpp
@@ -58,9 +58,6 @@ symbols::LabelEntry* UnaryExpression::getFalsyLabel(symbols::AnnotationStore& st
     return store.label(this, symbols::LabelSlot::Falsy);
 }
 
-symbols::ValueEntry* UnaryExpression::getLvalueSymbol(symbols::AnnotationStore& store) const {
-    return store.lvalue(this);
-}
 
 } // namespace ast
 

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -23,7 +23,6 @@ public:
     void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel);
     symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
 
-
     void setSizeofValue(int bytes);
     int getSizeofValue() const;
 

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -3,7 +3,8 @@
 
 #include <memory>
 
-#include "semantic_analyzer/LabelEntry.h"
+#include "symbols/AnnotationStore.h"
+#include "symbols/LabelEntry.h"
 #include "ast/SingleOperandExpression.h"
 
 namespace ast {
@@ -17,22 +18,17 @@ public:
     bool isLval() const override;
     bool evaluateConstant(long& value) const override;
 
-    void setTruthyLabel(semantic_analyzer::LabelEntry truthyLabel);
-    semantic_analyzer::LabelEntry* getTruthyLabel() const;
-    void setFalsyLabel(semantic_analyzer::LabelEntry falsyLabel);
-    semantic_analyzer::LabelEntry* getFalsyLabel() const;
+    void setTruthyLabel(symbols::AnnotationStore& store, symbols::LabelEntry truthyLabel);
+    symbols::LabelEntry* getTruthyLabel(symbols::AnnotationStore& store) const;
+    void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel);
+    symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
 
-    void setLvalueSymbol(symbols::ValueEntry lvalueSymbol);
     symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
     void setSizeofValue(int bytes);
     int getSizeofValue() const;
 
 private:
-    std::unique_ptr<semantic_analyzer::LabelEntry> truthyLabel { nullptr };
-    std::unique_ptr<semantic_analyzer::LabelEntry> falsyLabel { nullptr };
-
-    std::unique_ptr<symbols::ValueEntry> lvalueSymbol { nullptr };
     int sizeofValue { -1 };
 };
 

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -27,6 +27,7 @@ public:
     int getSizeofValue() const;
 
 private:
+    // Residual SA product for sizeof fold; feeds evaluateConstant. Optional later store.
     int sizeofValue { -1 };
 };
 

--- a/src/ast/UnaryExpression.h
+++ b/src/ast/UnaryExpression.h
@@ -23,7 +23,6 @@ public:
     void setFalsyLabel(symbols::AnnotationStore& store, symbols::LabelEntry falsyLabel);
     symbols::LabelEntry* getFalsyLabel(symbols::AnnotationStore& store) const;
 
-    symbols::ValueEntry* getLvalueSymbol(symbols::AnnotationStore& store) const override;
 
     void setSizeofValue(int bytes);
     int getSizeofValue() const;

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -95,7 +95,7 @@ void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
 void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     arrayAccess.visitLeftOperand(*this);
     arrayAccess.visitRightOperand(*this);
-    if (!arrayAccess.getLvalue(store_) || !arrayAccess.getResultSymbol(store_)) {
+    if (!arrayAccess.getLvalueSymbol(store_) || !arrayAccess.getResultSymbol(store_)) {
         return;
     }
     const auto* indexPlan = store_.addressPlan(&arrayAccess);
@@ -106,13 +106,13 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
             arrayAccess.leftOperandSymbol(store_)->getName(),
             arrayAccess.rightOperandSymbol(store_)->getName(),
             arrayAccess.getElementSize(),
-            arrayAccess.getLvalue(store_)->getName(),
+            arrayAccess.getLvalueSymbol(store_)->getName(),
             index->baseMode));
     if (!arrayAccess.holdsAggregateAddress()) {
         // Load scalar element for rvalue uses; stores use LvalueAssign on the address temp.
         instructions.push_back(std::make_unique<Dereference>(
-                arrayAccess.getLvalue(store_)->getName(),
-                arrayAccess.getLvalue(store_)->getName(),
+                arrayAccess.getLvalueSymbol(store_)->getName(),
+                arrayAccess.getLvalueSymbol(store_)->getName(),
                 arrayAccess.getResultSymbol(store_)->getName()));
     }
 }
@@ -123,7 +123,7 @@ void CodeGeneratingVisitor::visit(ast::InitializerListExpression& expression) {
 
 void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
     memberAccess.getBase()->accept(*this);
-    if (!memberAccess.getFieldAddressSymbol(store_) || !memberAccess.getResultSymbol(store_)) {
+    if (!memberAccess.getLvalueSymbol(store_) || !memberAccess.getResultSymbol(store_)) {
         return;
     }
     const auto* plan = store_.addressPlan(&memberAccess);
@@ -131,7 +131,7 @@ void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
     assert(field && "FieldPlan required for member access codegen");
     const std::string addrTemp = !field->addressTempName.empty()
             ? field->addressTempName
-            : memberAccess.getFieldAddressSymbol(store_)->getName();
+            : memberAccess.getLvalueSymbol(store_)->getName();
     instructions.push_back(std::make_unique<FieldAddress>(
             memberAccess.getBase()->getResultSymbol(store_)->getName(),
             field->fieldOffsetBytes,
@@ -633,7 +633,7 @@ void CodeGeneratingVisitor::visit(ast::SwitchStatement& statement) {
     statement.expression->accept(*this);
 
     auto switchResult = statement.expression->getResultSymbol(store_)->getName();
-    auto caseTemp = statement.getCaseTemp()->getName();
+    auto caseTemp = statement.getCaseTemp(store_)->getName();
 
     for (auto* caseLabel : statement.getCases()) {
         instructions.push_back(std::make_unique<AssignConstant>(

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -95,7 +95,7 @@ void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
 void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     arrayAccess.visitLeftOperand(*this);
     arrayAccess.visitRightOperand(*this);
-    if (!arrayAccess.getLvalue() || !arrayAccess.getResultSymbol(store_)) {
+    if (!arrayAccess.getLvalue(store_) || !arrayAccess.getResultSymbol(store_)) {
         return;
     }
     const auto* indexPlan = store_.addressPlan(&arrayAccess);
@@ -106,13 +106,13 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
             arrayAccess.leftOperandSymbol(store_)->getName(),
             arrayAccess.rightOperandSymbol(store_)->getName(),
             arrayAccess.getElementSize(),
-            arrayAccess.getLvalue()->getName(),
+            arrayAccess.getLvalue(store_)->getName(),
             index->baseMode));
     if (!arrayAccess.holdsAggregateAddress()) {
         // Load scalar element for rvalue uses; stores use LvalueAssign on the address temp.
         instructions.push_back(std::make_unique<Dereference>(
-                arrayAccess.getLvalue()->getName(),
-                arrayAccess.getLvalue()->getName(),
+                arrayAccess.getLvalue(store_)->getName(),
+                arrayAccess.getLvalue(store_)->getName(),
                 arrayAccess.getResultSymbol(store_)->getName()));
     }
 }
@@ -123,7 +123,7 @@ void CodeGeneratingVisitor::visit(ast::InitializerListExpression& expression) {
 
 void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
     memberAccess.getBase()->accept(*this);
-    if (!memberAccess.getFieldAddressSymbol() || !memberAccess.getResultSymbol(store_)) {
+    if (!memberAccess.getFieldAddressSymbol(store_) || !memberAccess.getResultSymbol(store_)) {
         return;
     }
     const auto* plan = store_.addressPlan(&memberAccess);
@@ -131,7 +131,7 @@ void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
     assert(field && "FieldPlan required for member access codegen");
     const std::string addrTemp = !field->addressTempName.empty()
             ? field->addressTempName
-            : memberAccess.getFieldAddressSymbol()->getName();
+            : memberAccess.getFieldAddressSymbol(store_)->getName();
     instructions.push_back(std::make_unique<FieldAddress>(
             memberAccess.getBase()->getResultSymbol(store_)->getName(),
             field->fieldOffsetBytes,
@@ -310,12 +310,12 @@ void CodeGeneratingVisitor::visit(ast::UnaryExpression& expression) {
         break;
     case '!':
         instructions.push_back(std::make_unique<ZeroCompare>(expression.operandSymbol(store_)->getName()));
-        instructions.push_back(std::make_unique<Jump>(expression.getTruthyLabel()->getName(), JumpCondition::IF_EQUAL));
+        instructions.push_back(std::make_unique<Jump>(expression.getTruthyLabel(store_)->getName(), JumpCondition::IF_EQUAL));
         instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
-        instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName()));
-        instructions.push_back(std::make_unique<Label>(expression.getTruthyLabel()->getName()));
+        instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel(store_)->getName()));
+        instructions.push_back(std::make_unique<Label>(expression.getTruthyLabel(store_)->getName()));
         instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
-        instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
+        instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel(store_)->getName()));
         break;
     default:
         throw std::runtime_error { "Unidentified unary operator: " + expression.getOperator()->getLexeme() };
@@ -424,7 +424,7 @@ void CodeGeneratingVisitor::visit(ast::ComparisonExpression& expression) {
 
     instructions.push_back(std::make_unique<ValueCompare>(expression.leftOperandSymbol(store_)->getName(), expression.rightOperandSymbol(store_)->getName()));
 
-    auto truthyLabel = expression.getTruthyLabel()->getName();
+    auto truthyLabel = expression.getTruthyLabel(store_)->getName();
     if (expression.getOperator()->getLexeme() == ">") {
         instructions.push_back(std::make_unique<Jump>(truthyLabel, JumpCondition::IF_ABOVE));
     } else if (expression.getOperator()->getLexeme() == "<") {
@@ -442,10 +442,10 @@ void CodeGeneratingVisitor::visit(ast::ComparisonExpression& expression) {
     }
 
     instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName()));
+    instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel(store_)->getName()));
     instructions.push_back(std::make_unique<Label>(truthyLabel));
     instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::BitwiseExpression& expression) {
@@ -475,15 +475,15 @@ void CodeGeneratingVisitor::visit(ast::LogicalAndExpression& expression) {
 
     instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<ZeroCompare>(expression.leftOperandSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel(store_)->getName(), JumpCondition::IF_EQUAL));
 
     expression.visitRightOperand(*this);
 
     instructions.push_back(std::make_unique<ZeroCompare>(expression.rightOperandSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel(store_)->getName(), JumpCondition::IF_EQUAL));
     instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
 
-    instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(expression.getExitLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::LogicalOrExpression& expression) {
@@ -491,33 +491,33 @@ void CodeGeneratingVisitor::visit(ast::LogicalOrExpression& expression) {
 
     instructions.push_back(std::make_unique<AssignConstant>("1", expression.getResultSymbol(store_)->getName()));
     instructions.push_back(std::make_unique<ZeroCompare>(expression.leftOperandSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_NOT_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel(store_)->getName(), JumpCondition::IF_NOT_EQUAL));
 
     expression.visitRightOperand(*this);
 
     instructions.push_back(std::make_unique<ZeroCompare>(expression.rightOperandSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName(), JumpCondition::IF_NOT_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel(store_)->getName(), JumpCondition::IF_NOT_EQUAL));
     instructions.push_back(std::make_unique<AssignConstant>("0", expression.getResultSymbol(store_)->getName()));
 
-    instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(expression.getExitLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::ConditionalExpression& expression) {
     expression.visitCondition(*this);
     instructions.push_back(std::make_unique<ZeroCompare>(expression.conditionSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(expression.getFalsyLabel(store_)->getName(), JumpCondition::IF_EQUAL));
 
     expression.visitTrueExpression(*this);
     instructions.push_back(std::make_unique<Assign>(
             expression.trueSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel()->getName()));
+    instructions.push_back(std::make_unique<Jump>(expression.getExitLabel(store_)->getName()));
 
-    instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(expression.getFalsyLabel(store_)->getName()));
     expression.visitFalseExpression(*this);
     instructions.push_back(std::make_unique<Assign>(
             expression.falseSymbol(store_)->getName(), expression.getResultSymbol(store_)->getName()));
 
-    instructions.push_back(std::make_unique<Label>(expression.getExitLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(expression.getExitLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::AssignmentExpression& expression) {
@@ -623,10 +623,10 @@ void CodeGeneratingVisitor::visit(ast::Operator&) {
 }
 
 void CodeGeneratingVisitor::visit(ast::JumpStatement& statement) {
-    if (!statement.getJumpTo()) {
+    if (!statement.getJumpTo(store_)) {
         throw std::runtime_error { "JumpStatement has no target label" };
     }
-    instructions.push_back(std::make_unique<Jump>(statement.getJumpTo()->getName()));
+    instructions.push_back(std::make_unique<Jump>(statement.getJumpTo(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::SwitchStatement& statement) {
@@ -639,41 +639,41 @@ void CodeGeneratingVisitor::visit(ast::SwitchStatement& statement) {
         instructions.push_back(std::make_unique<AssignConstant>(
                 std::to_string(caseLabel->getCaseValue()), caseTemp));
         instructions.push_back(std::make_unique<ValueCompare>(switchResult, caseTemp));
-        instructions.push_back(std::make_unique<Jump>(caseLabel->getLabel()->getName(), JumpCondition::IF_EQUAL));
+        instructions.push_back(std::make_unique<Jump>(caseLabel->getLabel(store_)->getName(), JumpCondition::IF_EQUAL));
     }
 
     if (statement.getDefaultLabel()) {
-        instructions.push_back(std::make_unique<Jump>(statement.getDefaultLabel()->getLabel()->getName()));
+        instructions.push_back(std::make_unique<Jump>(statement.getDefaultLabel()->getLabel(store_)->getName()));
     } else {
-        instructions.push_back(std::make_unique<Jump>(statement.getExitLabel()->getName()));
+        instructions.push_back(std::make_unique<Jump>(statement.getExitLabel(store_)->getName()));
     }
 
     statement.body->accept(*this);
-    instructions.push_back(std::make_unique<Label>(statement.getExitLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getExitLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::CaseLabel& statement) {
-    instructions.push_back(std::make_unique<Label>(statement.getLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getLabel(store_)->getName()));
     statement.statement->accept(*this);
 }
 
 void CodeGeneratingVisitor::visit(ast::DefaultLabel& statement) {
-    instructions.push_back(std::make_unique<Label>(statement.getLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getLabel(store_)->getName()));
     statement.statement->accept(*this);
 }
 
 void CodeGeneratingVisitor::visit(ast::GotoStatement& statement) {
-    if (!statement.getTarget()) {
+    if (!statement.getTarget(store_)) {
         throw std::runtime_error { "GotoStatement has no target label" };
     }
-    instructions.push_back(std::make_unique<Jump>(statement.getTarget()->getName()));
+    instructions.push_back(std::make_unique<Jump>(statement.getTarget(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::LabeledStatement& statement) {
-    if (!statement.getLabel()) {
+    if (!statement.getLabel(store_)) {
         throw std::runtime_error { "LabeledStatement has no label" };
     }
-    instructions.push_back(std::make_unique<Label>(statement.getLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getLabel(store_)->getName()));
     statement.statement->accept(*this);
 }
 
@@ -688,51 +688,51 @@ void CodeGeneratingVisitor::visit(ast::IfStatement& statement) {
     statement.testExpression->accept(*this);
 
     instructions.push_back(std::make_unique<ZeroCompare>(statement.testExpression->getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(statement.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(statement.getFalsyLabel(store_)->getName(), JumpCondition::IF_EQUAL));
 
     statement.body->accept(*this);
 
-    instructions.push_back(std::make_unique<Label>(statement.getFalsyLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getFalsyLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::IfElseStatement& statement) {
     statement.testExpression->accept(*this);
 
     instructions.push_back(std::make_unique<ZeroCompare>(statement.testExpression->getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(statement.getFalsyLabel()->getName(), JumpCondition::IF_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(statement.getFalsyLabel(store_)->getName(), JumpCondition::IF_EQUAL));
 
     statement.truthyBody->accept(*this);
-    instructions.push_back(std::make_unique<Jump>(statement.getExitLabel()->getName()));
-    instructions.push_back(std::make_unique<Label>(statement.getFalsyLabel()->getName()));
+    instructions.push_back(std::make_unique<Jump>(statement.getExitLabel(store_)->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getFalsyLabel(store_)->getName()));
 
     statement.falsyBody->accept(*this);
-    instructions.push_back(std::make_unique<Label>(statement.getExitLabel()->getName()));
+    instructions.push_back(std::make_unique<Label>(statement.getExitLabel(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::LoopStatement& loop) {
     if (loop.header->bodyBeforeTest()) {
         // do { body } while (cond); — header visit emits the trailing test + branch.
-        instructions.push_back(std::make_unique<Label>(loop.header->getLoopEntry()->getName()));
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopEntry(store_)->getName()));
         loop.body->accept(*this);
-        instructions.push_back(std::make_unique<Label>(loop.header->getLoopContinue()->getName()));
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopContinue(store_)->getName()));
         loop.header->accept(*this);
-        instructions.push_back(std::make_unique<Label>(loop.header->getLoopExit()->getName()));
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopExit(store_)->getName()));
         return;
     }
 
     loop.header->accept(*this);
     loop.body->accept(*this);
     // continue target: for-loops place a label before the increment; while reuses entry.
-    if (loop.header->getLoopContinue()
-            && loop.header->getLoopContinue()->getName() != loop.header->getLoopEntry()->getName()) {
-        instructions.push_back(std::make_unique<Label>(loop.header->getLoopContinue()->getName()));
+    if (loop.header->getLoopContinue(store_)
+            && loop.header->getLoopContinue(store_)->getName() != loop.header->getLoopEntry(store_)->getName()) {
+        instructions.push_back(std::make_unique<Label>(loop.header->getLoopContinue(store_)->getName()));
     }
     if (loop.header->increment) {
         loop.header->increment->accept(*this);
     }
 
-    instructions.push_back(std::make_unique<Jump>(loop.header->getLoopEntry()->getName()));
-    instructions.push_back(std::make_unique<Label>(loop.header->getLoopExit()->getName()));
+    instructions.push_back(std::make_unique<Jump>(loop.header->getLoopEntry(store_)->getName()));
+    instructions.push_back(std::make_unique<Label>(loop.header->getLoopExit(store_)->getName()));
 }
 
 void CodeGeneratingVisitor::visit(ast::ForLoopHeader& loopHeader) {
@@ -740,26 +740,26 @@ void CodeGeneratingVisitor::visit(ast::ForLoopHeader& loopHeader) {
         loopHeader.initialization->accept(*this);
     }
 
-    instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry()->getName()));
+    instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry(store_)->getName()));
     if (loopHeader.clause) {
         loopHeader.clause->accept(*this);
         instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol(store_)->getName()));
-        instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
+        instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit(store_)->getName(), JumpCondition::IF_EQUAL));
     }
 }
 
 void CodeGeneratingVisitor::visit(ast::WhileLoopHeader& loopHeader) {
-    instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry()->getName()));
+    instructions.push_back(std::make_unique<Label>(loopHeader.getLoopEntry(store_)->getName()));
     loopHeader.clause->accept(*this);
     instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit()->getName(), JumpCondition::IF_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopExit(store_)->getName(), JumpCondition::IF_EQUAL));
 }
 
 void CodeGeneratingVisitor::visit(ast::DoWhileLoopHeader& loopHeader) {
     // Invoked after the body and continue label (see visit(LoopStatement)).
     loopHeader.clause->accept(*this);
     instructions.push_back(std::make_unique<ZeroCompare>(loopHeader.clause->getResultSymbol(store_)->getName()));
-    instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopEntry()->getName(), JumpCondition::IF_NOT_EQUAL));
+    instructions.push_back(std::make_unique<Jump>(loopHeader.getLoopEntry(store_)->getName(), JumpCondition::IF_NOT_EQUAL));
 }
 
 void CodeGeneratingVisitor::visit(ast::Pointer&) {

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -64,15 +64,16 @@ void CodeGeneratingVisitor::visit(ast::Declarator& declarator) {
 }
 
 void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
+    auto* holder = declarator.getHolder(store_);
     // File-scope variables are initialized in .data; skip children (would emit assigns with no procedure).
-    if (declarator.hasInitializer() && declarator.getHolder(store_)->isGlobal()) {
+    if (declarator.hasInitializer() && holder && holder->isGlobal()) {
         return;
     }
     declarator.visitChildren(*this);
     if (!declarator.hasInitializer()) {
         return;
     }
-    auto* holder = declarator.getHolder(store_);
+    assert(holder && "InitializedDeclarator holder required after successful SA");
     const auto& fieldStores = store_.structFieldInits(&declarator);
     if (!fieldStores.empty()) {
         for (const auto& field : fieldStores) {
@@ -162,11 +163,12 @@ void CodeGeneratingVisitor::visit(ast::FunctionCall& functionCall) {
 }
 
 void CodeGeneratingVisitor::visit(ast::IdentifierExpression& identifier) {
-    // Function designators always carry FunctionDesignatorPlan from SA (label + temp).
+    // Function designators: plan holds the label; Result is the address temp.
     if (const auto* plan = store_.addressPlan(&identifier)) {
         if (const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(plan)) {
+            assert(identifier.hasResultSymbol(store_) && "designator Result required for FunctionAddress");
             instructions.push_back(std::make_unique<FunctionAddress>(
-                    d->functionName, d->addressTempName));
+                    d->functionName, identifier.getResultSymbol(store_)->getName()));
             return;
         }
     }
@@ -199,8 +201,10 @@ int incDecStepBytes(const type::Type& valueType) {
 void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
     expression.visitOperand(*this);
 
+    auto* pre = expression.getPreOperationSymbol(store_);
+    assert(pre && "Postfix PreOperation required after successful SA");
     auto resultSymbolName = expression.getResultSymbol(store_)->getName();
-    auto preOperationSymbol = expression.getPreOperationSymbol(store_)->getName();
+    auto preOperationSymbol = pre->getName();
     instructions.push_back(std::make_unique<Assign>(resultSymbolName, preOperationSymbol));
 
     const int step = incDecStepBytes(expression.getResultSymbol(store_)->getType());
@@ -215,7 +219,7 @@ void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
         instructions.push_back(std::make_unique<LvalueAssign>(resultSymbolName, lvalue->getName()));
     }
 
-    expression.setResultSymbol(store_, *expression.getPreOperationSymbol(store_));
+    expression.setResultSymbol(store_, *pre);
 }
 
 void CodeGeneratingVisitor::visit(ast::PrefixExpression& expression) {

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -65,14 +65,14 @@ void CodeGeneratingVisitor::visit(ast::Declarator& declarator) {
 
 void CodeGeneratingVisitor::visit(ast::InitializedDeclarator& declarator) {
     // File-scope variables are initialized in .data; skip children (would emit assigns with no procedure).
-    if (declarator.hasInitializer() && declarator.getHolder()->isGlobal()) {
+    if (declarator.hasInitializer() && declarator.getHolder(store_)->isGlobal()) {
         return;
     }
     declarator.visitChildren(*this);
     if (!declarator.hasInitializer()) {
         return;
     }
-    auto* holder = declarator.getHolder();
+    auto* holder = declarator.getHolder(store_);
     const auto& fieldStores = store_.structFieldInits(&declarator);
     if (!fieldStores.empty()) {
         for (const auto& field : fieldStores) {
@@ -105,7 +105,7 @@ void CodeGeneratingVisitor::visit(ast::ArrayAccess& arrayAccess) {
     instructions.push_back(std::make_unique<IndexAddress>(
             arrayAccess.leftOperandSymbol(store_)->getName(),
             arrayAccess.rightOperandSymbol(store_)->getName(),
-            arrayAccess.getElementSize(),
+            index->elementSize,
             arrayAccess.getLvalueSymbol(store_)->getName(),
             index->baseMode));
     if (!arrayAccess.holdsAggregateAddress()) {
@@ -129,9 +129,7 @@ void CodeGeneratingVisitor::visit(ast::MemberAccess& memberAccess) {
     const auto* plan = store_.addressPlan(&memberAccess);
     const auto* field = plan ? symbols::get_if<symbols::FieldPlan>(plan) : nullptr;
     assert(field && "FieldPlan required for member access codegen");
-    const std::string addrTemp = !field->addressTempName.empty()
-            ? field->addressTempName
-            : memberAccess.getLvalueSymbol(store_)->getName();
+    const std::string addrTemp = memberAccess.getLvalueSymbol(store_)->getName();
     instructions.push_back(std::make_unique<FieldAddress>(
             memberAccess.getBase()->getResultSymbol(store_)->getName(),
             field->fieldOffsetBytes,
@@ -202,7 +200,7 @@ void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
     expression.visitOperand(*this);
 
     auto resultSymbolName = expression.getResultSymbol(store_)->getName();
-    auto preOperationSymbol = expression.getPreOperationSymbol()->getName();
+    auto preOperationSymbol = expression.getPreOperationSymbol(store_)->getName();
     instructions.push_back(std::make_unique<Assign>(resultSymbolName, preOperationSymbol));
 
     const int step = incDecStepBytes(expression.getResultSymbol(store_)->getType());
@@ -217,7 +215,7 @@ void CodeGeneratingVisitor::visit(ast::PostfixExpression& expression) {
         instructions.push_back(std::make_unique<LvalueAssign>(resultSymbolName, lvalue->getName()));
     }
 
-    expression.setResultSymbol(store_, *expression.getPreOperationSymbol());
+    expression.setResultSymbol(store_, *expression.getPreOperationSymbol(store_));
 }
 
 void CodeGeneratingVisitor::visit(ast::PrefixExpression& expression) {

--- a/src/driver/CMakeLists.txt
+++ b/src/driver/CMakeLists.txt
@@ -1,4 +1,8 @@
 add_library(driver
+        LoggingSyntaxTreeVisitor.cpp
+        LoggingSyntaxTreeVisitor.h
+        VerboseSyntaxTreeBuilder.cpp
+        VerboseSyntaxTreeBuilder.h
         Compiler.cpp
         CompilerComponentsFactory.cpp
         ConfigurationParser.cpp
@@ -11,4 +15,4 @@ add_library(driver
         Driver.h)
 
 trans_target_defaults(driver)
-target_link_libraries(driver PUBLIC ast backend util)
+target_link_libraries(driver PUBLIC ast backend util semantic_analyzer)

--- a/src/driver/CompilerComponentsFactory.cpp
+++ b/src/driver/CompilerComponentsFactory.cpp
@@ -1,7 +1,7 @@
 #include "CompilerComponentsFactory.h"
 
 #include "ast/AbstractSyntaxTreeBuilder.h"
-#include "ast/VerboseSyntaxTreeBuilder.h"
+#include "VerboseSyntaxTreeBuilder.h"
 #include "parser/BNFFileReader.h"
 #include "parser/FilePersistedParsingTable.h"
 #include "parser/GeneratedParsingTable.h"

--- a/src/driver/CompilerComponentsFactory.cpp
+++ b/src/driver/CompilerComponentsFactory.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<parser::SyntaxTreeBuilder> CompilerComponentsFactory::makeSyntax
         return std::make_unique<parser::ParseTreeBuilder>(sourceFileName, grammar);
     }
     if (configuration.isSyntaxTreeLoggingEnabled()) {
-        return std::make_unique<ast::VerboseSyntaxTreeBuilder>(sourceFileName, grammar);
+        return std::make_unique<driver::VerboseSyntaxTreeBuilder>(sourceFileName, grammar);
     }
     return std::make_unique<ast::AbstractSyntaxTreeBuilder>(grammar);
 }

--- a/src/driver/LoggingSyntaxTreeVisitor.cpp
+++ b/src/driver/LoggingSyntaxTreeVisitor.cpp
@@ -1,7 +1,7 @@
 #include "LoggingSyntaxTreeVisitor.h"
 #include "parser/ParseTreeToSourceConverter.h"
 #include "parser/XmlOutputVisitor.h"
-#include "AbstractSyntaxTree.h"
+#include "ast/AbstractSyntaxTree.h"
 #include "semantic_analyzer/SemanticXmlOutputVisitor.h"
 
 #include <fstream>

--- a/src/driver/LoggingSyntaxTreeVisitor.cpp
+++ b/src/driver/LoggingSyntaxTreeVisitor.cpp
@@ -6,7 +6,7 @@
 
 #include <fstream>
 
-namespace ast {
+namespace driver {
 
 LoggingSyntaxTreeVisitor::LoggingSyntaxTreeVisitor(std::string sourceFileName):
     sourceFileName{sourceFileName}
@@ -14,7 +14,7 @@ LoggingSyntaxTreeVisitor::LoggingSyntaxTreeVisitor(std::string sourceFileName):
 
 LoggingSyntaxTreeVisitor::~LoggingSyntaxTreeVisitor() = default;
 
-void LoggingSyntaxTreeVisitor::visit(AbstractSyntaxTree& ast) {
+void LoggingSyntaxTreeVisitor::visit(ast::AbstractSyntaxTree& ast) {
     std::ofstream xmlStream { sourceFileName + ".semantic.tree.xml" };
     semantic_analyzer::SemanticXmlOutputVisitor toXml { &xmlStream };
     ast.accept(toXml);
@@ -30,5 +30,5 @@ void LoggingSyntaxTreeVisitor::visit(parser::ParseTree& parseTree) {
     parseTree.accept(toSource);
 }
 
-} // namespace ast
+} // namespace driver
 

--- a/src/driver/LoggingSyntaxTreeVisitor.h
+++ b/src/driver/LoggingSyntaxTreeVisitor.h
@@ -7,20 +7,20 @@
 
 #include <string>
 
-namespace ast {
+namespace driver {
 
 class LoggingSyntaxTreeVisitor : public parser::SyntaxTreeVisitor {
   public:
     LoggingSyntaxTreeVisitor(std::string sourceFileName);
     virtual ~LoggingSyntaxTreeVisitor();
 
-    virtual void visit(AbstractSyntaxTree& ast);
+    virtual void visit(ast::AbstractSyntaxTree& ast);
     virtual void visit(parser::ParseTree& parseTree);
 
   private:
     std::string sourceFileName;
 };
 
-} // namespace ast
+} // namespace driver
 
 #endif // _LOGGING_SYNTAX_TREE_VISITOR

--- a/src/driver/LoggingSyntaxTreeVisitor.h
+++ b/src/driver/LoggingSyntaxTreeVisitor.h
@@ -3,7 +3,7 @@
 
 #include "parser/SyntaxTreeVisitor.h"
 #include "parser/ParseTree.h"
-#include "AbstractSyntaxTree.h"
+#include "ast/AbstractSyntaxTree.h"
 
 #include <string>
 

--- a/src/driver/VerboseSyntaxTreeBuilder.cpp
+++ b/src/driver/VerboseSyntaxTreeBuilder.cpp
@@ -1,5 +1,5 @@
 #include "VerboseSyntaxTreeBuilder.h"
-#include "ast/LoggingSyntaxTreeVisitor.h"
+#include "LoggingSyntaxTreeVisitor.h"
 #include "parser/XmlOutputVisitor.h"
 
 #include <fstream>

--- a/src/driver/VerboseSyntaxTreeBuilder.cpp
+++ b/src/driver/VerboseSyntaxTreeBuilder.cpp
@@ -4,7 +4,7 @@
 
 #include <fstream>
 
-namespace ast {
+namespace driver {
 
 VerboseSyntaxTreeBuilder::VerboseSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar):
     astBuilder {grammar},
@@ -34,5 +34,5 @@ std::unique_ptr<parser::SyntaxTree> VerboseSyntaxTreeBuilder::build() {
     return ast;
 }
 
-} // namespace ast
+} // namespace driver
 

--- a/src/driver/VerboseSyntaxTreeBuilder.h
+++ b/src/driver/VerboseSyntaxTreeBuilder.h
@@ -5,7 +5,7 @@
 #include <string>
 
 #include "ast/AbstractSyntaxTreeBuilder.h"
-#include "ast/LoggingSyntaxTreeVisitor.h"
+#include "LoggingSyntaxTreeVisitor.h"
 
 namespace ast {
 

--- a/src/driver/VerboseSyntaxTreeBuilder.h
+++ b/src/driver/VerboseSyntaxTreeBuilder.h
@@ -7,7 +7,7 @@
 #include "ast/AbstractSyntaxTreeBuilder.h"
 #include "LoggingSyntaxTreeVisitor.h"
 
-namespace ast {
+namespace driver {
 
 class VerboseSyntaxTreeBuilder : public parser::SyntaxTreeBuilder {
 public:
@@ -20,12 +20,12 @@ public:
     std::unique_ptr<parser::SyntaxTree> build() override;
 
 private:
-    AbstractSyntaxTreeBuilder astBuilder;
+    ast::AbstractSyntaxTreeBuilder astBuilder;
     parser::ParseTreeBuilder parseTreeBuilder;
     std::string sourceFileName;
     LoggingSyntaxTreeVisitor loggingVisitor;
 };
 
-} // namespace ast
+} // namespace driver
 
 #endif // _VERBOSE_SYNTAX_TREE_BUILDER_H_

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -190,7 +190,7 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
             semanticError("label `" + gotoStmt->getLabelName() + "` used but not defined",
                     gotoStmt->label.context);
         } else {
-            gotoStmt->setTarget(it->second);
+            gotoStmt->setTarget(annotations(), it->second);
         }
     }
     namedLabels.clear();

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -69,13 +69,13 @@ void SemanticAnalysisVisitor::analyzeInitializedDeclarator(ast::InitializedDecla
     if (typeOk) {
         if (type.isVoid()) {
             semanticError("variable `" + declarator.getName() + "` declared void", declarator.getContext());
-        } else if (type.isIncompleteStructure()) {
+        } else if (type.isIncompleteRecord()) {
             semanticError("variable `" + declarator.getName() + "` has incomplete type", declarator.getContext());
         } else if (symbolTable.isAtFileScope() && symbolTable.hasFunction(declarator.getName())) {
             semanticError("symbol `" + declarator.getName() + "` declaration conflicts with function of the same name",
                     declarator.getContext());
         } else if (symbolTable.insertSymbol(declarator.getName(), type, declarator.getContext())) {
-            declarator.setHolder(symbolTable.lookup(declarator.getName()));
+            declarator.setHolder(annotations(), symbolTable.lookup(declarator.getName()));
             inserted = true;
         } else {
             semanticError(

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -17,7 +17,6 @@ void setFunctionDesignator(ast::IdentifierExpression& identifier, SymbolTable& s
     identifier.setFunctionDesignatorResult(store, addr);
     symbols::FunctionDesignatorPlan plan;
     plan.functionName = functionEntry.getName();
-    plan.addressTempName = addr.getName();
     store.setAddressPlan(&identifier, symbols::AddressPlan { plan });
     // form ⇒ plan: designator form is never set without a store plan.
     assert(identifier.holdsFunctionDesignator());

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Calls.cpp
@@ -36,7 +36,8 @@ std::optional<Callee> resolveCallee(ast::FunctionCall& functionCall, SymbolTable
     type::Type operandType = operandSym->getType();
     auto* operandExpr = functionCall.getOperandExpression();
 
-    // Designator identity lives on the store plan (label + temp). Form is the cheap tag.
+    // Designator label lives on FunctionDesignatorPlan; address temp is Result.
+    // Form is the cheap tag.
     if (operandExpr->holdsFunctionDesignator()) {
         const auto* addrPlan = store.addressPlan(operandExpr);
         const auto* d = symbols::get_if<symbols::FunctionDesignatorPlan>(addrPlan);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -36,12 +36,12 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
                 ? type::pointer(elementType.getElementType())
                 : type::pointer(elementType);
         auto addr = symbolTable.createTemporarySymbol(addrType);
-        arrayAccess.setLvalue(addr);
+        arrayAccess.setLvalue(annotations(), addr);
         arrayAccess.setAggregateAddressResult(annotations(), addr, elementType);
         indexPlan.addressTempName = addr.getName();
     } else {
         auto addr = symbolTable.createTemporarySymbol(type::pointer(elementType));
-        arrayAccess.setLvalue(addr);
+        arrayAccess.setLvalue(annotations(), addr);
         arrayAccess.setTypeAndResult(annotations(), symbolTable.createTemporarySymbol(elementType));
         indexPlan.addressTempName = addr.getName();
     }
@@ -84,7 +84,7 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
         return;
     }
     auto fieldAddr = symbolTable.createTemporarySymbol(type::pointer(memberType));
-    memberAccess.setFieldAddressSymbol(fieldAddr);
+    memberAccess.setFieldAddressSymbol(annotations(), fieldAddr);
     symbols::FieldPlan fieldPlan;
     fieldPlan.baseExpr = memberAccess.getBase();
     fieldPlan.fieldOffsetBytes = offset;
@@ -205,11 +205,11 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             } else if (pointee.isArray()) {
                 // *ptr-to-array yields the array object (address); do not scalar-load the row.
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(pointee.getElementType()));
-                expression.setLvalueSymbol(addr);
+                expression.setLvalueSymbol(annotations(), addr);
                 expression.setAggregateAddressResult(annotations(), addr, pointee);
             } else {
                 expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(pointee));
-                expression.setLvalueSymbol(symbolTable.createTemporarySymbol(valueType));
+                expression.setLvalueSymbol(annotations(), symbolTable.createTemporarySymbol(valueType));
             }
             break;
         }
@@ -219,11 +219,11 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
             if (elem.isArray()) {
                 // *a for multi-dim: yield decayed address of first row; keep array expr type.
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(elem.getElementType()));
-                expression.setLvalueSymbol(addr);
+                expression.setLvalueSymbol(annotations(), addr);
                 expression.setAggregateAddressResult(annotations(), addr, elem);
             } else {
                 auto addr = symbolTable.createTemporarySymbol(type::pointer(elem));
-                expression.setLvalueSymbol(addr);
+                expression.setLvalueSymbol(annotations(), addr);
                 expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(elem));
                 expression.setType(elem);
             }
@@ -247,8 +247,8 @@ void SemanticAnalysisVisitor::visit(ast::UnaryExpression& expression) {
     case '!':
         rejectFunctionValue(expression.operandType(), expression.getContext());
         expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
-        expression.setTruthyLabel(symbolTable.newLabel());
-        expression.setFalsyLabel(symbolTable.newLabel());
+        expression.setTruthyLabel(annotations(), symbolTable.newLabel());
+        expression.setFalsyLabel(annotations(), symbolTable.newLabel());
         break;
     default:
         throw std::runtime_error { "Unidentified unary operator: " + expression.getOperator()->getLexeme() };
@@ -336,8 +336,8 @@ void SemanticAnalysisVisitor::visit(ast::ComparisonExpression& expression) {
             expression.getContext());
 
     expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
-    expression.setTruthyLabel(symbolTable.newLabel());
-    expression.setFalsyLabel(symbolTable.newLabel());
+    expression.setTruthyLabel(annotations(), symbolTable.newLabel());
+    expression.setFalsyLabel(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::BitwiseExpression& expression) {
@@ -374,7 +374,7 @@ void SemanticAnalysisVisitor::visit(ast::LogicalAndExpression& expression) {
             expression.getContext());
 
     expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
-    expression.setExitLabel(symbolTable.newLabel());
+    expression.setExitLabel(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::LogicalOrExpression& expression) {
@@ -392,7 +392,7 @@ void SemanticAnalysisVisitor::visit(ast::LogicalOrExpression& expression) {
             expression.getContext());
 
     expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
-    expression.setExitLabel(symbolTable.newLabel());
+    expression.setExitLabel(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::ConditionalExpression& expression) {
@@ -419,8 +419,8 @@ void SemanticAnalysisVisitor::visit(ast::ConditionalExpression& expression) {
     const type::Type resultType = expression.trueSymbol(annotations())->getType();
     expression.setType(resultType);
     expression.setResultSymbol(annotations(), symbolTable.createTemporarySymbol(resultType));
-    expression.setFalsyLabel(symbolTable.newLabel());
-    expression.setExitLabel(symbolTable.newLabel());
+    expression.setFalsyLabel(annotations(), symbolTable.newLabel());
+    expression.setExitLabel(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::AssignmentExpression& expression) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -37,12 +37,10 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
         auto addr = symbolTable.createTemporarySymbol(addrType);
         arrayAccess.setLvalueSymbol(annotations(), addr);
         arrayAccess.setAggregateAddressResult(annotations(), addr, elementType);
-        indexPlan.addressTempName = addr.getName();
     } else {
         auto addr = symbolTable.createTemporarySymbol(type::pointer(elementType));
         arrayAccess.setLvalueSymbol(annotations(), addr);
         arrayAccess.setTypeAndResult(annotations(), symbolTable.createTemporarySymbol(elementType));
-        indexPlan.addressTempName = addr.getName();
     }
     annotations().setAddressPlan(&arrayAccess, symbols::AddressPlan { indexPlan });
 }
@@ -89,7 +87,6 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
     fieldPlan.fieldOffsetBytes = offset;
     fieldPlan.baseMode = base.addressIsPointer ? symbols::AddressBaseMode::PointerValue
                                                : symbols::AddressBaseMode::LeaObject;
-    fieldPlan.addressTempName = fieldAddr.getName();
     annotations().setAddressPlan(&memberAccess, symbols::AddressPlan { fieldPlan });
     if (memberType.isStructure() || memberType.isArray()) {
         memberAccess.setAggregateAddressResult(annotations(), fieldAddr, memberType);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -21,7 +21,6 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
         return;
     }
 
-    arrayAccess.setElementSize(sub.elementStride);
     type::Type elementType = sub.elementType;
 
     symbols::IndexPlan indexPlan;
@@ -122,7 +121,7 @@ void SemanticAnalysisVisitor::visit(ast::PostfixExpression& expression) {
 
     auto preOperationSymbolName = operandSymbol.getName() + "_pre";
     symbolTable.insertSymbol(preOperationSymbolName, operandSymbol.getType(), operandSymbol.getContext());
-    expression.setPreOperationSymbol(symbolTable.lookup(preOperationSymbolName));
+    expression.setPreOperationSymbol(annotations(), symbolTable.lookup(preOperationSymbolName));
 
     if (!expression.isLval()) {
         semanticError("lvalue required as increment operand", expression.getContext());

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -36,12 +36,12 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
                 ? type::pointer(elementType.getElementType())
                 : type::pointer(elementType);
         auto addr = symbolTable.createTemporarySymbol(addrType);
-        arrayAccess.setLvalue(annotations(), addr);
+        arrayAccess.setLvalueSymbol(annotations(), addr);
         arrayAccess.setAggregateAddressResult(annotations(), addr, elementType);
         indexPlan.addressTempName = addr.getName();
     } else {
         auto addr = symbolTable.createTemporarySymbol(type::pointer(elementType));
-        arrayAccess.setLvalue(annotations(), addr);
+        arrayAccess.setLvalueSymbol(annotations(), addr);
         arrayAccess.setTypeAndResult(annotations(), symbolTable.createTemporarySymbol(elementType));
         indexPlan.addressTempName = addr.getName();
     }
@@ -84,7 +84,7 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
         return;
     }
     auto fieldAddr = symbolTable.createTemporarySymbol(type::pointer(memberType));
-    memberAccess.setFieldAddressSymbol(annotations(), fieldAddr);
+    memberAccess.setLvalueSymbol(annotations(), fieldAddr);
     symbols::FieldPlan fieldPlan;
     fieldPlan.baseExpr = memberAccess.getBase();
     fieldPlan.fieldOffsetBytes = offset;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
@@ -31,7 +31,7 @@ void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
 
     auto exitLabel = symbolTable.newLabel();
     statement.setExitLabel(annotations(), exitLabel);
-    statement.setCaseTemp(symbolTable.createTemporarySymbol(type::signedInteger()));
+    statement.setCaseTemp(annotations(), symbolTable.createTemporarySymbol(type::signedInteger()));
 
     LabelEntry* continueLabel = nullptr;
     if (!loopStack.empty()) {

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
@@ -10,13 +10,13 @@ void SemanticAnalysisVisitor::visit(ast::JumpStatement& statement) {
     }
     const auto& loop = loopStack.back();
     if (statement.jumpKeyword.type == "break") {
-        statement.setJumpTo(*loop.exit);
+        statement.setJumpTo(annotations(), *loop.exit);
     } else if (statement.jumpKeyword.type == "continue") {
         if (!loop.cont) {
             semanticError("`continue` statement not in loop", statement.jumpKeyword.context);
             return;
         }
-        statement.setJumpTo(*loop.cont);
+        statement.setJumpTo(annotations(), *loop.cont);
     } else {
         semanticError("unsupported jump statement `" + statement.jumpKeyword.type + "`", statement.jumpKeyword.context);
     }
@@ -30,7 +30,7 @@ void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
     }
 
     auto exitLabel = symbolTable.newLabel();
-    statement.setExitLabel(exitLabel);
+    statement.setExitLabel(annotations(), exitLabel);
     statement.setCaseTemp(symbolTable.createTemporarySymbol(type::signedInteger()));
 
     LabelEntry* continueLabel = nullptr;
@@ -38,7 +38,7 @@ void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
         continueLabel = loopStack.back().cont;
     }
     // break → switch exit; continue only if nested in a loop (cont may be null).
-    loopStack.push_back({ nullptr, continueLabel, statement.getExitLabel() });
+    loopStack.push_back({ nullptr, continueLabel, statement.getExitLabel(annotations()) });
     switchStack.push_back(&statement);
 
     statement.body->accept(*this);
@@ -49,7 +49,7 @@ void SemanticAnalysisVisitor::visit(ast::SwitchStatement& statement) {
 
 void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
     // Always attach a codegen label so the node is well-formed even when illegal.
-    statement.setLabel(symbolTable.newLabel());
+    statement.setLabel(annotations(), symbolTable.newLabel());
 
     if (switchStack.empty()) {
         semanticError("case label not within a switch statement", statement.caseExpression->getContext());
@@ -79,7 +79,7 @@ void SemanticAnalysisVisitor::visit(ast::CaseLabel& statement) {
 
 void SemanticAnalysisVisitor::visit(ast::DefaultLabel& statement) {
     // Always attach a label for codegen, even when the label is illegal / duplicate.
-    statement.setLabel(symbolTable.newLabel());
+    statement.setLabel(annotations(), symbolTable.newLabel());
 
     if (switchStack.empty()) {
         semanticError("default label not within a switch statement", statement.defaultKeyword.context);
@@ -105,7 +105,7 @@ void SemanticAnalysisVisitor::visit(ast::LabeledStatement& statement) {
     // Always attach a codegen label so the statement node is well-formed even when
     // the name is a duplicate (goto targets keep the first definition only).
     auto label = symbolTable.newLabel();
-    statement.setLabel(label);
+    statement.setLabel(annotations(), label);
     if (namedLabels.find(statement.getLabelName()) != namedLabels.end()) {
         semanticError("duplicate label `" + statement.getLabelName() + "`", statement.name.context);
     } else {
@@ -144,7 +144,7 @@ void SemanticAnalysisVisitor::visit(ast::IfStatement& statement) {
     }
     statement.body->accept(*this);
 
-    statement.setFalsyLabel(symbolTable.newLabel());
+    statement.setFalsyLabel(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::IfElseStatement& statement) {
@@ -156,8 +156,8 @@ void SemanticAnalysisVisitor::visit(ast::IfElseStatement& statement) {
     statement.truthyBody->accept(*this);
     statement.falsyBody->accept(*this);
 
-    statement.setFalsyLabel(symbolTable.newLabel());
-    statement.setExitLabel(symbolTable.newLabel());
+    statement.setFalsyLabel(annotations(), symbolTable.newLabel());
+    statement.setExitLabel(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::LoopStatement& loop) {
@@ -169,11 +169,11 @@ void SemanticAnalysisVisitor::visit(ast::LoopStatement& loop) {
     // for-with-increment: continue before increment. while: continue → entry.
     // do-while: header preassigns continue (before the test); leave it alone.
     if (loop.header->increment) {
-        loop.header->setLoopContinue(symbolTable.newLabel());
+        loop.header->setLoopContinue(annotations(), symbolTable.newLabel());
     } else if (loop.header->continueTargetsEntry()) {
-        loop.header->setLoopContinue(*loop.header->getLoopEntry());
+        loop.header->setLoopContinue(annotations(), *loop.header->getLoopEntry(annotations()));
     }
-    loopStack.push_back({ loop.header->getLoopEntry(), loop.header->getLoopContinue(), loop.header->getLoopExit() });
+    loopStack.push_back({ loop.header->getLoopEntry(annotations()), loop.header->getLoopContinue(annotations()), loop.header->getLoopExit(annotations()) });
     loop.body->accept(*this);
     loopStack.pop_back();
     if (declScope) {
@@ -192,24 +192,24 @@ void SemanticAnalysisVisitor::visit(ast::ForLoopHeader& loopHeader) {
         loopHeader.increment->accept(*this);
     }
 
-    loopHeader.setLoopEntry(symbolTable.newLabel());
-    loopHeader.setLoopExit(symbolTable.newLabel());
+    loopHeader.setLoopEntry(annotations(), symbolTable.newLabel());
+    loopHeader.setLoopExit(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::WhileLoopHeader& loopHeader) {
     loopHeader.clause->accept(*this);
 
-    loopHeader.setLoopEntry(symbolTable.newLabel());
-    loopHeader.setLoopExit(symbolTable.newLabel());
+    loopHeader.setLoopEntry(annotations(), symbolTable.newLabel());
+    loopHeader.setLoopExit(annotations(), symbolTable.newLabel());
 }
 
 void SemanticAnalysisVisitor::visit(ast::DoWhileLoopHeader& loopHeader) {
     loopHeader.clause->accept(*this);
 
-    loopHeader.setLoopEntry(symbolTable.newLabel());
+    loopHeader.setLoopEntry(annotations(), symbolTable.newLabel());
     // continue jumps here (re-test), not to the body entry.
-    loopHeader.setLoopContinue(symbolTable.newLabel());
-    loopHeader.setLoopExit(symbolTable.newLabel());
+    loopHeader.setLoopContinue(annotations(), symbolTable.newLabel());
+    loopHeader.setLoopExit(annotations(), symbolTable.newLabel());
 }
 
 

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -68,8 +68,6 @@ struct FieldPlan {
     ExpressionRef baseExpr;
     int fieldOffsetBytes { 0 };
     AddressBaseMode baseMode { AddressBaseMode::LeaObject };
-    // Temp name for the computed field address (SA-allocated).
-    std::string addressTempName;
 };
 
 struct IndexPlan {
@@ -77,7 +75,6 @@ struct IndexPlan {
     ExpressionRef indexExpr;
     int elementSize { 8 };
     AddressBaseMode baseMode { AddressBaseMode::LeaObject };
-    std::string addressTempName;
 };
 
 

--- a/src/symbols/AddressPlan.h
+++ b/src/symbols/AddressPlan.h
@@ -78,9 +78,9 @@ struct IndexPlan {
 };
 
 
+// Address temp is the designator Result symbol on the store (not duplicated here).
 struct FunctionDesignatorPlan {
     std::string functionName;
-    std::string addressTempName;
 };
 
 using AddressPlan = std::variant<FieldPlan, IndexPlan, FunctionDesignatorPlan>;

--- a/src/symbols/AnnotationStore.h
+++ b/src/symbols/AnnotationStore.h
@@ -12,7 +12,7 @@
 #include "ValueEntry.h"
 
 // Side table for SA→CG facts.
-// Result and plans live here. Lvalue/labels: API ready; production migration in Phase 0.5.
+// Result and plans live here. Lvalue and control-flow labels are store-backed (production).
 
 namespace symbols {
 
@@ -39,7 +39,7 @@ public:
     const ValueEntry* result(NodeRef node) const;
     bool hasResult(NodeRef node) const { return hasValue(node, ValueSlot::Result); }
 
-    // Lvalue API ready; SA still writes node fields until Phase 0.5 migration.
+    // Lvalue address temps (arrays, members, *).
     void setLvalue(NodeRef node, ValueEntry value) {
         setValue(node, ValueSlot::Lvalue, std::move(value));
     }

--- a/src/symbols/AnnotationStore.h
+++ b/src/symbols/AnnotationStore.h
@@ -46,6 +46,24 @@ public:
     ValueEntry* lvalue(NodeRef node) { return value(node, ValueSlot::Lvalue); }
     const ValueEntry* lvalue(NodeRef node) const { return value(node, ValueSlot::Lvalue); }
 
+    void setCaseTemp(NodeRef node, ValueEntry value) {
+        setValue(node, ValueSlot::CaseTemp, std::move(value));
+    }
+    ValueEntry* caseTemp(NodeRef node) { return value(node, ValueSlot::CaseTemp); }
+    const ValueEntry* caseTemp(NodeRef node) const { return value(node, ValueSlot::CaseTemp); }
+
+    void setPreOperation(NodeRef node, ValueEntry value) {
+        setValue(node, ValueSlot::PreOperation, std::move(value));
+    }
+    ValueEntry* preOperation(NodeRef node) { return value(node, ValueSlot::PreOperation); }
+    const ValueEntry* preOperation(NodeRef node) const { return value(node, ValueSlot::PreOperation); }
+
+    void setHolder(NodeRef node, ValueEntry value) {
+        setValue(node, ValueSlot::Holder, std::move(value));
+    }
+    ValueEntry* holder(NodeRef node) { return value(node, ValueSlot::Holder); }
+    const ValueEntry* holder(NodeRef node) const { return value(node, ValueSlot::Holder); }
+
     void setLabel(NodeRef node, LabelSlot slot, LabelEntry label);
     LabelEntry* label(NodeRef node, LabelSlot slot);
     const LabelEntry* label(NodeRef node, LabelSlot slot) const;

--- a/src/symbols/AnnotationTypes.h
+++ b/src/symbols/AnnotationTypes.h
@@ -3,7 +3,6 @@
 
 // Shared annotation slot types used by AnnotationStore (SA→CG product).
 // Keep this header free of FunctionEntry / frame types so store TUs stay light.
-// FunctionFrame and extra slots land with the migration that uses them.
 
 namespace symbols {
 
@@ -11,8 +10,12 @@ enum class ValueSlot {
     Result,
     // Production address temp for this expression (members, arrays, *).
     Lvalue,
-    // Switch comparison temp (was on SwitchStatement).
+    // Switch comparison temp.
     CaseTemp,
+    // Postfix ++/-- value before the side effect.
+    PreOperation,
+    // Declarator object symbol (global/local storage).
+    Holder,
 };
 
 enum class LabelSlot {

--- a/src/symbols/AnnotationTypes.h
+++ b/src/symbols/AnnotationTypes.h
@@ -9,8 +9,10 @@ namespace symbols {
 
 enum class ValueSlot {
     Result,
-    // Address temp for this expression (members, arrays, *).
+    // Production address temp for this expression (members, arrays, *).
     Lvalue,
+    // Switch comparison temp (was on SwitchStatement).
+    CaseTemp,
 };
 
 enum class LabelSlot {

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -14,7 +14,7 @@ add_executable(astTest
     astTest/CSNBCreatorsStubTest.cpp
     astTest/ExpressionDualTypeTest.cpp
         )
-target_link_libraries(astTest PRIVATE GTest::gmock_main ast translation_unit)
+target_link_libraries(astTest PRIVATE semantic_analyzer GTest::gmock_main ast translation_unit)
 add_test(NAME astTest COMMAND astTest)
 
 add_executable(parserGeneratorTest

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -173,4 +173,20 @@ TEST(AnnotationStore, labelSlots) {
     EXPECT_EQ(cstore.label(&node, symbols::LabelSlot::Exit)->getName(), "Le");
 }
 
+
+TEST(AnnotationStore, caseTempPreOperationAndHolderSlots) {
+    symbols::AnnotationStore store;
+    int node = 9;
+    translation_unit::Context ctx { "t", 1 };
+    store.setCaseTemp(&node, symbols::ValueEntry("ct", type::signedInteger(), true, ctx, 0));
+    store.setPreOperation(&node, symbols::ValueEntry("pre", type::signedInteger(), true, ctx, 1));
+    store.setHolder(&node, symbols::ValueEntry("hold", type::signedInteger(), false, ctx, 2));
+    ASSERT_NE(store.caseTemp(&node), nullptr);
+    EXPECT_EQ(store.caseTemp(&node)->getName(), "ct");
+    ASSERT_NE(store.preOperation(&node), nullptr);
+    EXPECT_EQ(store.preOperation(&node)->getName(), "pre");
+    ASSERT_NE(store.holder(&node), nullptr);
+    EXPECT_EQ(store.holder(&node)->getName(), "hold");
+}
+
 } // namespace

--- a/test/src/symbolsTest/AnnotationStoreTest.cpp
+++ b/test/src/symbolsTest/AnnotationStoreTest.cpp
@@ -14,7 +14,6 @@ TEST(AnnotationStore, addressPlanRoundTrip) {
     symbols::FieldPlan field;
     field.fieldOffsetBytes = 8;
     field.baseMode = symbols::AddressBaseMode::PointerValue;
-    field.addressTempName = "t0";
     store.setAddressPlan(&node, symbols::AddressPlan { field });
 
     const auto* plan = store.addressPlan(&node);
@@ -24,7 +23,6 @@ TEST(AnnotationStore, addressPlanRoundTrip) {
     EXPECT_EQ(f->fieldOffsetBytes, 8);
     EXPECT_EQ(f->baseMode, symbols::AddressBaseMode::PointerValue);
     EXPECT_TRUE(symbols::addressBaseIsPointerValue(f->baseMode));
-    EXPECT_EQ(f->addressTempName, "t0");
     EXPECT_EQ(store.addressPlan(&node + 1), nullptr);
 }
 
@@ -145,7 +143,6 @@ TEST(AnnotationStore, indexPlanVariant) {
     symbols::IndexPlan idx;
     idx.elementSize = 4;
     idx.baseMode = symbols::AddressBaseMode::LeaObject;
-    idx.addressTempName = "idx";
     store.setAddressPlan(&node, symbols::AddressPlan { idx });
     const auto* plan = store.addressPlan(&node);
     ASSERT_NE(plan, nullptr);


### PR DESCRIPTION
## Summary
- AnnotationStore-backed lvalues and labels; remove ast→SA link.
- Includes post-master multi-decl merge fix for `setHolder`.
- Round-2 through Round-4 annotation residuals.

## Stack
Base: `phase0/04-symbols-leaf` → this PR → `phase0/06-package-graph`

## Test plan
- [ ] SA/annotation tests pass
- [ ] Verify multi-decl path after master rebase remains correct