### PR TITLE
phase2/01: per-TU LexicalSession with typedef/enum registries

### DIFF
--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -8,6 +8,7 @@
 #include "codegen/GlobalVariable.h"
 #include "codegen/QuadrupleGenerator.h"
 #include "parser/SyntaxTreeBuilder.h"
+#include "scanner/LexicalSession.h"
 #include "scanner/Scanner.h"
 #include "semantic_analyzer/SemanticAnalyzer.h"
 #include "codegen/quadruples/Quadruple.h"
@@ -44,7 +45,10 @@ Compiler::Compiler(Configuration configuration) :
 void Compiler::compile(std::string sourceFileName) const {
     out << "Compiling " << sourceFileName << "...\n";
 
-    std::unique_ptr<scanner::Scanner> scanner = compilerComponentsFactory.makeScannerForSourceFile(sourceFileName);
+    // Per-TU lexical state (typedefs, enums). Not process-static.
+    scanner::LexicalSession session;
+    std::unique_ptr<scanner::Scanner> scanner =
+            compilerComponentsFactory.makeScannerForSourceFile(sourceFileName, session);
     std::unique_ptr<parser::SyntaxTreeBuilder> syntaxTreeBuilder = compilerComponentsFactory.makeSyntaxTreeBuilder(sourceFileName, &grammar);
     std::unique_ptr<parser::SyntaxTree> syntaxTree = parser->parse(*scanner, *syntaxTreeBuilder);
 

--- a/src/driver/CompilerComponentsFactory.cpp
+++ b/src/driver/CompilerComponentsFactory.cpp
@@ -22,12 +22,14 @@ CompilerComponentsFactory::CompilerComponentsFactory(Configuration configuration
 {
 }
 
-std::unique_ptr<scanner::Scanner> CompilerComponentsFactory::makeScannerForSourceFile(std::string sourceFileName) const {
+std::unique_ptr<scanner::Scanner> CompilerComponentsFactory::makeScannerForSourceFile(
+        std::string sourceFileName, scanner::LexicalSession& session) const {
     Logger logger { configuration.isScannerLoggingEnabled() ? &std::cout : &NullStream::getInstance() };
     LogManager::registerComponentLogger(Component::SCANNER, logger);
 
     scanner::LexFileScannerReader scannerReader;
-    return std::make_unique<scanner::Scanner>(sourceFileName, scannerReader.fromConfiguration(configuration.getLexPath()));
+    return std::make_unique<scanner::Scanner>(
+            sourceFileName, scannerReader.fromConfiguration(configuration.getLexPath()), session);
 }
 
 parser::Grammar CompilerComponentsFactory::makeGrammar() const {

--- a/src/driver/CompilerComponentsFactory.h
+++ b/src/driver/CompilerComponentsFactory.h
@@ -7,6 +7,7 @@
 #include "parser/Grammar.h"
 #include "parser/Parser.h"
 #include "parser/ParsingTable.h"
+#include "scanner/LexicalSession.h"
 #include "scanner/Scanner.h"
 
 #include <iostream>
@@ -17,7 +18,8 @@ class CompilerComponentsFactory {
 public:
     CompilerComponentsFactory(Configuration configuration);
 
-    std::unique_ptr<scanner::Scanner> makeScannerForSourceFile(std::string sourceFileName) const;
+    std::unique_ptr<scanner::Scanner> makeScannerForSourceFile(
+            std::string sourceFileName, scanner::LexicalSession& session) const;
 
     parser::Grammar makeGrammar() const;
     std::unique_ptr<parser::Parser> makeParser(parser::Grammar* grammar) const;

--- a/src/scanner/CMakeLists.txt
+++ b/src/scanner/CMakeLists.txt
@@ -11,7 +11,12 @@ add_library(scanner
         State.cpp
         Token.h
         Token.cpp
+        TypedefRegistry.h
+        TypedefRegistry.cpp
+        EnumConstantRegistry.h
+        EnumConstantRegistry.cpp
+        LexicalSession.h
         )
 
 trans_target_defaults(scanner)
-target_link_libraries(scanner PUBLIC translation_unit)
+target_link_libraries(scanner PUBLIC translation_unit types)

--- a/src/scanner/EnumConstantRegistry.cpp
+++ b/src/scanner/EnumConstantRegistry.cpp
@@ -1,0 +1,18 @@
+#include "EnumConstantRegistry.h"
+
+namespace scanner {
+
+void EnumConstantRegistry::add(const std::string& name, long value) {
+    table_.insert_or_assign(name, value);
+}
+
+bool EnumConstantRegistry::lookup(const std::string& name, long& value) const {
+    auto it = table_.find(name);
+    if (it == table_.end()) {
+        return false;
+    }
+    value = it->second;
+    return true;
+}
+
+} // namespace scanner

--- a/src/scanner/EnumConstantRegistry.h
+++ b/src/scanner/EnumConstantRegistry.h
@@ -1,0 +1,27 @@
+#ifndef ENUMCONSTANTREGISTRY_H_
+#define ENUMCONSTANTREGISTRY_H_
+
+#include <map>
+#include <string>
+
+namespace scanner {
+
+// Enumerators visible while building one translation unit, so that later
+// enumerators (and const expressions) can fold references to earlier ones.
+// Instance-owned (LexicalSession); never process-static.
+// Product limit: TU-flat (not C block scope). SA import keeps the same map.
+// add() is last-wins; redefinition diagnostics belong at the PE/SA layer.
+// Sessions are single-shot per compile; no reset API (fresh LexicalSession each TU).
+class EnumConstantRegistry {
+public:
+    void add(const std::string& name, long value);
+    bool lookup(const std::string& name, long& value) const;
+    const std::map<std::string, long>& entries() const { return table_; }
+
+private:
+    std::map<std::string, long> table_;
+};
+
+} // namespace scanner
+
+#endif // ENUMCONSTANTREGISTRY_H_

--- a/src/scanner/FiniteAutomaton.cpp
+++ b/src/scanner/FiniteAutomaton.cpp
@@ -1,4 +1,5 @@
 #include "FiniteAutomaton.h"
+#include "TypedefRegistry.h"
 
 namespace scanner {
 
@@ -21,8 +22,12 @@ void FiniteAutomaton::updateState(char inputSymbol) {
     auto nextState = currentState->nextStateForCharacter(inputSymbol);
     if (nextState->isFinal()) {
         accumulatedToken = currentState->getTokenId();
-        if (currentState->needsKeywordLookup() && (keywordIds.find(accumulator) != keywordIds.end())) {
-            accumulatedToken = accumulator;
+        if (currentState->needsKeywordLookup()) {
+            if (keywordIds.find(accumulator) != keywordIds.end()) {
+                accumulatedToken = accumulator;
+            } else if (isTypedefName(accumulator)) {
+                accumulatedToken = "typedef_name";
+            }
         }
         if (!accumulatedToken.empty()) {
             accumulatedLexeme = accumulator;
@@ -50,5 +55,9 @@ std::string FiniteAutomaton::getAccumulatedToken() const {
     return accumulatedToken;
 }
 
-} // namespace scanner
+bool FiniteAutomaton::isTypedefName(const std::string& name) const {
+    // Shadows are TokenStream's job; FA only consults the typedef name table.
+    return typedefs_ && typedefs_->has(name);
+}
 
+} // namespace scanner

--- a/src/scanner/FiniteAutomaton.h
+++ b/src/scanner/FiniteAutomaton.h
@@ -8,6 +8,8 @@
 
 namespace scanner {
 
+class TypedefRegistry;
+
 class FiniteAutomaton {
 public:
     FiniteAutomaton(
@@ -21,7 +23,12 @@ public:
     std::string getAccumulatedLexeme() const;
     std::string getAccumulatedToken() const;
 
+    // Lexer feedback: typedef names live only on the session TypedefRegistry.
+    void setTypedefRegistry(TypedefRegistry* registry) { typedefs_ = registry; }
+
 private:
+    bool isTypedefName(const std::string& name) const;
+
     const State* startState { nullptr };
     const State* currentState { nullptr };
     std::map<std::string, int> keywordIds;
@@ -30,6 +37,8 @@ private:
     std::string accumulator;
     std::string accumulatedLexeme;
     std::string accumulatedToken;
+
+    TypedefRegistry* typedefs_ { nullptr };
 };
 
 } // namespace scanner

--- a/src/scanner/LexicalSession.h
+++ b/src/scanner/LexicalSession.h
@@ -1,0 +1,28 @@
+#ifndef LEXICALSESSION_H_
+#define LEXICALSESSION_H_
+
+// Per-translation-unit lexical state. Owned by the compile pipeline
+// (Compiler::compile); shared with the scanner now, and with TokenStream/AST
+// in later Phase-2 slices. Never process-static.
+
+#include "EnumConstantRegistry.h"
+#include "TypedefRegistry.h"
+
+namespace scanner {
+
+// Stack-owned only: FA holds a raw pointer into typedefs, so copies/moves would
+// dangle. Share by reference (Compiler::compile owns the session for one TU).
+struct LexicalSession {
+    TypedefRegistry typedefs;
+    EnumConstantRegistry enums;
+
+    LexicalSession() = default;
+    LexicalSession(const LexicalSession&) = delete;
+    LexicalSession& operator=(const LexicalSession&) = delete;
+    LexicalSession(LexicalSession&&) = delete;
+    LexicalSession& operator=(LexicalSession&&) = delete;
+};
+
+} // namespace scanner
+
+#endif // LEXICALSESSION_H_

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -4,9 +4,11 @@
 
 namespace scanner {
 
-Scanner::Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine) :
+Scanner::Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine, LexicalSession& session) :
         translationUnit { fileName },
-        automaton { std::move(stateMachine) } {
+        automaton { std::move(stateMachine) },
+        session_ { session } {
+    automaton->setTypedefRegistry(&session_.typedefs);
 }
 
 Token Scanner::nextToken() {
@@ -19,4 +21,3 @@ Token Scanner::nextToken() {
 }
 
 } // namespace scanner
-

--- a/src/scanner/Scanner.h
+++ b/src/scanner/Scanner.h
@@ -2,6 +2,7 @@
 #define SCANNER_H_
 
 #include "scanner/FiniteAutomaton.h"
+#include "scanner/LexicalSession.h"
 #include "scanner/Token.h"
 #include "translation_unit/TranslationUnit.h"
 
@@ -11,13 +12,18 @@ namespace scanner {
 
 class Scanner {
 public:
-    Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine);
+    Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine, LexicalSession& session);
 
     Token nextToken();
+
+    LexicalSession& session() { return session_; }
+    const LexicalSession& session() const { return session_; }
+    TypedefRegistry& typedefs() { return session_.typedefs; }
 
 private:
     TranslationUnit translationUnit;
     std::unique_ptr<FiniteAutomaton> automaton;
+    LexicalSession& session_;
 };
 
 } // namespace scanner

--- a/src/scanner/TypedefRegistry.cpp
+++ b/src/scanner/TypedefRegistry.cpp
@@ -1,0 +1,52 @@
+#include "TypedefRegistry.h"
+
+namespace scanner {
+
+void TypedefRegistry::add(const std::string& name, const type::Type& type) {
+    // Last-wins until product redefinition diagnostics land (typedef branch).
+    table_.insert_or_assign(name, type);
+    // A new typedef binding wins over any prior object shadow of the same name.
+    for (auto& scope : identifierShadowScopes_) {
+        scope.erase(name);
+    }
+}
+
+bool TypedefRegistry::has(const std::string& name) const {
+    return table_.count(name) > 0;
+}
+
+std::optional<type::Type> TypedefRegistry::tryLookup(const std::string& name) const {
+    auto it = table_.find(name);
+    if (it == table_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+void TypedefRegistry::addIdentifierShadow(const std::string& name) {
+    if (identifierShadowScopes_.empty()) {
+        identifierShadowScopes_.push_back({});
+    }
+    identifierShadowScopes_.back().insert(name);
+}
+
+bool TypedefRegistry::isIdentifierShadow(const std::string& name) const {
+    for (const auto& scope : identifierShadowScopes_) {
+        if (scope.count(name) > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void TypedefRegistry::pushIdentifierShadowScope() {
+    identifierShadowScopes_.push_back({});
+}
+
+void TypedefRegistry::popIdentifierShadowScope() {
+    if (!identifierShadowScopes_.empty()) {
+        identifierShadowScopes_.pop_back();
+    }
+}
+
+} // namespace scanner

--- a/src/scanner/TypedefRegistry.h
+++ b/src/scanner/TypedefRegistry.h
@@ -1,0 +1,47 @@
+#ifndef TYPEDEFREGISTRY_H_
+#define TYPEDEFREGISTRY_H_
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "types/Type.h"
+
+namespace scanner {
+
+// Typedef name table for one translation unit (lexer feedback + type lookup).
+//
+// Layer split:
+// - FiniteAutomaton: keyword lookup first, then has(name) -> emit typedef_name.
+//   FA does not consult identifier shadows.
+// - TokenStream (Phase 2+): reclassifies via LexIdContext + isIdentifierShadow.
+//
+// Object shadows (e.g. `cmp_type cmp_type = ...`) are recorded so later uses
+// reclassify as "id". Brace scopes: TokenStream push on `{`, pop on `}`.
+// File-scope shadows: addIdentifierShadow auto-opens a root frame when the
+// stack is empty (no prior push). pop on empty stack is a no-op so extra `}`
+// does not throw; mismatched pops should be caught by TokenStream tests.
+// Sessions are single-shot per compile; no reset API (fresh LexicalSession each TU).
+class TypedefRegistry {
+public:
+    void add(const std::string& name, const type::Type& type);
+    bool has(const std::string& name) const;
+    std::optional<type::Type> tryLookup(const std::string& name) const;
+
+    // Shadows are consulted by TokenStream reclassify, not by the FA.
+    // Auto-root when empty (file-scope objects); see class comment.
+    void addIdentifierShadow(const std::string& name);
+    bool isIdentifierShadow(const std::string& name) const;
+    void pushIdentifierShadowScope();
+    void popIdentifierShadowScope();
+
+private:
+    std::map<std::string, type::Type> table_;
+    std::vector<std::set<std::string>> identifierShadowScopes_;
+};
+
+} // namespace scanner
+
+#endif // TYPEDEFREGISTRY_H_

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -55,6 +55,7 @@ add_executable(scannerTest
         scannerTest/ScannerTokensTest.cpp
         scannerTest/FiniteAutomatonTest.cpp
         scannerTest/LexFileScannerReaderTest.cpp
+        scannerTest/LexicalSessionTest.cpp
         scannerTest/StateTest.cpp
         scannerTest/TokenMatcher.h
         )

--- a/test/src/parserGeneratorTest/LR1ParserGeneratedTableTests.cpp
+++ b/test/src/parserGeneratorTest/LR1ParserGeneratedTableTests.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+
+#include "scanner/LexicalSession.h"
 #include "gmock/gmock.h"
 
 #include "parser/BNFFileReader.h"
@@ -34,8 +36,10 @@ void generateAndParseExample(AutomatonKind kind) {
     Grammar grammar = reader.readGrammar(getResourcePath(kProductGrammar));
     LR1Parser parser { std::make_unique<GeneratedParsingTable>(&grammar, kind) };
     auto syntaxTreeBuilder = factory.makeSyntaxTreeBuilder("test", &grammar);
+    scanner::LexicalSession session;
     ASSERT_NO_THROW(
-            parser.parse(*factory.makeScannerForSourceFile(getTestResourcePath("programs/example_prog.src")),
+            parser.parse(*factory.makeScannerForSourceFile(
+                    getTestResourcePath("programs/example_prog.src"), session),
                     *syntaxTreeBuilder));
 }
 

--- a/test/src/parserTest/LR1ParserTest.cpp
+++ b/test/src/parserTest/LR1ParserTest.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+
+#include "scanner/LexicalSession.h"
 #include "gmock/gmock.h"
 
 #include "parser/LR1Parser.h"
@@ -33,8 +35,10 @@ TEST(LR1Parser, parsesTestProgram) {
 
     LR1Parser parser { std::move(parsingTable) };
     auto builder = compilerComponentsFactory.makeSyntaxTreeBuilder("test", &grammar);
+    scanner::LexicalSession session;
     ASSERT_NO_THROW(
-            parser.parse(*compilerComponentsFactory.makeScannerForSourceFile(getTestResourcePath("programs/example_prog.src")),
+            parser.parse(*compilerComponentsFactory.makeScannerForSourceFile(
+                    getTestResourcePath("programs/example_prog.src"), session),
                     *builder));
 }
 

--- a/test/src/scannerTest/FiniteAutomatonTest.cpp
+++ b/test/src/scannerTest/FiniteAutomatonTest.cpp
@@ -2,8 +2,9 @@
 #include "gmock/gmock.h"
 
 #include "scanner/FiniteAutomaton.h"
-
 #include "scanner/State.h"
+#include "scanner/TypedefRegistry.h"
+#include "types/Type.h"
 
 using namespace testing;
 using namespace scanner;
@@ -132,4 +133,67 @@ TEST(FiniteAutomaton, returnsAdjacentTokens) {
 	ASSERT_THAT(finiteAutomaton.isAtFinalState(), Eq(true));
 
 	ASSERT_THAT(finiteAutomaton.getAccumulatedLexeme(), Eq("a"));
+}
+
+TEST(FiniteAutomaton, emitsTypedefNameWhenRegistered) {
+    State startState("start", "");
+    IdentifierState accumulatingState("accumulating", "id");
+    State finalState("final", "");
+    startState.addTransition("", &startState);
+    startState.addTransition("m", &accumulatingState);
+    accumulatingState.addTransition("yint", &accumulatingState);
+    accumulatingState.addTransition("", &finalState);
+    TypedefRegistry reg;
+    reg.add("myint", type::signedInteger());
+    FiniteAutomaton finiteAutomaton { &startState, {}, {} };
+    finiteAutomaton.setTypedefRegistry(&reg);
+
+    for (char c : std::string("myint ")) {
+        finiteAutomaton.updateState(c);
+    }
+    ASSERT_THAT(finiteAutomaton.isAtFinalState(), Eq(true));
+    ASSERT_THAT(finiteAutomaton.getAccumulatedToken(), Eq("typedef_name"));
+    ASSERT_THAT(finiteAutomaton.getAccumulatedLexeme(), Eq("myint"));
+}
+
+TEST(FiniteAutomaton, keywordWinsOverTypedefRegistry) {
+    State startState("start", "");
+    IdentifierState accumulatingState("accumulating", "id");
+    State finalState("final", "");
+    startState.addTransition("", &startState);
+    startState.addTransition("v", &accumulatingState);
+    accumulatingState.addTransition("oid", &accumulatingState);
+    accumulatingState.addTransition("", &finalState);
+    TypedefRegistry reg;
+    reg.add("void", type::signedInteger());
+    FiniteAutomaton finiteAutomaton { &startState, { {"void", 1} }, {} };
+    finiteAutomaton.setTypedefRegistry(&reg);
+
+    for (char c : std::string("void ")) {
+        finiteAutomaton.updateState(c);
+    }
+    ASSERT_THAT(finiteAutomaton.isAtFinalState(), Eq(true));
+    ASSERT_THAT(finiteAutomaton.getAccumulatedToken(), Eq("void"));
+}
+
+// FA ignores identifier shadows; TokenStream reclassify is the only consumer.
+TEST(FiniteAutomaton, stillEmitsTypedefNameWhenIdentifierShadowed) {
+    State startState("start", "");
+    IdentifierState accumulatingState("accumulating", "id");
+    State finalState("final", "");
+    startState.addTransition("", &startState);
+    startState.addTransition("T", &accumulatingState);
+    accumulatingState.addTransition("", &finalState);
+    TypedefRegistry reg;
+    reg.add("T", type::signedInteger());
+    reg.addIdentifierShadow("T");
+    FiniteAutomaton finiteAutomaton { &startState, {}, {} };
+    finiteAutomaton.setTypedefRegistry(&reg);
+
+    for (char c : std::string("T ")) {
+        finiteAutomaton.updateState(c);
+    }
+    ASSERT_THAT(finiteAutomaton.isAtFinalState(), Eq(true));
+    ASSERT_THAT(finiteAutomaton.getAccumulatedToken(), Eq("typedef_name"));
+    ASSERT_THAT(finiteAutomaton.getAccumulatedLexeme(), Eq("T"));
 }

--- a/test/src/scannerTest/LexicalSessionTest.cpp
+++ b/test/src/scannerTest/LexicalSessionTest.cpp
@@ -1,0 +1,89 @@
+#include "gtest/gtest.h"
+
+#include "scanner/LexicalSession.h"
+#include "types/Type.h"
+
+using namespace scanner;
+
+TEST(LexicalSession, typedefAndEnumAreInstanceOwned) {
+    LexicalSession a;
+    LexicalSession b;
+    a.typedefs.add("T", type::signedInteger());
+    a.enums.add("E", 3);
+    EXPECT_TRUE(a.typedefs.has("T"));
+    EXPECT_FALSE(b.typedefs.has("T"));
+    long v = 0;
+    EXPECT_TRUE(a.enums.lookup("E", v));
+    EXPECT_EQ(v, 3);
+    EXPECT_FALSE(b.enums.lookup("E", v));
+}
+
+TEST(TypedefRegistry, shadowScopesPushPop) {
+    TypedefRegistry reg;
+    reg.add("T", type::signedInteger());
+    reg.pushIdentifierShadowScope();
+    reg.addIdentifierShadow("T");
+    EXPECT_TRUE(reg.isIdentifierShadow("T"));
+    reg.popIdentifierShadowScope();
+    EXPECT_FALSE(reg.isIdentifierShadow("T"));
+}
+
+TEST(TypedefRegistry, fileScopeAutoRootShadow) {
+    // No prior push: add opens a root frame so file-scope object shadows work.
+    TypedefRegistry reg;
+    reg.add("T", type::signedInteger());
+    reg.addIdentifierShadow("T");
+    EXPECT_TRUE(reg.isIdentifierShadow("T"));
+}
+
+TEST(TypedefRegistry, emptyPopIsNoOp) {
+    TypedefRegistry reg;
+    reg.add("T", type::signedInteger());
+    reg.addIdentifierShadow("T");
+    reg.popIdentifierShadowScope(); // root
+    EXPECT_FALSE(reg.isIdentifierShadow("T"));
+    reg.popIdentifierShadowScope(); // extra empty pop: no throw, no erase
+    reg.pushIdentifierShadowScope();
+    reg.addIdentifierShadow("T");
+    EXPECT_TRUE(reg.isIdentifierShadow("T"));
+}
+
+TEST(TypedefRegistry, addClearsShadowOfSameName) {
+    TypedefRegistry reg;
+    reg.pushIdentifierShadowScope();
+    reg.addIdentifierShadow("T");
+    reg.add("T", type::signedInteger());
+    EXPECT_FALSE(reg.isIdentifierShadow("T"));
+    EXPECT_TRUE(reg.has("T"));
+}
+
+TEST(TypedefRegistry, addLastWins) {
+    TypedefRegistry reg;
+    reg.add("T", type::signedInteger());
+    reg.add("T", type::unsignedInteger());
+    auto t = reg.tryLookup("T");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_TRUE(t->equivalentTo(type::unsignedInteger()));
+    EXPECT_FALSE(t->equivalentTo(type::signedInteger()));
+}
+
+TEST(EnumConstantRegistry, addAndLookup) {
+    EnumConstantRegistry enums;
+    enums.add("A", 1);
+    enums.add("B", 2);
+    long v = 0;
+    EXPECT_TRUE(enums.lookup("A", v));
+    EXPECT_EQ(v, 1);
+    EXPECT_TRUE(enums.lookup("B", v));
+    EXPECT_EQ(v, 2);
+    EXPECT_FALSE(enums.lookup("C", v));
+}
+
+TEST(EnumConstantRegistry, addLastWins) {
+    EnumConstantRegistry enums;
+    enums.add("A", 1);
+    enums.add("A", 9);
+    long v = 0;
+    ASSERT_TRUE(enums.lookup("A", v));
+    EXPECT_EQ(v, 9);
+}

--- a/test/src/scannerTest/ScannerTest.cpp
+++ b/test/src/scannerTest/ScannerTest.cpp
@@ -2,6 +2,7 @@
 #include "gmock/gmock.h"
 
 #include "scanner/LexFileScannerReader.h"
+#include "scanner/LexicalSession.h"
 #include "scanner/Token.h"
 #include "scanner/Scanner.h"
 #include "TokenMatcher.h"
@@ -15,9 +16,11 @@ using namespace scanner;
 TEST(ScannerTest, scansTheExampleProgram) {
     auto exampleProgramFilename = getTestResourcePath("programs/example_prog.src");
     LexFileScannerReader reader;
+    LexicalSession session;
     Scanner scanner {
         exampleProgramFilename,
-        reader.fromConfiguration(getResourcePath("configuration/scanner.lex"))
+        reader.fromConfiguration(getResourcePath("configuration/scanner.lex")),
+        session
     };
 
     ASSERT_THAT(scanner.nextToken(), tokenMatches(Token {"int", "int", {exampleProgramFilename, 2} }));

--- a/test/src/scannerTest/ScannerTokensTest.cpp
+++ b/test/src/scannerTest/ScannerTokensTest.cpp
@@ -2,8 +2,10 @@
 #include "gtest/gtest.h"
 
 #include "scanner/LexFileScannerReader.h"
+#include "scanner/LexicalSession.h"
 #include "scanner/Scanner.h"
 #include "scanner/Token.h"
+#include "types/Type.h"
 
 #include "ResourceHelpers.h"
 
@@ -37,7 +39,8 @@ std::string writeTempSource(const std::string &name, const std::string &contents
 
 std::vector<Token> scanAll(const std::string &path) {
     LexFileScannerReader reader;
-    Scanner scanner{path, reader.fromConfiguration(getResourcePath("configuration/scanner.lex"))};
+    LexicalSession session;
+    Scanner scanner{path, reader.fromConfiguration(getResourcePath("configuration/scanner.lex")), session};
     std::vector<Token> out;
     for (int i = 0; i < 200; ++i) {
         Token t = scanner.nextToken();
@@ -179,6 +182,18 @@ TEST(ScannerTokens, stillScansExistingKeywords) {
     EXPECT_TRUE(has("while"));
     EXPECT_TRUE(has("return"));
     EXPECT_TRUE(has("void"));
+}
+
+
+TEST(ScannerTokens, emitsTypedefNameWhenSessionRegisters) {
+    auto path = writeTempSource("scan_typedef_name", "myint x;\n");
+    LexFileScannerReader reader;
+    LexicalSession session;
+    session.typedefs.add("myint", type::signedInteger());
+    Scanner scanner{path, reader.fromConfiguration(getResourcePath("configuration/scanner.lex")), session};
+    Token t = scanner.nextToken();
+    EXPECT_EQ(t.id, "typedef_name");
+    EXPECT_EQ(t.lexeme, "myint");
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

- Introduce stack-owned per-translation-unit `LexicalSession` holding `TypedefRegistry` and `EnumConstantRegistry` (no process-static maps).
- Wire factory → `Scanner` → FA: keyword lookup first, then `has(name)` emits `typedef_name`.
- FA does not consult identifier shadows (TokenStream owns that in later slices). Sessions are single-shot (no reset API).

## Stack

Phase 2 PR **1 of 6** (base: `master`).

| # | Branch |
| --- | --- |
| 01 | `phase2/01-lexical-session` (this PR) |
| 02 | `phase2/02-lex-id-context` |
| 03 | `phase2/03-parse-environment` |
| 04 | `phase2/04-enums` |
| 05 | `phase2/05-typedef` |
| 06 | `phase2/06-scanner-filters` |

## Test plan

- [x] Unit pins: per-TU isolation, keyword-over-typedef, FA ignores shadows, last-wins, file-scope auto-root / empty-pop
- [x] Full `ctest` green on stack tip