### PR TITLE
phase1/01: complete integer type-spec matrix

### DIFF
--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -19,6 +19,10 @@ void AbstractSyntaxTreeBuilderContext::pushTypeSpecifier(TypeSpecifier typeSpeci
     typeSpecifiers.push(typeSpecifier);
 }
 
+bool AbstractSyntaxTreeBuilderContext::hasTypeSpecifier() const {
+    return !typeSpecifiers.empty();
+}
+
 TypeSpecifier AbstractSyntaxTreeBuilderContext::popTypeSpecifier() {
     auto typeSpecifier = typeSpecifiers.top();
     typeSpecifiers.pop();

--- a/src/ast/AbstractSyntaxTreeBuilderContext.h
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.h
@@ -31,6 +31,7 @@ public:
     TerminalSymbol popTerminal();
 
     void pushTypeSpecifier(TypeSpecifier typeSpecifier);
+    bool hasTypeSpecifier() const;
     TypeSpecifier popTypeSpecifier();
 
     void pushStorageSpecifier(StorageSpecifier storageSpecifier);

--- a/src/ast/CSNB_Creators.cpp
+++ b/src/ast/CSNB_Creators.cpp
@@ -15,7 +15,7 @@ std::function<void(AbstractSyntaxTreeBuilderContext&)> notImplementedYet(const c
 }
 
 void shortType(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "short type is not implemented yet" };
+    context.pushTypeSpecifier( { type::signedShort(), context.popTerminal().value });
 }
 
 void integerType(AbstractSyntaxTreeBuilderContext& context) {
@@ -23,7 +23,7 @@ void integerType(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void longType(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "long type is not implemented yet" };
+    context.pushTypeSpecifier( { type::signedLong(), context.popTerminal().value });
 }
 
 void characterType(AbstractSyntaxTreeBuilderContext& context) {
@@ -39,15 +39,17 @@ void floatType(AbstractSyntaxTreeBuilderContext& context) {
 }
 
 void doubleType(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "double type is not implemented yet" };
+    // Phase 3: full float/double codegen; front-end accepts the type specifier.
+    context.pushTypeSpecifier( { type::doubleFloating(), context.popTerminal().value });
 }
 
 void signedType(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "signed type is not implemented yet" };
+    // bare `signed` means signed int
+    context.pushTypeSpecifier( { type::signedInteger(), context.popTerminal().value });
 }
 
 void unsignedType(AbstractSyntaxTreeBuilderContext& context) {
-    throw std::runtime_error { "unsigned type is not implemented yet" };
+    context.pushTypeSpecifier( { type::unsignedInteger(), context.popTerminal().value });
 }
 
 void typedefName(AbstractSyntaxTreeBuilderContext& context) {
@@ -97,6 +99,19 @@ void addDeclarationTypeSpecifier(AbstractSyntaxTreeBuilderContext& context) {
     auto declarationSpecifiers = context.popDeclarationSpecifiers();
     auto typeSpecifier = context.popTypeSpecifier();
     context.pushDeclarationSpecifiers( { typeSpecifier, declarationSpecifiers });
+}
+
+// Multi-word type-name pieces (unsigned + long) collapse to one TypeSpecifier.
+void combineSpecQualifierTypeSpecs(AbstractSyntaxTreeBuilderContext& context) {
+    auto left = context.popTypeSpecifier();
+    if (!context.hasTypeSpecifier()) {
+        context.pushTypeSpecifier(left);
+        return;
+    }
+    auto right = context.popTypeSpecifier();
+    DeclarationSpecifiers combined { left, DeclarationSpecifiers { right } };
+    type::Type resolved = combined.getResolvedType();
+    context.pushTypeSpecifier(TypeSpecifier { resolved, left.getName() + " " + right.getName() });
 }
 
 void declarationStorageClassSpecifier(AbstractSyntaxTreeBuilderContext& context) {

--- a/src/ast/CSNB_Internal.h
+++ b/src/ast/CSNB_Internal.h
@@ -81,6 +81,7 @@ void braceInitializer(AbstractSyntaxTreeBuilderContext& context);
 void caseLabel(AbstractSyntaxTreeBuilderContext& context);
 void characterConstant(AbstractSyntaxTreeBuilderContext& context);
 void characterType(AbstractSyntaxTreeBuilderContext& context);
+void combineSpecQualifierTypeSpecs(AbstractSyntaxTreeBuilderContext& context);
 void conditionalExpression(AbstractSyntaxTreeBuilderContext& context);
 void constQualifier(AbstractSyntaxTreeBuilderContext& context);
 void constantExpression(AbstractSyntaxTreeBuilderContext& context);

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -119,10 +119,13 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     // type_specifier already pushed a TypeSpecifier; identity keeps it on the stack.
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier }] = doNothing;
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_specifier, s_spec_qualifier_list }] =
-            notImplementedYet("multi type-specifier type names");
-    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier }] = notImplementedYet("qualified type names");
+            combineSpecQualifierTypeSpecs;
+    // Qualifiers alone in type_name are dropped for this product subset (const/volatile on
+    // sizeof/cast type names are not modeled yet).
+    nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier }] =
+            [](AbstractSyntaxTreeBuilderContext& context) { context.popTypeQualifier(); };
     nodeCreatorRegistry[s_spec_qualifier_list][{ s_type_qualifier, s_spec_qualifier_list }] =
-            notImplementedYet("qualified type names");
+            [](AbstractSyntaxTreeBuilderContext& context) { context.popTypeQualifier(); };
     nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list }] = doNothing;
     nodeCreatorRegistry[s_type_name][{ s_spec_qualifier_list, s_abstract_declarator_sym }] =
             typeNameWithAbstractDeclarator;

