### PR TITLE
phase2/02: TokenStream LexIdContext for typedef_name vs id

### DIFF
--- a/src/parser/LR1Parser.cpp
+++ b/src/parser/LR1Parser.cpp
@@ -18,7 +18,7 @@ LR1Parser::~LR1Parser() = default;
 std::unique_ptr<SyntaxTree> LR1Parser::parse(scanner::Scanner& scanner, SyntaxTreeBuilder& syntaxTreeBuilder) {
     TokenStream tokenStream { [&scanner]() {
         return scanner.nextToken();
-    }};
+    }, scanner.typedefs() };
 
     std::stack<parse_state> parsingStack;
     parsingStack.push(0);

--- a/src/parser/TokenStream.cpp
+++ b/src/parser/TokenStream.cpp
@@ -1,33 +1,151 @@
 #include "TokenStream.h"
 
+#include "scanner/TypedefRegistry.h"
+
+#include <optional>
+#include <string_view>
+
 namespace parser {
 
-TokenStream::TokenStream(std::function<scanner::Token()> scan) :
-    scan { scan },
+namespace {
+
+// Closed transition membership: after consuming this token id, next name is
+// AsType / AsIdentifier, or keep current role (nullopt). Extend via these
+// helpers only - do not add one-off previous-token specials in nextToken.
+
+bool isTagKeyword(std::string_view id) {
+    return id == "struct" || id == "union" || id == "enum";
+}
+
+bool isMemberOp(std::string_view id) {
+    return id == "." || id == "->";
+}
+
+// Declarator / unary '*': next name is an identifier.
+bool isStar(std::string_view id) {
+    return id == "*";
+}
+
+// After a typedef_name token, the next name is the object/declarator identifier.
+bool isTypedefNameToken(std::string_view id) {
+    return id == "typedef_name";
+}
+
+// Keywords, unaries (except '*'), assigns/relops, primaries that put the next
+// name in expression position. Extend this table only - keep roleAfter closed.
+constexpr std::string_view kExpressionCues[] = {
+        "return", "else", "goto", "sizeof", "case",
+        "++", "--", "+", "-", "&", "!", "~",
+        "=", "+=", "-=", "*=", "/=", "%=",
+        "<<=", ">>=", "&=", "^=", "|=",
+        "==", "!=", "<", ">", "<=", ">=",
+        "<<", ">>", "/", "%", "^", "|",
+        "&&", "||", "?", "[",
+        "id", "int_const", "char_const", "float_const", "string", "enumeration_const",
+};
+
+bool isExpressionCue(std::string_view id) {
+    for (std::string_view cue : kExpressionCues) {
+        if (cue == id) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Restart type position. Intentionally omits ':' (label/case vs ternary).
+// ',' prefers type-list / multi-declarator type reuse (`void f(int a, size_t b)`)
+// over multi-declarator object lists that reuse a typedef spelling as a name
+// without a shadow (`int a, T` in an inner scope). Shadows cover the common
+// object case; a full type-vs-expression lattice is out of product scope.
+bool isTypeRestart(std::string_view id) {
+    return id == ";" || id == "{" || id == "}" || id == ")" || id == "]"
+            || id == "(" || id == ",";
+}
+
+// Primitive type-specifiers put the next name in declarator position (`int T`).
+// Qualifiers (const/volatile) intentionally keep context (nullopt) so
+// `const foo_t x` still treats foo_t as a typedef_name.
+bool isPrimitiveTypeSpec(std::string_view id) {
+    return id == "int" || id == "char" || id == "void" || id == "short"
+            || id == "long" || id == "signed" || id == "unsigned"
+            || id == "float" || id == "double";
+}
+
+std::optional<LexIdContext> roleAfter(std::string_view id) {
+    if (isTagKeyword(id) || isMemberOp(id) || isStar(id) || isTypedefNameToken(id)
+            || isExpressionCue(id) || isPrimitiveTypeSpec(id)) {
+        return LexIdContext::AsIdentifier;
+    }
+    if (isTypeRestart(id)) {
+        return LexIdContext::AsType;
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+TokenStream::TokenStream(std::function<scanner::Token()> scan, scanner::TypedefRegistry& typedefs) :
+    scan { std::move(scan) },
+    typedefs_ { typedefs },
     currentToken { this->scan() }
 {
 }
 
+// Transitions use the reclassified token id so shadows and type promotions
+// feed roleAfter (not the raw FA id).
+void TokenStream::advanceIdContext(const scanner::Token& token) {
+    if (auto next = roleAfter(token.id)) {
+        idContext_ = *next;
+    }
+}
+
+scanner::Token TokenStream::reclassify(const scanner::Token& token) const {
+    if (token.id != "id" && token.id != "typedef_name") {
+        return token;
+    }
+    if (typedefs_.isIdentifierShadow(token.lexeme)) {
+        return scanner::Token { "id", token.lexeme, token.context };
+    }
+    if (!typedefs_.has(token.lexeme)) {
+        if (token.id == "typedef_name") {
+            return scanner::Token { "id", token.lexeme, token.context };
+        }
+        return token;
+    }
+    if (idContext_ == LexIdContext::AsIdentifier) {
+        return scanner::Token { "id", token.lexeme, token.context };
+    }
+    return scanner::Token { "typedef_name", token.lexeme, token.context };
+}
+
 scanner::Token TokenStream::getCurrentToken() const {
-	return (forgedToken ? *forgedToken : *currentToken);
+    const scanner::Token& raw = forgedToken ? *forgedToken : *currentToken;
+    return reclassify(raw);
 }
 
 scanner::Token TokenStream::nextToken() {
-	if (forgedToken) {
+    scanner::Token consumed = getCurrentToken();
+    advanceIdContext(consumed);
+    if (consumed.id == "{") {
+        typedefs_.pushIdentifierShadowScope();
+    } else if (consumed.id == "}") {
+        typedefs_.popIdentifierShadowScope();
+    }
+    if (forgedToken) {
         forgedToken.reset();
-	} else {
-		currentToken.emplace(scan());
-	}
-	return *currentToken;
+    } else {
+        currentToken.emplace(scan());
+    }
+    return getCurrentToken();
 }
 
 void TokenStream::forgeToken(scanner::Token forgedToken) {
-	this->forgedToken.emplace(forgedToken);
+    this->forgedToken.emplace(forgedToken);
 }
 
 bool TokenStream::currentTokenIsForged() const {
-	return (forgedToken ? true : false);
+    return static_cast<bool>(forgedToken);
 }
 
 } // namespace parser
-

--- a/src/parser/TokenStream.h
+++ b/src/parser/TokenStream.h
@@ -3,25 +3,47 @@
 
 #include "scanner/Token.h"
 
-#include <optional>
 #include <functional>
+#include <optional>
+
+namespace scanner {
+class TypedefRegistry;
+}
 
 namespace parser {
 
+// Role the next identifier plays when its spelling collides with a typedef name.
+// Two-state previous-token machine: transitions live only in roleAfter (TokenStream.cpp).
+// Approximate C (brace-matched shadows on TypedefRegistry); not full type vs expression
+// position. Primitive type-specs force AsIdentifier (`int T`); qualifiers keep type
+// (`const foo_t`). Parser-fed context is the larger redesign if this limit is hit.
+enum class LexIdContext {
+    AsType,        // default: typedef spelling stays typedef_name
+    AsIdentifier,  // object / declarator / member / tag / expression name
+};
+
 class TokenStream {
 public:
-	TokenStream(std::function<scanner::Token()> scan);
+    TokenStream(std::function<scanner::Token()> scan, scanner::TypedefRegistry& typedefs);
 
+    // Live view: reclassifies against current registry (do not cache .id across
+    // reduce-time typedef/shadow writes).
     scanner::Token getCurrentToken() const;
     scanner::Token nextToken();
 
-	void forgeToken(scanner::Token forgedToken);
-	bool currentTokenIsForged() const;
-private:
-    std::function<scanner::Token()> scan;
+    void forgeToken(scanner::Token forgedToken);
+    bool currentTokenIsForged() const;
 
-	std::optional<const scanner::Token> currentToken;
-	std::optional<const scanner::Token> forgedToken;
+private:
+    void advanceIdContext(const scanner::Token& token);
+    scanner::Token reclassify(const scanner::Token& token) const;
+
+    std::function<scanner::Token()> scan;
+    scanner::TypedefRegistry& typedefs_;
+
+    std::optional<const scanner::Token> currentToken;
+    std::optional<const scanner::Token> forgedToken;
+    LexIdContext idContext_ { LexIdContext::AsType };
 };
 
 } // namespace parser

--- a/src/scanner/TypedefRegistry.h
+++ b/src/scanner/TypedefRegistry.h
@@ -30,7 +30,8 @@ public:
     bool has(const std::string& name) const;
     std::optional<type::Type> tryLookup(const std::string& name) const;
 
-    // Shadows are consulted by TokenStream reclassify, not by the FA.
+    // Object declarators that reuse a typedef spelling (AST reduce records;
+    // TokenStream pushes/pops brace frames). Consulted by reclassify, not FA.
     // Auto-root when empty (file-scope objects); see class comment.
     void addIdentifierShadow(const std::string& name);
     bool isIdentifierShadow(const std::string& name) const;

--- a/test/src/parserTest/AcceptActionTest.cpp
+++ b/test/src/parserTest/AcceptActionTest.cpp
@@ -1,3 +1,4 @@
+#include "scanner/TypedefRegistry.h"
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
@@ -37,7 +38,8 @@ TEST(AcceptAction, isDeserializedFromString) {
 TEST(AcceptAction, acceptsTheParse) {
     Action acceptAction = Action::accept();
     std::stack<parse_state> parsingStack;
-    TokenStream tokenStream { [](){ return scanner::Token{"", "", {"",2}}; }};
+    scanner::TypedefRegistry typedefs;
+    TokenStream tokenStream { [](){ return scanner::Token{"", "", {"",2}}; }, typedefs };
     ParseTreeBuilder builder {"test", nullptr};
 
     bool parsingDone = acceptAction.parse(parsingStack, tokenStream, builder);

--- a/test/src/parserTest/ActionValueTest.cpp
+++ b/test/src/parserTest/ActionValueTest.cpp
@@ -6,6 +6,7 @@
 #include "parser/ParsingTable.h"
 #include "parser/ParseTreeBuilder.h"
 #include "parser/TokenStream.h"
+#include "scanner/TypedefRegistry.h"
 
 #include <memory>
 #include <stack>
@@ -82,7 +83,8 @@ TEST(Action, errorParseReportsAndStops) {
     Action error = Action::error(0, cands, &grammar);
 
     std::stack<parse_state> stack;
-    TokenStream tokens { []() { return scanner::Token{ "a", "a", { "", 1 } }; } };
+    scanner::TypedefRegistry typedefs;
+    TokenStream tokens { []() { return scanner::Token{ "a", "a", { "", 1 } }; }, typedefs };
     ParseTreeBuilder treeBuilder { "test", &grammar };
     EXPECT_TRUE(error.parse(stack, tokens, treeBuilder));
 }

--- a/test/src/parserTest/ShiftActionTest.cpp
+++ b/test/src/parserTest/ShiftActionTest.cpp
@@ -1,3 +1,4 @@
+#include "scanner/TypedefRegistry.h"
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
@@ -56,7 +57,8 @@ TEST(ShiftAction, pushesItsStateOnStackAndAdvancesTokenStream) {
     std::stack<parse_state> parsingStack;
     std::vector<scanner::Token> tokens { { "a", "a", { "", 0 } }, { "b", "b", { "", 1 } } };
     int currentToken {0};
-    TokenStream tokenStream { [&]() { return tokens[currentToken++]; } };
+    scanner::TypedefRegistry typedefs;
+    TokenStream tokenStream { [&]() { return tokens[currentToken++]; }, typedefs };
     ParseTreeBuilderMock parseTreeBuilderMock;
 
     EXPECT_CALL(parseTreeBuilderMock, makeTerminalNode("a", "a", testing::_));

--- a/test/src/parserTest/TokenStreamTest.cpp
+++ b/test/src/parserTest/TokenStreamTest.cpp
@@ -3,34 +3,34 @@
 
 #include "TokenMatcher.h"
 
-#include <memory>
-
 #include "parser/TokenStream.h"
-#include "scanner/Scanner.h"
+#include "scanner/TypedefRegistry.h"
 #include "scanner/Token.h"
-#include "translation_unit/Context.h"
+#include "types/Type.h"
 
 using namespace testing;
 using namespace parser;
 using namespace scanner;
 
 TEST(TokenStream, usesScannerToRetrieveNextToken) {
-    std::vector<scanner::Token> tokens { {"id", "variable", {"fileName", 10}}, {"add_op", "+", {"fileName", 50}} };
+    std::vector<scanner::Token> tokens { {"id", "variable", {"fileName", 10}}, {"+", "+", {"fileName", 50}} };
     int currentToken { 0 };
-    TokenStream tokenStream { [&]() { return tokens[currentToken++]; } };
+    scanner::TypedefRegistry typedefs;
+    TokenStream tokenStream { [&]() { return tokens[currentToken++]; }, typedefs };
 
     ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "id", "variable", { "fileName", 10 } }));
     ASSERT_THAT(tokenStream.currentTokenIsForged(), Eq(false));
 
-    ASSERT_THAT(tokenStream.nextToken(), tokenMatches(Token { "add_op", "+", { "fileName", 50 } }));
-    ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "add_op", "+", { "fileName", 50 } }));
+    ASSERT_THAT(tokenStream.nextToken(), tokenMatches(Token { "+", "+", { "fileName", 50 } }));
+    ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "+", "+", { "fileName", 50 } }));
     ASSERT_THAT(tokenStream.currentTokenIsForged(), Eq(false));
 }
 
 TEST(TokenStream, insertsForgedTokenIntoStream) {
-    std::vector<scanner::Token> tokens { {"id", "variable", {"fileName", 10}}, {"add_op", "+", {"fileName", 50}} };
+    std::vector<scanner::Token> tokens { {"id", "variable", {"fileName", 10}}, {"+", "+", {"fileName", 50}} };
     int currentToken { 0 };
-    TokenStream tokenStream { [&]() { return tokens[currentToken++]; } };
+    scanner::TypedefRegistry typedefs;
+    TokenStream tokenStream { [&]() { return tokens[currentToken++]; }, typedefs };
 
     ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "id", "variable", { "fileName", 10 } }));
     ASSERT_THAT(tokenStream.currentTokenIsForged(), Eq(false));
