### PR TITLE
phase1/02: unions end-to-end

### DIFF
--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -310,7 +310,7 @@ type::Type AbstractSyntaxTreeBuilderContext::ensureStructTag(const std::string& 
 
 void AbstractSyntaxTreeBuilderContext::completeStructTag(const std::string& tag, type::Type completeType) {
     auto it = structTags.find(tag);
-    if (it != structTags.end() && it->second.isStructure()) {
+    if (it != structTags.end() && it->second.isRecord()) {
         // In-place: keep the incomplete Type's shared StructBody identity so
         // pointer-to-tag types captured during the body (struct Node *next)
         // observe the completed layout.
@@ -323,7 +323,11 @@ void AbstractSyntaxTreeBuilderContext::completeStructTag(const std::string& tag,
                 members.emplace_back(std::move(name), std::move(memberType));
             }
         }
-        type::completeStructure(it->second, members);
+        if (completeType.isUnion()) {
+            type::completeUnion(it->second, members);
+        } else {
+            type::completeStructure(it->second, members);
+        }
         return;
     }
     structTags.insert_or_assign(tag, std::move(completeType));

--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -308,31 +308,6 @@ type::Type AbstractSyntaxTreeBuilderContext::ensureStructTag(const std::string& 
     return incomplete;
 }
 
-void AbstractSyntaxTreeBuilderContext::completeStructTag(const std::string& tag, type::Type completeType) {
-    auto it = structTags.find(tag);
-    if (it != structTags.end() && it->second.isRecord()) {
-        // In-place: keep the incomplete Type's shared StructBody identity so
-        // pointer-to-tag types captured during the body (struct Node *next)
-        // observe the completed layout.
-        std::vector<std::pair<std::string, type::Type>> members;
-        for (int i = 0; i < completeType.memberCount(); ++i) {
-            std::string name;
-            type::Type memberType = type::voidType();
-            int offset = 0;
-            if (completeType.memberAt(i, name, memberType, offset)) {
-                members.emplace_back(std::move(name), std::move(memberType));
-            }
-        }
-        if (completeType.isUnion()) {
-            type::completeUnion(it->second, members);
-        } else {
-            type::completeStructure(it->second, members);
-        }
-        return;
-    }
-    structTags.insert_or_assign(tag, std::move(completeType));
-}
-
 bool AbstractSyntaxTreeBuilderContext::hasStructTag(const std::string& tag) const {
     return structTags.find(tag) != structTags.end();
 }

--- a/src/ast/AbstractSyntaxTreeBuilderContext.h
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.h
@@ -110,7 +110,6 @@ public:
     void addStructDeclarator(std::unique_ptr<Declarator> declarator);
     std::vector<std::unique_ptr<Declarator>> popStructDeclarators();
     type::Type ensureStructTag(const std::string& tag);
-    void completeStructTag(const std::string& tag, type::Type completeType);
     bool hasStructTag(const std::string& tag) const;
     type::Type lookupStructTag(const std::string& tag) const;
 

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -388,7 +388,7 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
     registerFor({ s_for, s_open_paren, s_decl_for, s_semicolon, s_exp, s_close_paren, s_matched }, forLoop(ForInit::Declaration, false, true));
     registerFor({ s_for, s_open_paren, s_decl_for, s_semicolon, s_close_paren, s_matched }, forLoop(ForInit::Declaration, false, false));
 
-    // --- struct (unions deferred) ---
+    // --- struct / union ---
     int s_struct_or_union = grammar.symbolId("<struct_or_union>");
     int s_struct_or_union_spec = grammar.symbolId("<struct_or_union_spec>");
     int s_struct_decl_list = grammar.symbolId("<struct_decl_list>");
@@ -415,14 +415,13 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
                 auto tag = context.popTerminal();
                 auto members = context.popStructMemberList();
                 bool isUnion = context.popIsUnion();
+                // Shared incomplete tag so self-referential members keep one layout identity.
+                type::Type tagType = context.ensureStructTag(tag.value);
                 if (isUnion) {
-                    throw std::runtime_error { "union types are not implemented yet" };
+                    type::completeUnion(tagType, std::move(members));
+                } else {
+                    type::completeStructure(tagType, std::move(members));
                 }
-                // Ensure a shared incomplete tag exists before completion so
-                // self-referential members (struct Node *next) keep one layout identity.
-                context.ensureStructTag(tag.value);
-                type::Type completed = type::structure(std::move(members));
-                context.completeStructTag(tag.value, completed);
                 context.pushTypeSpecifier(TypeSpecifier { context.lookupStructTag(tag.value), tag.value });
             };
     nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, s_open_brace, s_struct_decl_list, s_close_brace }] =