--- a/src/ast/DeclarationSpecifiers.cpp
+++ b/src/ast/DeclarationSpecifiers.cpp
@@ -3,6 +3,8 @@
 #include "AbstractSyntaxTreeVisitor.h"
 #include "types/Type.h"
 
+#include <sstream>
+
 namespace ast {
 
 DeclarationSpecifiers::DeclarationSpecifiers(TypeSpecifier typeSpecifier, DeclarationSpecifiers declarationSpecifiers) :
@@ -39,6 +41,53 @@ const std::vector<StorageSpecifier>& DeclarationSpecifiers::getStorageSpecifiers
     return storageSpecifiers;
 }
 
+namespace {
+
+// True when token is a C type-specifier keyword we fold (not a tag/typedef name).
+bool applyKeywordToken(const std::string& tok,
+        bool& hasUnsigned, bool& hasSigned, bool& hasChar, bool& hasShort, bool& hasInt,
+        int& longCount, bool& hasFloat, bool& hasDouble, bool& hasVoid) {
+    if (tok == "unsigned") {
+        hasUnsigned = true;
+        return true;
+    }
+    if (tok == "signed") {
+        hasSigned = true;
+        return true;
+    }
+    if (tok == "char") {
+        hasChar = true;
+        return true;
+    }
+    if (tok == "short") {
+        hasShort = true;
+        return true;
+    }
+    if (tok == "int") {
+        hasInt = true;
+        return true;
+    }
+    if (tok == "long") {
+        ++longCount;
+        return true;
+    }
+    if (tok == "float") {
+        hasFloat = true;
+        return true;
+    }
+    if (tok == "double") {
+        hasDouble = true;
+        return true;
+    }
+    if (tok == "void") {
+        hasVoid = true;
+        return true;
+    }
+    return false;
+}
+
+} // namespace
+
 type::Type DeclarationSpecifiers::getResolvedType() const {
     bool hasUnsigned = false;
     bool hasSigned = false;
@@ -52,62 +101,41 @@ type::Type DeclarationSpecifiers::getResolvedType() const {
     type::Type complexType = type::voidType();
     bool hasComplex = false;
 
+    // Tokenize each TypeSpecifier name so multi-word packages from type_name
+    // combine (e.g. "unsigned int") still contribute bare keywords in any order.
     for (const auto& ts : typeSpecifiers) {
         const std::string& n = ts.getName();
-        if (n == "unsigned") {
-            hasUnsigned = true;
-        } else if (n == "signed") {
-            hasSigned = true;
-        } else if (n == "char") {
-            hasChar = true;
-        } else if (n == "short") {
-            hasShort = true;
-        } else if (n == "int") {
-            hasInt = true;
-        } else if (n == "long") {
-            ++longCount;
-        } else if (n == "float") {
-            hasFloat = true;
-        } else if (n == "double") {
-            hasDouble = true;
-        } else if (n == "void") {
-            hasVoid = true;
-        } else {
-            // typedef / struct / union / enum type_spec - use stored type.
+        if (n.empty()) {
             hasComplex = true;
             complexType = ts.getType();
+            continue;
         }
+        std::istringstream iss { n };
+        std::string tok;
+        bool anyKeyword = false;
+        while (iss >> tok) {
+            if (applyKeywordToken(tok, hasUnsigned, hasSigned, hasChar, hasShort, hasInt, longCount,
+                        hasFloat, hasDouble, hasVoid)) {
+                anyKeyword = true;
+            } else {
+                // Non-keyword token (tag / typedef name / "struct" etc.): use stored Type.
+                hasComplex = true;
+                complexType = ts.getType();
+            }
+        }
+        (void)anyKeyword;
     }
 
-    if (hasComplex) {
-        // Intermediate multi-word packages (e.g. "short int") may arrive as one
-        // TypeSpecifier; outer signedness still applies when the type is integer.
-        if (complexType.isPrimitive() && !complexType.getPrimitive().isFloating()
-                && (hasUnsigned || hasSigned)) {
-            const int sz = complexType.getPrimitive().getSize();
-            if (sz == 1) {
-                hasChar = true;
-            } else if (sz == 2) {
-                hasShort = true;
-            } else if (sz == 4) {
-                hasInt = true;
-            } else if (sz == 8) {
-                if (longCount < 1) {
-                    longCount = 1;
-                }
-            } else {
-                if (!typeQualifiers.empty()) {
-                    return type::primitive(complexType.getPrimitive(), typeQualifiers);
-                }
-                return complexType;
-            }
-        } else {
-            if (!typeQualifiers.empty() && complexType.isPrimitive()) {
-                return type::primitive(complexType.getPrimitive(), typeQualifiers);
-            }
-            return complexType;
+    // Struct/union/enum/typedef without keyword mix: return stored type.
+    if (hasComplex && !hasUnsigned && !hasSigned && !hasChar && !hasShort && !hasInt
+            && longCount == 0 && !hasFloat && !hasDouble && !hasVoid) {
+        if (!typeQualifiers.empty() && complexType.isPrimitive()) {
+            return type::primitive(complexType.getPrimitive(), typeQualifiers);
         }
+        return complexType;
     }
+    // Keyword + complex together (e.g. invalid "unsigned struct S"): prefer keyword path;
+    // full constraint diagnostics deferred.
     if (hasVoid) {
         return type::voidType();
     }
@@ -132,6 +160,7 @@ type::Type DeclarationSpecifiers::getResolvedType() const {
     if (hasSigned || hasInt || typeSpecifiers.empty()) {
         return type::signedInteger(typeQualifiers);
     }
+    // Unknown non-keyword-only list: fall back to first stored type.
     return typeSpecifiers.at(0).getType();
 }
 

--- a/src/ast/DeclarationSpecifiers.cpp
+++ b/src/ast/DeclarationSpecifiers.cpp
@@ -1,6 +1,7 @@
 #include "DeclarationSpecifiers.h"
 
 #include "AbstractSyntaxTreeVisitor.h"
+#include "types/Type.h"
 
 namespace ast {
 
@@ -36,6 +37,102 @@ const std::vector<type::Qualifier>& DeclarationSpecifiers::getTypeQualifiers() c
 
 const std::vector<StorageSpecifier>& DeclarationSpecifiers::getStorageSpecifiers() const {
     return storageSpecifiers;
+}
+
+type::Type DeclarationSpecifiers::getResolvedType() const {
+    bool hasUnsigned = false;
+    bool hasSigned = false;
+    bool hasChar = false;
+    bool hasShort = false;
+    bool hasInt = false;
+    int longCount = 0;
+    bool hasFloat = false;
+    bool hasDouble = false;
+    bool hasVoid = false;
+    type::Type complexType = type::voidType();
+    bool hasComplex = false;
+
+    for (const auto& ts : typeSpecifiers) {
+        const std::string& n = ts.getName();
+        if (n == "unsigned") {
+            hasUnsigned = true;
+        } else if (n == "signed") {
+            hasSigned = true;
+        } else if (n == "char") {
+            hasChar = true;
+        } else if (n == "short") {
+            hasShort = true;
+        } else if (n == "int") {
+            hasInt = true;
+        } else if (n == "long") {
+            ++longCount;
+        } else if (n == "float") {
+            hasFloat = true;
+        } else if (n == "double") {
+            hasDouble = true;
+        } else if (n == "void") {
+            hasVoid = true;
+        } else {
+            // typedef / struct / union / enum type_spec - use stored type.
+            hasComplex = true;
+            complexType = ts.getType();
+        }
+    }
+
+    if (hasComplex) {
+        // Intermediate multi-word packages (e.g. "short int") may arrive as one
+        // TypeSpecifier; outer signedness still applies when the type is integer.
+        if (complexType.isPrimitive() && !complexType.getPrimitive().isFloating()
+                && (hasUnsigned || hasSigned)) {
+            const int sz = complexType.getPrimitive().getSize();
+            if (sz == 1) {
+                hasChar = true;
+            } else if (sz == 2) {
+                hasShort = true;
+            } else if (sz == 4) {
+                hasInt = true;
+            } else if (sz == 8) {
+                if (longCount < 1) {
+                    longCount = 1;
+                }
+            } else {
+                if (!typeQualifiers.empty()) {
+                    return type::primitive(complexType.getPrimitive(), typeQualifiers);
+                }
+                return complexType;
+            }
+        } else {
+            if (!typeQualifiers.empty() && complexType.isPrimitive()) {
+                return type::primitive(complexType.getPrimitive(), typeQualifiers);
+            }
+            return complexType;
+        }
+    }
+    if (hasVoid) {
+        return type::voidType();
+    }
+    if (hasFloat) {
+        return type::floating(typeQualifiers);
+    }
+    if (hasDouble) {
+        return longCount > 0 ? type::longDoubleFloating(typeQualifiers) : type::doubleFloating(typeQualifiers);
+    }
+    if (hasChar) {
+        return hasUnsigned ? type::unsignedCharacter(typeQualifiers) : type::signedCharacter(typeQualifiers);
+    }
+    if (hasShort) {
+        return hasUnsigned ? type::unsignedShort(typeQualifiers) : type::signedShort(typeQualifiers);
+    }
+    if (longCount > 0) {
+        return hasUnsigned ? type::unsignedLong(typeQualifiers) : type::signedLong(typeQualifiers);
+    }
+    if (hasUnsigned) {
+        return type::unsignedInteger(typeQualifiers);
+    }
+    if (hasSigned || hasInt || typeSpecifiers.empty()) {
+        return type::signedInteger(typeQualifiers);
+    }
+    return typeSpecifiers.at(0).getType();
 }
 
 } // namespace ast

--- a/src/ast/DeclarationSpecifiers.h
+++ b/src/ast/DeclarationSpecifiers.h
@@ -21,6 +21,8 @@ public:
     const std::vector<TypeSpecifier>& getTypeSpecifiers() const;
     const std::vector<type::Qualifier>& getTypeQualifiers() const;
     const std::vector<StorageSpecifier>& getStorageSpecifiers() const;
+    // Combine multi-word type specs (unsigned int, long unsigned, ...) into one Type.
+    type::Type getResolvedType() const;
 
 private:
     DeclarationSpecifiers() = default;

--- a/src/ast/FormalArgument.cpp
+++ b/src/ast/FormalArgument.cpp
@@ -36,10 +36,9 @@ void FormalArgument::visitDeclarator(AbstractSyntaxTreeVisitor& visitor) {
 }
 
 type::Type FormalArgument::getType() const {
-    // FIXME: terribly wrong
-    auto baseType = specifiers.getTypeSpecifiers().at(0).getType();
+    auto baseType = specifiers.getResolvedType();
     if (!declarator) {
-        // Abstract parameter: `int f(int)` — type only, no name/declarator.
+        // Abstract parameter: `int f(int)` - type only, no name/declarator.
         return baseType;
     }
     return declarator->getFundamentalType(baseType);
@@ -57,7 +56,7 @@ translation_unit::Context FormalArgument::getDeclarationContext() const {
 }
 
 bool FormalArgument::isVoid() const {
-    return !declarator && specifiers.getTypeSpecifiers().at(0).getType().isVoid();
+    return !declarator && specifiers.getResolvedType().isVoid();
 }
 
 } // namespace ast

--- a/src/ast/FunctionDefinition.cpp
+++ b/src/ast/FunctionDefinition.cpp
@@ -53,6 +53,18 @@ std::string FunctionDefinition::getName() const {
     return declarator->getName();
 }
 
+const DeclarationSpecifiers& FunctionDefinition::getReturnTypeSpecifiers() const {
+    return returnType;
+}
+
+type::Type FunctionDefinition::getDeclaratorType(const type::Type& baseType) const {
+    return declarator->getFundamentalType(baseType);
+}
+
+translation_unit::Context FunctionDefinition::getDeclaratorContext() const {
+    return declarator->getContext();
+}
+
 
 void FunctionDefinition::setLocalVariables(std::map<std::string, symbols::ValueEntry> localVariables) {
     this->localVariables = localVariables;

--- a/src/ast/FunctionDefinition.h
+++ b/src/ast/FunctionDefinition.h
@@ -35,6 +35,9 @@ public:
     std::vector<symbols::ValueEntry> getArguments() const;
 
     std::string getName() const;
+    const DeclarationSpecifiers& getReturnTypeSpecifiers() const;
+    type::Type getDeclaratorType(const type::Type& baseType) const;
+    translation_unit::Context getDeclaratorContext() const;
 
 private:
     DeclarationSpecifiers returnType;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -126,33 +126,11 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDeclarator& declarator) {
     declarator.visitFormalArguments(*this);
 
     argumentNames.clear();
-    std::vector<type::Type> arguments;
     for (auto& argumentDeclaration : declarator.getFormalArguments()) {
-        try {
-            arguments.push_back(argumentDeclaration.getType());
-        } catch (const std::invalid_argument&) {
-            // visit(FormalArgument) already diagnosed; placeholder so analysis can finish.
-            arguments.push_back(type::voidType());
-        }
         argumentNames.push_back(argumentDeclaration.getName());
     }
-
-    // FIXME: return type is not known at this point!
-    type::Type functionType = type::function(type::signedInteger(), arguments);
-    if (symbolTable.hasGlobalVariable(declarator.getName())) {
-        semanticError("function `" + declarator.getName() + "` conflicts with global variable of the same name",
-                declarator.getContext());
-        return;
-    }
-    FunctionEntry functionEntry = symbolTable.insertFunction(
-            declarator.getName(),
-            functionType.getFunction(),
-            declarator.getContext());
-
-    if (functionEntry.getContext() != declarator.getContext()) {
-        semanticError("function `" + declarator.getName() + "` definition conflicts with previous one on "
-                + to_string(functionEntry.getContext()), declarator.getContext());
-    }
+    // Registration happens in visit(Declaration) for prototypes or visit(FunctionDefinition)
+    // for definitions, once the full return type is known via getResolvedType.
 }
 
 void SemanticAnalysisVisitor::visit(ast::FormalArgument& argument) {
@@ -172,13 +150,37 @@ void SemanticAnalysisVisitor::visit(ast::FormalArgument& argument) {
 
 void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
     function.visitReturnType(*this);
+    type::Type baseType = type::signedInteger();
+    if (!function.getReturnTypeSpecifiers().getTypeSpecifiers().empty()) {
+        baseType = function.getReturnTypeSpecifiers().getResolvedType();
+    }
     function.visitDeclarator(*this);
 
-    if (!symbolTable.hasFunction(function.getName())) {
+    type::Type functionType = function.getDeclaratorType(baseType);
+    if (!functionType.isFunction()) {
+        semanticError("function definition declarator is not a function", function.getDeclaratorContext());
         return;
     }
+    if (symbolTable.hasGlobalVariable(function.getName())) {
+        semanticError("function `" + function.getName() + "` conflicts with global variable of the same name",
+                function.getDeclaratorContext());
+        return;
+    }
+    if (symbolTable.hasFunction(function.getName())) {
+        FunctionEntry existing = symbolTable.findFunction(function.getName());
+        if (existing.getContext() != function.getDeclaratorContext()) {
+            semanticError("function `" + function.getName()
+                            + "` definition conflicts with previous one on "
+                            + to_string(existing.getContext()),
+                    function.getDeclaratorContext());
+            return;
+        }
+    } else {
+        symbolTable.insertFunction(function.getName(), functionType.getFunction(),
+                function.getDeclaratorContext());
+    }
     function.setSymbol(symbolTable.findFunction(function.getName()));
-    currentReturnType = function.getSymbol()->returnType();
+    currentReturnType = functionType.getFunction().getReturnType();
     symbolTable.startFunction(function.getName(), argumentNames);
     namedLabels.clear();
     pendingGotos.clear();

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -168,17 +168,27 @@ void SemanticAnalysisVisitor::visit(ast::FunctionDefinition& function) {
     }
     if (symbolTable.hasFunction(function.getName())) {
         FunctionEntry existing = symbolTable.findFunction(function.getName());
-        if (existing.getContext() != function.getDeclaratorContext()) {
+        if (symbolTable.isFunctionDefined(function.getName())) {
             semanticError("function `" + function.getName()
                             + "` definition conflicts with previous one on "
                             + to_string(existing.getContext()),
                     function.getDeclaratorContext());
             return;
         }
+        if (!functionTypesCompatible(existing.getType(), functionType.getFunction())) {
+            semanticError("function `" + function.getName()
+                            + "` definition conflicts with previous one on "
+                            + to_string(existing.getContext()),
+                    function.getDeclaratorContext());
+            return;
+        }
+        symbolTable.updateFunction(function.getName(), functionType.getFunction(),
+                function.getDeclaratorContext());
     } else {
         symbolTable.insertFunction(function.getName(), functionType.getFunction(),
                 function.getDeclaratorContext());
     }
+    symbolTable.markFunctionDefined(function.getName());
     function.setSymbol(symbolTable.findFunction(function.getName()));
     currentReturnType = functionType.getFunction().getReturnType();
     symbolTable.startFunction(function.getName(), argumentNames);

--- a/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor.cpp
@@ -32,8 +32,8 @@ void SemanticAnalysisVisitor::visit(ast::DeclarationSpecifiers& declarationSpeci
 void SemanticAnalysisVisitor::visit(ast::Declaration& declaration) {
     declaration.visitSpecifiers(*this);
 
-    const type::Type baseType =
-            declaration.getDeclarationSpecifiers().getTypeSpecifiers().at(0).getType();
+    // Multi-word type-specs (long unsigned, etc.) via getResolvedType.
+    const type::Type baseType = declaration.getDeclarationSpecifiers().getResolvedType();
     // C: each declarator is visible to later initializers in the same declaration
     // (`int a = 1, b = a;`). Insert before walking the initializer.
     for (const auto& declarator : declaration.getDeclarators()) {
@@ -71,6 +71,24 @@ void SemanticAnalysisVisitor::analyzeInitializedDeclarator(ast::InitializedDecla
             semanticError("variable `" + declarator.getName() + "` declared void", declarator.getContext());
         } else if (type.isIncompleteRecord()) {
             semanticError("variable `" + declarator.getName() + "` has incomplete type", declarator.getContext());
+        } else if (type.isFunction()) {
+            // Prototypes: register with resolved return type (FunctionDeclarator no longer inserts).
+            if (symbolTable.hasGlobalVariable(declarator.getName())) {
+                semanticError("function `" + declarator.getName()
+                                + "` conflicts with global variable of the same name",
+                        declarator.getContext());
+            } else if (symbolTable.hasFunction(declarator.getName())) {
+                auto existing = symbolTable.findFunction(declarator.getName());
+                if (!functionTypesCompatible(existing.getType(), type.getFunction())) {
+                    semanticError("function `" + declarator.getName()
+                                    + "` declaration conflicts with previous one on "
+                                    + to_string(existing.getContext()),
+                            declarator.getContext());
+                }
+            } else {
+                symbolTable.insertFunction(declarator.getName(), type.getFunction(),
+                        declarator.getContext());
+            }
         } else if (symbolTable.isAtFileScope() && symbolTable.hasFunction(declarator.getName())) {
             semanticError("symbol `" + declarator.getName() + "` declaration conflicts with function of the same name",
                     declarator.getContext());

--- a/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
@@ -24,6 +24,27 @@ inline const translation_unit::Context& externalContext() {
     return ctx;
 }
 
+// Prototype / definition compatibility (return + arity + arg types + variadic).
+inline bool functionTypesCompatible(const type::Function& existing, const type::Function& incoming) {
+    if (!existing.getReturnType().equivalentTo(incoming.getReturnType())) {
+        return false;
+    }
+    if (existing.isVariadic() != incoming.isVariadic()) {
+        return false;
+    }
+    const auto existingArgs = existing.getArguments();
+    const auto newArgs = incoming.getArguments();
+    if (existingArgs.size() != newArgs.size()) {
+        return false;
+    }
+    for (std::size_t i = 0; i < existingArgs.size(); ++i) {
+        if (!existingArgs[i].equivalentTo(newArgs[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
 // Locals are stored as `$s<scopeId><name>`; strip for diagnostics / function lookup.
 inline std::string unscopedSymbolName(const std::string& name) {
     if (name.size() > 2 && name[0] == '$' && name[1] == 's') {

--- a/src/semantic_analyzer/SymbolTable.cpp
+++ b/src/semantic_analyzer/SymbolTable.cpp
@@ -57,12 +57,27 @@ FunctionEntry SymbolTable::insertFunction(std::string name, type::Function funct
     return function;
 }
 
+FunctionEntry SymbolTable::updateFunction(std::string name, type::Function functionType, translation_unit::Context context) {
+    FunctionEntry entry { name, std::move(functionType), context };
+    functions.insert_or_assign(name, entry);
+    return functions.at(name);
+}
+
 FunctionEntry SymbolTable::findFunction(std::string name) const {
     return functions.at(name);
 }
 
 bool SymbolTable::hasFunction(const std::string& name) const {
     return functions.find(name) != functions.end();
+}
+
+bool SymbolTable::isFunctionDefined(const std::string& name) const {
+    auto it = functionDefined.find(name);
+    return it != functionDefined.end() && it->second;
+}
+
+void SymbolTable::markFunctionDefined(const std::string& name) {
+    functionDefined[name] = true;
 }
 
 bool SymbolTable::isAtFileScope() const {

--- a/src/semantic_analyzer/SymbolTable.h
+++ b/src/semantic_analyzer/SymbolTable.h
@@ -19,7 +19,10 @@ public:
     bool insertSymbol(std::string name, const type::Type& type, translation_unit::Context context);
     std::string newConstant(const std::string& value);
     FunctionEntry insertFunction(std::string name, type::Function functionType, translation_unit::Context line);
+    FunctionEntry updateFunction(std::string name, type::Function functionType, translation_unit::Context line);
     FunctionEntry findFunction(std::string name) const;
+    bool isFunctionDefined(const std::string& name) const;
+    void markFunctionDefined(const std::string& name);
     bool hasSymbol(std::string symbolName) const;
     ValueEntry lookup(std::string name) const;
     ValueEntry createTemporarySymbol(type::Type type);
@@ -45,6 +48,7 @@ private:
     void insertFunctionArgument(std::string name, type::Type type, translation_unit::Context context);
 
     std::map<std::string, FunctionEntry> functions;
+    std::map<std::string, bool> functionDefined;
     std::map<std::string, LabelEntry> labels;
     std::map<std::string, std::string> constants;
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -143,6 +143,7 @@ add_executable(functionalTest
         functionalTest/ArraysTest.cpp
         functionalTest/TypeCastTest.cpp
         functionalTest/StructsTest.cpp
+        functionalTest/IntegerTypesTest.cpp
         functionalTest/InitializersTest.cpp
         functionalTest/FunctionPointersTest.cpp
         functionalTest/FactorialTest.cpp

--- a/test/src/astTest/CSNBCreatorsStubTest.cpp
+++ b/test/src/astTest/CSNBCreatorsStubTest.cpp
@@ -5,14 +5,9 @@
 
 namespace {
 
-// Cover not-yet-implemented type stubs (always throw regardless of later features).
+// Remaining type stubs still throw; integer type-specs are implemented (Phase 1).
 TEST(CSNBCreators, unimplementedTypeStubsThrow) {
     ast::AbstractSyntaxTreeBuilderContext context;
-    EXPECT_THROW(ast::shortType(context), std::runtime_error);
-    EXPECT_THROW(ast::longType(context), std::runtime_error);
-    EXPECT_THROW(ast::doubleType(context), std::runtime_error);
-    EXPECT_THROW(ast::signedType(context), std::runtime_error);
-    EXPECT_THROW(ast::unsignedType(context), std::runtime_error);
     EXPECT_THROW(ast::typedefName(context), std::runtime_error);
     EXPECT_THROW(ast::enumType(context), std::runtime_error);
 }

--- a/test/src/astTest/DeclarationSpecifiersTest.cpp
+++ b/test/src/astTest/DeclarationSpecifiersTest.cpp
@@ -1,98 +1,51 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "ast/DeclarationSpecifiers.h"
-#include "semantic_analyzer/SemanticXmlOutputVisitor.h"
+#include "ast/TypeSpecifier.h"
+#include "types/Type.h"
 
 namespace {
 
-using namespace testing;
-using namespace ast;
-using namespace semantic_analyzer;
-
-translation_unit::Context context { "test.c", 42 };
-
-TEST(DeclarationSpecifiers, isConstructedUsingTypeSpecifier) {
-    DeclarationSpecifiers declSpecs { TypeSpecifier { type::signedInteger(), "int" } };
-
-    EXPECT_THAT(declSpecs.getTypeSpecifiers(), SizeIs(1));
-    EXPECT_THAT(declSpecs.getTypeQualifiers(), IsEmpty());
-    EXPECT_THAT(declSpecs.getStorageSpecifiers(), IsEmpty());
+TEST(DeclarationSpecifiers, resolveBareAndCombinedIntegers) {
+    using namespace ast;
+    {
+        DeclarationSpecifiers d { TypeSpecifier { type::signedShort(), "short" } };
+        EXPECT_TRUE(d.getResolvedType().isPrimitive());
+        EXPECT_EQ(d.getResolvedType().getSize(), 2);
+        EXPECT_TRUE(d.getResolvedType().getPrimitive().isSigned());
+    }
+    {
+        DeclarationSpecifiers d { TypeSpecifier { type::unsignedInteger(), "unsigned" } };
+        EXPECT_EQ(d.getResolvedType().getSize(), 4);
+        EXPECT_FALSE(d.getResolvedType().getPrimitive().isSigned());
+    }
+    {
+        // unsigned + int
+        DeclarationSpecifiers d {
+                TypeSpecifier { type::unsignedInteger(), "unsigned" },
+                DeclarationSpecifiers { TypeSpecifier { type::signedInteger(), "int" } } };
+        auto t = d.getResolvedType();
+        EXPECT_EQ(t.getSize(), 4);
+        EXPECT_FALSE(t.getPrimitive().isSigned());
+    }
+    {
+        // unsigned + short
+        DeclarationSpecifiers d {
+                TypeSpecifier { type::unsignedInteger(), "unsigned" },
+                DeclarationSpecifiers { TypeSpecifier { type::signedShort(), "short" } } };
+        auto t = d.getResolvedType();
+        EXPECT_EQ(t.getSize(), 2);
+        EXPECT_FALSE(t.getPrimitive().isSigned());
+    }
+    {
+        DeclarationSpecifiers d { TypeSpecifier { type::signedLong(), "long" } };
+        EXPECT_EQ(d.getResolvedType().getSize(), 8);
+    }
+    {
+        DeclarationSpecifiers d { TypeSpecifier { type::signedInteger(), "signed" } };
+        EXPECT_EQ(d.getResolvedType().getSize(), 4);
+        EXPECT_TRUE(d.getResolvedType().getPrimitive().isSigned());
+    }
 }
 
-TEST(DeclarationSpecifiers, isConstructedUsingTypeQualifier) {
-    DeclarationSpecifiers declSpecs { type::Qualifier::CONST };
-
-    EXPECT_THAT(declSpecs.getTypeSpecifiers(), IsEmpty());
-    EXPECT_THAT(declSpecs.getTypeQualifiers(), ElementsAre(type::Qualifier::CONST));
-    EXPECT_THAT(declSpecs.getStorageSpecifiers(), IsEmpty());
-}
-
-TEST(DeclarationSpecifiers, isConstructedUsingStorageSpecifier) {
-    DeclarationSpecifiers declSpecs { StorageSpecifier::STATIC(context) };
-
-    EXPECT_THAT(declSpecs.getTypeSpecifiers(), IsEmpty());
-    EXPECT_THAT(declSpecs.getTypeQualifiers(), IsEmpty());
-    EXPECT_THAT(declSpecs.getStorageSpecifiers(), ElementsAre(StorageSpecifier::STATIC(context)));
-}
-
-TEST(DeclarationSpecifiers, canBeChainConstructed) {
-    DeclarationSpecifiers intDeclSpecs { TypeSpecifier { type::signedInteger(), "int" } };
-    DeclarationSpecifiers intIntDeclSpecs { TypeSpecifier { type::signedInteger(), "int" }, intDeclSpecs };
-    EXPECT_THAT(intIntDeclSpecs.getTypeSpecifiers(), SizeIs(2));
-    EXPECT_THAT(intIntDeclSpecs.getTypeQualifiers(), IsEmpty());
-    EXPECT_THAT(intIntDeclSpecs.getStorageSpecifiers(), IsEmpty());
-
-    DeclarationSpecifiers intIntVoidDeclSpecs { TypeSpecifier { type::voidType(), "void" }, intIntDeclSpecs };
-    EXPECT_THAT(intIntVoidDeclSpecs.getTypeSpecifiers(), SizeIs(3));
-    EXPECT_THAT(intIntVoidDeclSpecs.getTypeQualifiers(), IsEmpty());
-    EXPECT_THAT(intIntVoidDeclSpecs.getStorageSpecifiers(), IsEmpty());
-
-    DeclarationSpecifiers constIntIntVoidDeclSpecs { type::Qualifier::CONST, intIntVoidDeclSpecs };
-    EXPECT_THAT(constIntIntVoidDeclSpecs.getTypeSpecifiers(), SizeIs(3));
-    EXPECT_THAT(constIntIntVoidDeclSpecs.getTypeQualifiers(), ElementsAre(type::Qualifier::CONST));
-    EXPECT_THAT(constIntIntVoidDeclSpecs.getStorageSpecifiers(), IsEmpty());
-
-    DeclarationSpecifiers constConstIntIntVoidDeclSpecs { type::Qualifier::CONST, constIntIntVoidDeclSpecs };
-    EXPECT_THAT(constConstIntIntVoidDeclSpecs.getTypeSpecifiers(), SizeIs(3));
-    EXPECT_THAT(constConstIntIntVoidDeclSpecs.getTypeQualifiers(), ElementsAre(type::Qualifier::CONST, type::Qualifier::CONST));
-    EXPECT_THAT(constConstIntIntVoidDeclSpecs.getStorageSpecifiers(), IsEmpty());
-
-    DeclarationSpecifiers staticConstConstIntIntVoidDeclSpecs { StorageSpecifier::STATIC(context), constConstIntIntVoidDeclSpecs };
-    EXPECT_THAT(staticConstConstIntIntVoidDeclSpecs.getTypeSpecifiers(), SizeIs(3));
-    EXPECT_THAT(staticConstConstIntIntVoidDeclSpecs.getTypeQualifiers(), ElementsAre(type::Qualifier::CONST, type::Qualifier::CONST));
-    EXPECT_THAT(staticConstConstIntIntVoidDeclSpecs.getStorageSpecifiers(), ElementsAre(StorageSpecifier::STATIC(context)));
-
-    DeclarationSpecifiers autoStaticConstConstIntIntVoidDeclSpecs { StorageSpecifier::AUTO(context), staticConstConstIntIntVoidDeclSpecs };
-    EXPECT_THAT(autoStaticConstConstIntIntVoidDeclSpecs.getTypeSpecifiers(), SizeIs(3));
-    EXPECT_THAT(autoStaticConstConstIntIntVoidDeclSpecs.getTypeQualifiers(), ElementsAre(type::Qualifier::CONST, type::Qualifier::CONST));
-    EXPECT_THAT(autoStaticConstConstIntIntVoidDeclSpecs.getStorageSpecifiers(),
-            ElementsAre(StorageSpecifier::STATIC(context), StorageSpecifier::AUTO(context)));
-}
-
-TEST(SemanticXmlOutputVisitor, outputsDeclarationSpecifiersAsXml) {
-    DeclarationSpecifiers intDeclSpecs { TypeSpecifier { type::signedInteger(), "int" } };
-    DeclarationSpecifiers intIntDeclSpecs { TypeSpecifier { type::signedInteger(), "int" }, intDeclSpecs };
-
-    DeclarationSpecifiers intIntVoidDeclSpecs { TypeSpecifier { type::voidType(), "void" }, intIntDeclSpecs };
-    DeclarationSpecifiers constIntIntVoidDeclSpecs { type::Qualifier::CONST, intIntVoidDeclSpecs };
-    DeclarationSpecifiers constConstIntIntVoidDeclSpecs { type::Qualifier::CONST, constIntIntVoidDeclSpecs };
-    DeclarationSpecifiers staticConstConstIntIntVoidDeclSpecs { StorageSpecifier::STATIC(context), constConstIntIntVoidDeclSpecs };
-    DeclarationSpecifiers autoStaticConstConstIntIntVoidDeclSpecs { StorageSpecifier::AUTO(context), staticConstConstIntIntVoidDeclSpecs };
-
-    std::ostringstream outputStream;
-    SemanticXmlOutputVisitor outputVisitor { &outputStream };
-    autoStaticConstConstIntIntVoidDeclSpecs.accept(outputVisitor);
-
-    EXPECT_THAT(outputStream.str(), StrEq("<declarationSpecifiers>\n"
-            "  <typeSpecifier>int</typeSpecifier>\n"
-            "  <typeSpecifier>int</typeSpecifier>\n"
-            "  <typeSpecifier>void</typeSpecifier>\n"
-            "  <typeQualifier>const</typeQualifier>\n"
-            "  <typeQualifier>const</typeQualifier>\n"
-            "  <storageSpecifier>static</storageSpecifier>\n"
-            "  <storageSpecifier>auto</storageSpecifier>\n"
-            "</declarationSpecifiers>\n"));
-}
-
-}
+} // namespace

--- a/test/src/astTest/DeclarationSpecifiersTest.cpp
+++ b/test/src/astTest/DeclarationSpecifiersTest.cpp
@@ -46,6 +46,25 @@ TEST(DeclarationSpecifiers, resolveBareAndCombinedIntegers) {
         EXPECT_EQ(d.getResolvedType().getSize(), 4);
         EXPECT_TRUE(d.getResolvedType().getPrimitive().isSigned());
     }
+    {
+        // Multi-word package name as type_name combine produces (order-independent).
+        DeclarationSpecifiers d {
+                TypeSpecifier { type::signedLong(), "long" },
+                DeclarationSpecifiers {
+                        TypeSpecifier { type::unsignedInteger(), "unsigned int" } } };
+        auto t = d.getResolvedType();
+        EXPECT_EQ(t.getSize(), 8);
+        EXPECT_FALSE(t.getPrimitive().isSigned());
+    }
+    {
+        DeclarationSpecifiers d {
+                TypeSpecifier { type::unsignedInteger(), "unsigned" },
+                DeclarationSpecifiers {
+                        TypeSpecifier { type::signedLong(), "long" },
+                        DeclarationSpecifiers { TypeSpecifier { type::signedInteger(), "int" } } } };
+        EXPECT_EQ(d.getResolvedType().getSize(), 8);
+        EXPECT_FALSE(d.getResolvedType().getPrimitive().isSigned());
+    }
 }
 
 } // namespace

--- a/test/src/functionalTest/IntegerTypesTest.cpp
+++ b/test/src/functionalTest/IntegerTypesTest.cpp
@@ -1,0 +1,130 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, longVariableArithmetic) {
+    SourceProgram program{R"prg(
+        int main() {
+            long a;
+            long b;
+            a = 100;
+            b = 23;
+            printf("%d", a + b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("123");
+}
+
+TEST(Compiler, unsignedVariableArithmetic) {
+    SourceProgram program{R"prg(
+        int main() {
+            unsigned a;
+            unsigned b;
+            a = 10;
+            b = 7;
+            printf("%d", a - b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, shortVariableArithmetic) {
+    SourceProgram program{R"prg(
+        int main() {
+            short a;
+            short b;
+            a = 4;
+            b = 5;
+            printf("%d", a * b);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("20");
+}
+
+TEST(Compiler, signedVariableArithmetic) {
+    SourceProgram program{R"prg(
+        int main() {
+            signed a;
+            a = -3;
+            printf("%d", -a);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("3");
+}
+
+TEST(Compiler, longFunctionParameterAndReturn) {
+    SourceProgram program{R"prg(
+        long add(long x, long y) {
+            return x + y;
+        }
+        int main() {
+            printf("%d", add(40, 2));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
+TEST(Compiler, unsignedPointer) {
+    SourceProgram program{R"prg(
+        int main() {
+            unsigned v;
+            unsigned* p;
+            v = 99;
+            p = &v;
+            *p = 11;
+            printf("%d", v);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("11");
+}
+
+TEST(Compiler, unsignedIntIsUnsigned) {
+    SourceProgram program{R"prg(
+        int main() {
+            unsigned int a;
+            a = 5;
+            printf("%d", a + 1);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("6");
+}
+
+TEST(Compiler, sizeofLongAndShort) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d %d %d", (int)sizeof(long), (int)sizeof(short), (int)sizeof(unsigned));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8 2 4");
+}
+
+TEST(Compiler, multiWordUnsignedLongLocal) {
+    SourceProgram program{R"prg(
+        int main() {
+            unsigned long x;
+            x = 41;
+            printf("%d", x + 1);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
+} // namespace

--- a/test/src/functionalTest/IntegerTypesTest.cpp
+++ b/test/src/functionalTest/IntegerTypesTest.cpp
@@ -127,4 +127,16 @@ TEST(Compiler, multiWordUnsignedLongLocal) {
     program.runAndExpect("42");
 }
 
+TEST(Compiler, sizeofLongUnsignedOrderIndependent) {
+    // type_name combine must not drop long when keywords are reordered.
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d %d", (int)sizeof(long unsigned), (int)sizeof(long unsigned int));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("8 8");
+}
+
 } // namespace

--- a/test/src/functionalTest/StructsTest.cpp
+++ b/test/src/functionalTest/StructsTest.cpp
@@ -374,26 +374,4 @@ TEST(Compiler, constIntLocalCompile) {
     program.runAndExpect("3");
 }
 
-TEST(Compiler, shortTypeNotImplementedIsError) {
-    SourceProgram program{R"prg(
-        int main() {
-            short x;
-            return 0;
-        }
-    )prg"};
-    program.compile();
-    program.assertCompilationErrors("not implemented");
-}
-
-TEST(Compiler, unsignedTypeNotImplementedIsError) {
-    SourceProgram program{R"prg(
-        int main() {
-            unsigned x;
-            return 0;
-        }
-    )prg"};
-    program.compile();
-    program.assertCompilationErrors("not implemented");
-}
-
 } // namespace


### PR DESCRIPTION
## Summary
- Complete integer type-spec matrix (Phase 1.1).
- Round-1 review fixes; post-master multi-decl fix for `getResolvedType` base and prototype insert.

## Stack
Base: `phase0/06-package-graph` → this PR → `phase1/02-unions`

## Test plan
- [ ] Integer type-spec / SA tests pass
- [ ] Multi-decl analyze path still correct after master rebase