@@ -43,6 +43,224 @@ TEST(TokenStream, insertsForgedTokenIntoStream) {
     ASSERT_THAT(tokenStream.currentTokenIsForged(), Eq(false));
     ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "id", "variable", { "fileName", 10 } }));
 
-    ASSERT_THAT(tokenStream.nextToken(), tokenMatches(Token { "add_op", "+", { "fileName", 50 } }));
-    ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "add_op", "+", { "fileName", 50 } }));
+    ASSERT_THAT(tokenStream.nextToken(), tokenMatches(Token { "+", "+", { "fileName", 50 } }));
+    ASSERT_THAT(tokenStream.getCurrentToken(), tokenMatches(Token { "+", "+", { "fileName", 50 } }));
 }
+
+TEST(TokenStream, reclassifiesTypedefNameInExpressionContext) {
+    // After return, a typedef spelling is an identifier (expression).
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("size_t", type::unsignedLong());
+    std::vector<scanner::Token> tokens {
+        {"return", "return", {"f", 1}},
+        {"typedef_name", "size_t", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "return");
+    ASSERT_EQ(ts.nextToken().id, "id");
+    ASSERT_EQ(ts.getCurrentToken().lexeme, "size_t");
+}
+
+TEST(TokenStream, keepsTypedefNameInTypePosition) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("size_t", type::unsignedLong());
+    std::vector<scanner::Token> tokens {
+        {"typedef_name", "size_t", {"f", 1}},
+        {"id", "x", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "typedef_name");
+    ASSERT_EQ(ts.nextToken().id, "id"); // after typedef_name -> AsIdentifier
+}
+
+TEST(TokenStream, forcesIdWhenIdentifierShadow) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    typedefs.pushIdentifierShadowScope();
+    typedefs.addIdentifierShadow("T");
+    std::vector<scanner::Token> tokens {
+        {"typedef_name", "T", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "id");
+}
+
+TEST(TokenStream, tagAfterStructIsIdentifier) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("S", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"struct", "struct", {"f", 1}},
+        {"typedef_name", "S", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "struct");
+    ASSERT_EQ(ts.nextToken().id, "id");
+}
+
+TEST(TokenStream, memberAfterDotIsIdentifier) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {".", ".", {"f", 1}},
+        {"typedef_name", "T", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, ".");
+    ASSERT_EQ(ts.nextToken().id, "id");
+}
+
+TEST(TokenStream, declaratorAfterStarIsIdentifier) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"typedef_name", "T", {"f", 1}},
+        {"*", "*", {"f", 1}},
+        {"typedef_name", "T", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "typedef_name");
+    ASSERT_EQ(ts.nextToken().id, "*");
+    ASSERT_EQ(ts.nextToken().id, "id");
+}
+
+TEST(TokenStream, braceScopePopsIdentifierShadow) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"{", "{", {"f", 1}},
+        {"typedef_name", "T", {"f", 1}},
+        {"}", "}", {"f", 1}},
+        {"typedef_name", "T", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "{");
+    // nextToken('{') opens a shadow scope; add the shadow on that frame.
+    ts.nextToken();
+    typedefs.addIdentifierShadow("T");
+    ASSERT_EQ(ts.getCurrentToken().id, "id"); // shadowed inside brace
+    ASSERT_EQ(ts.nextToken().id, "}");
+    ASSERT_EQ(ts.nextToken().id, "typedef_name"); // shadow popped
+}
+
+TEST(TokenStream, promotesIdToTypedefNameInTypePosition) {
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"id", "T", {"f", 1}},
+        {"id", "x", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "typedef_name");
+}
+
+TEST(TokenStream, constKeepsTypedefName) {
+    // Qualifiers keep type context: const foo_t x keeps foo_t as typedef_name.
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("foo_t", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"const", "const", {"f", 1}},
+        {"typedef_name", "foo_t", {"f", 1}},
+        {"id", "x", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "const");
+    ASSERT_EQ(ts.nextToken().id, "typedef_name");
+    ASSERT_EQ(ts.getCurrentToken().lexeme, "foo_t");
+}
+
+TEST(TokenStream, afterPrimitiveTypeSpecDeclaratorIsIdentifier) {
+    // After int/char/..., the next spelling is a declarator name (`int T`), not a type.
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"int", "int", {"f", 1}},
+        {"typedef_name", "T", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "int");
+    ASSERT_EQ(ts.nextToken().id, "id");
+    ASSERT_EQ(ts.getCurrentToken().lexeme, "T");
+}
+
+TEST(TokenStream, afterConstThenPrimitiveDeclaratorIsIdentifier) {
+    // const int T: qualifier keeps type, then int forces declarator context.
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("T", type::signedInteger());
+    std::vector<scanner::Token> tokens {
+        {"const", "const", {"f", 1}},
+        {"int", "int", {"f", 1}},
+        {"typedef_name", "T", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "const");
+    ASSERT_EQ(ts.nextToken().id, "int");
+    ASSERT_EQ(ts.nextToken().id, "id");
+    ASSERT_EQ(ts.getCurrentToken().lexeme, "T");
+}
+
+TEST(TokenStream, colonDoesNotForceTypeRestart) {
+    // ':' is intentionally omitted from AsType restart (label/case vs ternary).
+    // After a primary (AsIdentifier), keep context: typedef spelling stays id.
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("size_t", type::unsignedLong());
+    std::vector<scanner::Token> tokens {
+        {"return", "return", {"f", 1}},
+        {"typedef_name", "size_t", {"f", 1}},
+        {":", ":", {"f", 1}},
+        {"typedef_name", "size_t", {"f", 1}},
+        {";", ";", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "return");
+    ASSERT_EQ(ts.nextToken().id, "id"); // expression after return
+    ASSERT_EQ(ts.nextToken().id, ":");
+    // After ':', context kept (AsIdentifier) so next typedef spelling is id.
+    ASSERT_EQ(ts.nextToken().id, "id");
+}
+
+TEST(TokenStream, commaRestartsTypePositionForTypedefName) {
+    // Product: ',' is AsType restart so multi-param type lists work
+    // (`void f(int a, size_t b)` keeps size_t as typedef_name after comma).
+    scanner::TypedefRegistry typedefs;
+    typedefs.add("size_t", type::unsignedLong());
+    std::vector<scanner::Token> tokens {
+        {"int", "int", {"f", 1}},
+        {"id", "a", {"f", 1}},
+        {",", ",", {"f", 1}},
+        {"typedef_name", "size_t", {"f", 1}},
+        {"id", "b", {"f", 1}},
+        {")", ")", {"f", 1}},
+    };
+    int i = 0;
+    TokenStream ts { [&]() { return tokens[i++]; }, typedefs };
+    ASSERT_EQ(ts.getCurrentToken().id, "int");
+    ASSERT_EQ(ts.nextToken().id, "id");
+    ASSERT_EQ(ts.getCurrentToken().lexeme, "a");
+    ASSERT_EQ(ts.nextToken().id, ",");
+    ASSERT_EQ(ts.nextToken().id, "typedef_name");
+    ASSERT_EQ(ts.getCurrentToken().lexeme, "size_t");
+}
+


### PR DESCRIPTION
## Summary

- Add two-state `LexIdContext` with closed `roleAfter` membership tables (AsType / AsIdentifier / keep).
- Single `reclassify` choke point; live `getCurrentToken` reclassifies against the current registry.
- Brace-scoped identifier shadows on `TypedefRegistry`; FA remains membership-only.

## Stack

Phase 2 PR **2 of 6** (base: `phase2/01-lexical-session`).

Depends on #92.

## Test plan

- [x] TokenStream policy tests (expression/type position, shadows, tag/member/star, const keep, after-int, colon non-restart, comma AsType)
- [x] Full `ctest` green on stack tip