@@ -431,15 +430,15 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
                 context.popTerminal(); // {
                 auto members = context.popStructMemberList();
                 bool isUnion = context.popIsUnion();
-                if (isUnion) {
-                    throw std::runtime_error { "union types are not implemented yet" };
-                }
-                context.pushTypeSpecifier(TypeSpecifier { type::structure(std::move(members)), "" });
+                type::Type completed = isUnion
+                        ? type::unionType(std::move(members))
+                        : type::structure(std::move(members));
+                context.pushTypeSpecifier(TypeSpecifier { completed, "" });
             };
     nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, s_identifier }] =
             [](AbstractSyntaxTreeBuilderContext& context) {
                 auto tag = context.popTerminal();
-                context.popIsUnion();
+                context.popIsUnion(); // layout decided at definition
                 context.popStructMemberList(); // no body
                 if (!context.hasStructTag(tag.value)) {
                     context.ensureStructTag(tag.value);
@@ -475,10 +474,15 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
                     context.addStructMember(declarator->getName(), declarator->getFundamentalType(baseType));
                 }
             };
+    // C11 anonymous struct/union member: empty-name nested aggregate; lookup walks it.
     nodeCreatorRegistry[s_struct_decl][{ s_spec_qualifier_list, s_semicolon }] =
             [](AbstractSyntaxTreeBuilderContext& context) {
-                context.popTerminal();
-                context.popTypeSpecifier(); // ignore anonymous nested for this slice
+                context.popTerminal(); // ;
+                auto typeSpec = context.popTypeSpecifier();
+                auto nested = typeSpec.getType();
+                if (nested.isRecord() && nested.isCompleteRecord()) {
+                    context.addStructMember("", nested);
+                }
             };
     nodeCreatorRegistry[s_struct_decl_list][{ s_struct_decl }] = doNothing;
     nodeCreatorRegistry[s_struct_decl_list][{ s_struct_decl_list, s_struct_decl }] = doNothing;

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -474,13 +474,14 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
                     context.addStructMember(declarator->getName(), declarator->getFundamentalType(baseType));
                 }
             };
-    // C11 anonymous struct/union member: empty-name nested aggregate; lookup walks it.
+    // C11 anonymous struct/union: untagged complete record only (empty TypeSpecifier name).
+    // Tagged type-only forms (struct T { ... };) must not become empty-name members.
     nodeCreatorRegistry[s_struct_decl][{ s_spec_qualifier_list, s_semicolon }] =
             [](AbstractSyntaxTreeBuilderContext& context) {
                 context.popTerminal(); // ;
                 auto typeSpec = context.popTypeSpecifier();
                 auto nested = typeSpec.getType();
-                if (nested.isRecord() && nested.isCompleteRecord()) {
+                if (typeSpec.getName().empty() && nested.isRecord() && nested.isCompleteRecord()) {
                     context.addStructMember("", nested);
                 }
             };

--- a/src/semantic_analyzer/InitializerLowering.cpp
+++ b/src/semantic_analyzer/InitializerLowering.cpp
@@ -33,7 +33,54 @@ void SemanticAnalysisVisitor::lowerLocalInitializer(ast::InitializedDeclarator& 
     }
 
     if (auto* list = dynamic_cast<ast::InitializerListExpression*>(declarator.getInitializer())) {
-        if (objectType.isRecord()) {
+        // Unions: C initializes only the first member; never zero other arms at offset 0.
+        if (objectType.isUnion()) {
+            if (static_cast<int>(list->getElements().size()) > 1) {
+                semanticError("excess elements in union initializer", declarator.getContext());
+            }
+            std::vector<symbols::StructFieldInit> plan;
+            if (objectType.memberCount() >= 1) {
+                std::string name;
+                type::Type memberType = type::voidType();
+                int offset = 0;
+                if (objectType.memberAt(0, name, memberType, offset)) {
+                    if (memberType.isRecord() || memberType.isArray()) {
+                        semanticError(
+                                "aggregate member initializer requires nested braces (not implemented)",
+                                declarator.getContext());
+                    } else {
+                        symbols::StructFieldInit field;
+                        field.offsetBytes = offset;
+                        auto addr = symbolTable.createTemporarySymbol(type::pointer(memberType));
+                        field.addressName = addr.getName();
+                        const bool hasElement = !list->getElements().empty()
+                                && list->getElements().front()
+                                && list->getElements().front()->hasResultSymbol(annotations());
+                        if (hasElement) {
+                            auto& element = list->getElements().front();
+                            typeCheck(assignSourceType(*element, memberType, annotations()), memberType,
+                                    declarator.getContext());
+                            field.zeroInitialize = false;
+                            field.sourceName = element->getResultSymbol(annotations())->getName();
+                            plan.push_back(std::move(field));
+                        } else {
+                            // Empty braces: zero the whole union object once (not per-arm).
+                            symbols::StructFieldInit whole;
+                            whole.offsetBytes = 0;
+                            auto addrU = symbolTable.createTemporarySymbol(type::pointer(objectType));
+                            whole.addressName = addrU.getName();
+                            auto zero = symbolTable.createTemporarySymbol(objectType);
+                            whole.zeroInitialize = true;
+                            whole.sourceName = zero.getName();
+                            plan.push_back(std::move(whole));
+                        }
+                    }
+                }
+            }
+            annotations().setStructFieldInits(&declarator, std::move(plan));
+            return;
+        }
+        if (objectType.isStructure()) {
             if (static_cast<int>(list->getElements().size()) > objectType.memberCount()) {
                 semanticError("excess elements in structure initializer", declarator.getContext());
             }

--- a/src/semantic_analyzer/InitializerLowering.cpp
+++ b/src/semantic_analyzer/InitializerLowering.cpp
@@ -33,7 +33,7 @@ void SemanticAnalysisVisitor::lowerLocalInitializer(ast::InitializedDeclarator& 
     }
 
     if (auto* list = dynamic_cast<ast::InitializerListExpression*>(declarator.getInitializer())) {
-        if (objectType.isStructure()) {
+        if (objectType.isRecord()) {
             if (static_cast<int>(list->getElements().size()) > objectType.memberCount()) {
                 semanticError("excess elements in structure initializer", declarator.getContext());
             }
@@ -46,7 +46,7 @@ void SemanticAnalysisVisitor::lowerLocalInitializer(ast::InitializedDeclarator& 
                 if (!objectType.memberAt(i, name, memberType, offset)) {
                     break;
                 }
-                if (memberType.isStructure() || memberType.isArray()) {
+                if (memberType.isRecord() || memberType.isArray()) {
                     semanticError(
                             "aggregate member initializer requires nested braces (not implemented)",
                             declarator.getContext());

--- a/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
@@ -90,12 +90,12 @@ inline MemberBaseResolution resolveMemberBase(const ast::Expression& base, bool 
 
     if (isArrow) {
         if (!baseType.isPointer()) {
-            r.error = "base of ‘->’ is not a pointer to structure";
+            r.error = "base of ‘->’ is not a pointer to structure or union";
             return r;
         }
         r.structureType = baseType.dereference();
-        if (!r.structureType.isStructure()) {
-            r.error = "base of ‘->’ is not a pointer to structure";
+        if (!r.structureType.isRecord()) {
+            r.error = "base of ‘->’ is not a pointer to structure or union";
             return r;
         }
         r.addressIsPointer = true;
@@ -104,8 +104,8 @@ inline MemberBaseResolution resolveMemberBase(const ast::Expression& base, bool 
     }
 
     // Dot: aggregate-address form already holds the object address in the result.
-    if (!baseType.isStructure()) {
-        r.error = "request for member in non-structure type";
+    if (!baseType.isRecord()) {
+        r.error = "request for member in non-structure or non-union type";
         return r;
     }
     r.structureType = baseType;

--- a/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
+++ b/src/semantic_analyzer/SemanticAnalysisVisitorInternal.h
@@ -90,12 +90,12 @@ inline MemberBaseResolution resolveMemberBase(const ast::Expression& base, bool 
 
     if (isArrow) {
         if (!baseType.isPointer()) {
-            r.error = "base of ‘->’ is not a pointer to structure or union";
+            r.error = "base of '->' is not a pointer to structure or union";
             return r;
         }
         r.structureType = baseType.dereference();
         if (!r.structureType.isRecord()) {
-            r.error = "base of ‘->’ is not a pointer to structure or union";
+            r.error = "base of '->' is not a pointer to structure or union";
             return r;
         }
         r.addressIsPointer = true;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -76,7 +76,7 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
     type::Type memberType = type::voidType();
     if (!base.structureType.memberOffset(memberAccess.getMemberName(), offset)
             || !base.structureType.memberType(memberAccess.getMemberName(), memberType)) {
-        semanticError("no member named ‘" + memberAccess.getMemberName() + "’ in structure",
+        semanticError("no member named ‘" + memberAccess.getMemberName() + "’ in structure or union",
                 memberAccess.getContext());
         return;
     }

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Expressions.cpp
@@ -30,7 +30,7 @@ void SemanticAnalysisVisitor::visit(ast::ArrayAccess& arrayAccess) {
     indexPlan.baseMode = sub.baseIsArray ? symbols::AddressBaseMode::LeaObject
                                          : symbols::AddressBaseMode::PointerValue;
 
-    if (elementType.isArray() || elementType.isStructure()) {
+    if (elementType.isArray() || elementType.isRecord()) {
         type::Type addrType = elementType.isArray()
                 ? type::pointer(elementType.getElementType())
                 : type::pointer(elementType);
@@ -88,7 +88,7 @@ void SemanticAnalysisVisitor::visit(ast::MemberAccess& memberAccess) {
     fieldPlan.baseMode = base.addressIsPointer ? symbols::AddressBaseMode::PointerValue
                                                : symbols::AddressBaseMode::LeaObject;
     annotations().setAddressPlan(&memberAccess, symbols::AddressPlan { fieldPlan });
-    if (memberType.isStructure() || memberType.isArray()) {
+    if (memberType.isRecord() || memberType.isArray()) {
         memberAccess.setAggregateAddressResult(annotations(), fieldAddr, memberType);
     } else {
         memberAccess.setTypeAndResult(annotations(), symbolTable.createTemporarySymbol(memberType));
@@ -430,7 +430,7 @@ void SemanticAnalysisVisitor::visit(ast::AssignmentExpression& expression) {
         const type::Type left = expression.leftOperandType();
         auto* right = expression.getRightOperand();
         // Dual-type structure address is not a structure object rvalue.
-        if (right->holdsAggregateAddress() && left.isStructure()) {
+        if (right->holdsAggregateAddress() && left.isRecord()) {
             semanticError("assignment of structure from dual-type aggregate is not supported",
                     expression.getContext());
             return;

--- a/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
+++ b/src/semantic_analyzer/SemanticAnalysisVisitor_Statements.cpp
@@ -120,7 +120,7 @@ void SemanticAnalysisVisitor::visit(ast::ReturnStatement& statement) {
         return;
     }
     auto* retExpr = statement.returnExpression.get();
-    if (retExpr->holdsAggregateAddress() && currentReturnType && currentReturnType->isStructure()) {
+    if (retExpr->holdsAggregateAddress() && currentReturnType && currentReturnType->isRecord()) {
         semanticError("returning dual-type aggregate address is not supported",
                 retExpr->getContext());
         return;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -144,6 +144,7 @@ add_executable(functionalTest
         functionalTest/TypeCastTest.cpp
         functionalTest/StructsTest.cpp
         functionalTest/IntegerTypesTest.cpp
+        functionalTest/UnionsTest.cpp
         functionalTest/InitializersTest.cpp
         functionalTest/FunctionPointersTest.cpp
         functionalTest/FactorialTest.cpp

--- a/test/src/functionalTest/UnionsTest.cpp
+++ b/test/src/functionalTest/UnionsTest.cpp
@@ -83,4 +83,39 @@ TEST(Compiler, namedUnionInsideStruct) {
 }
 
 
+
+TEST(Compiler, unionBraceInitializesFirstMember) {
+    SourceProgram program{R"prg(
+        union U {
+            int i;
+            int j;
+        };
+        int main() {
+            union U u = { 7 };
+            printf("%d %d", u.i, u.j);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("7 7");
+}
+
+TEST(Compiler, unionZeroBraceFirstMember) {
+    // Grammar requires a non-empty initializer_list; zero first arm via { 0 }.
+    SourceProgram program{R"prg(
+        union U {
+            int i;
+            int j;
+        };
+        int main() {
+            union U u = { 0 };
+            printf("%d %d", u.i, u.j);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("0 0");
+}
+
 } // namespace
+

--- a/test/src/functionalTest/UnionsTest.cpp
+++ b/test/src/functionalTest/UnionsTest.cpp
@@ -1,0 +1,86 @@
+#include "TestFixtures.h"
+
+namespace {
+
+TEST(Compiler, unionBasicOverlay) {
+    SourceProgram program{R"prg(
+        union U {
+            int i;
+            int j;
+        };
+
+        int main() {
+            union U u;
+            u.i = 42;
+            printf("%d", u.j);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("42");
+}
+
+TEST(Compiler, unionSizeIsMaxMember) {
+    SourceProgram program{R"prg(
+        union U {
+            int i;
+            int *p;
+        };
+
+        int main() {
+            union U u;
+            int x;
+            x = 7;
+            u.p = &x;
+            printf("%d %d", *u.p, (int)sizeof(union U));
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    // pointer is 8 bytes; sizeof union should be 8
+    program.runAndExpect("7 8");
+}
+
+TEST(Compiler, unionPointerArrow) {
+    SourceProgram program{R"prg(
+        union U {
+            int i;
+            int j;
+        };
+
+        int main() {
+            union U u;
+            union U *pu;
+            pu = &u;
+            pu->i = 9;
+            printf("%d", u.j);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("9");
+}
+
+TEST(Compiler, namedUnionInsideStruct) {
+    SourceProgram program{R"prg(
+        struct S {
+            int tag;
+            union U {
+                int i;
+                int j;
+            } u;
+        };
+
+        int main() {
+            struct S s;
+            s.tag = 1;
+            s.u.i = 42;
+            printf("%d %d %d", s.tag, s.u.i, s.u.j);
+            return 0;
+        }
+    )prg"};
+    program.compile();
+    program.runAndExpect("1 42 42");
+}
+
+} // namespace

--- a/test/src/functionalTest/UnionsTest.cpp
+++ b/test/src/functionalTest/UnionsTest.cpp
@@ -37,7 +37,6 @@ TEST(Compiler, unionSizeIsMaxMember) {
         }
     )prg"};
     program.compile();
-    // pointer is 8 bytes; sizeof union should be 8
     program.runAndExpect("7 8");
 }
 
@@ -82,5 +81,6 @@ TEST(Compiler, namedUnionInsideStruct) {
     program.compile();
     program.runAndExpect("1 42 42");
 }
+
 
 } // namespace


### PR DESCRIPTION
## Summary
- Unions end-to-end (Phase 1.2).
- Review fixes for union brace-init and Round-1 residuals.

## Stack
Base: `phase1/01-integer-type-specs` → this PR → `phase1/03-forward-decl`

## Test plan
- [ ] Union SA/AST tests pass
- [ ] Brace-init for unions behaves as expected