### PR TITLE
phase2/03: ParseEnvironment for tags, typedef/enum APIs, session wire

### DIFF
--- a/src/ast/AbstractSyntaxTree.h
+++ b/src/ast/AbstractSyntaxTree.h
@@ -2,7 +2,9 @@
 #define ABSTRACTSYNTAXTREE_H_
 
 #include <iostream>
+#include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "ast/AbstractSyntaxTreeNode.h"
@@ -15,6 +17,8 @@ class AbstractSyntaxTree: public parser::SyntaxTree {
 private:
     std::vector<std::unique_ptr<AbstractSyntaxTreeNode>> translationUnit;
     symbols::AnnotationStore annotations_;
+    // Parse-time enumerators (nested enums included) for SA symbol-table import.
+    std::map<std::string, long> parseEnumConstants_;
 
 public:
     AbstractSyntaxTree(std::vector<std::unique_ptr<AbstractSyntaxTreeNode>> translationUnit);
@@ -25,6 +29,13 @@ public:
 
     symbols::AnnotationStore& annotations() { return annotations_; }
     const symbols::AnnotationStore& annotations() const { return annotations_; }
+
+    void setParseEnumConstants(std::map<std::string, long> constants) {
+        parseEnumConstants_ = std::move(constants);
+    }
+    const std::map<std::string, long>& parseEnumConstants() const {
+        return parseEnumConstants_;
+    }
 
     void accept(ast::AbstractSyntaxTreeVisitor& visitor) const;
     void accept(parser::SyntaxTreeVisitor& visitor) override;

--- a/src/ast/AbstractSyntaxTreeBuilder.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilder.cpp
@@ -7,8 +7,9 @@
 
 namespace ast {
 
-AbstractSyntaxTreeBuilder::AbstractSyntaxTreeBuilder(const parser::Grammar* grammar):
-    syntaxNodeBuilder{*grammar}
+AbstractSyntaxTreeBuilder::AbstractSyntaxTreeBuilder(const parser::Grammar* grammar, scanner::LexicalSession& session):
+    syntaxNodeBuilder{*grammar},
+    treeBuilderContext{session}
 {
 }
 
@@ -24,7 +25,10 @@ void AbstractSyntaxTreeBuilder::makeTerminalNode(std::string type, std::string v
 
 std::unique_ptr<parser::SyntaxTree> AbstractSyntaxTreeBuilder::build() {
     assertBuildable();
-	return std::make_unique<AbstractSyntaxTree>(treeBuilderContext.popTranslationUnit());
+    auto tree = std::make_unique<AbstractSyntaxTree>(treeBuilderContext.popTranslationUnit());
+    // All enumerators registered on the session during parse (for SA import).
+    tree->setParseEnumConstants(treeBuilderContext.environment().enumConstantsSnapshot());
+    return tree;
 }
 
 } // namespace ast

--- a/src/ast/AbstractSyntaxTreeBuilder.h
+++ b/src/ast/AbstractSyntaxTreeBuilder.h
@@ -10,12 +10,13 @@
 #include "parser/SyntaxTreeBuilder.h"
 #include "AbstractSyntaxTreeBuilderContext.h"
 #include "ContextualSyntaxNodeBuilder.h"
+#include "scanner/LexicalSession.h"
 
 namespace ast {
 
 class AbstractSyntaxTreeBuilder: public parser::SyntaxTreeBuilder {
 public:
-    AbstractSyntaxTreeBuilder(const parser::Grammar* grammar);
+    AbstractSyntaxTreeBuilder(const parser::Grammar* grammar, scanner::LexicalSession& session);
     virtual ~AbstractSyntaxTreeBuilder();
 
     void makeTerminalNode(std::string type, std::string value, const translation_unit::Context& context) override;

--- a/src/ast/AbstractSyntaxTreeBuilderContext.cpp
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.cpp
@@ -2,7 +2,8 @@
 
 namespace ast {
 
-AbstractSyntaxTreeBuilderContext::AbstractSyntaxTreeBuilderContext() {
+AbstractSyntaxTreeBuilderContext::AbstractSyntaxTreeBuilderContext(scanner::LexicalSession& session) :
+        environment_ { session } {
 }
 
 void AbstractSyntaxTreeBuilderContext::pushTerminal(TerminalSymbol terminal) {
@@ -295,25 +296,6 @@ std::vector<std::unique_ptr<Declarator>> AbstractSyntaxTreeBuilderContext::popSt
     auto declarators = std::move(structDeclaratorLists.top());
     structDeclaratorLists.pop();
     return declarators;
-}
-
-type::Type AbstractSyntaxTreeBuilderContext::ensureStructTag(const std::string& tag) {
-    auto it = structTags.find(tag);
-    if (it != structTags.end()) {
-        return it->second;
-    }
-    // Incomplete placeholder until a defining body completes the tag.
-    type::Type incomplete = type::incompleteStructure();
-    structTags.insert({ tag, incomplete });
-    return incomplete;
-}
-
-bool AbstractSyntaxTreeBuilderContext::hasStructTag(const std::string& tag) const {
-    return structTags.find(tag) != structTags.end();
-}
-
-type::Type AbstractSyntaxTreeBuilderContext::lookupStructTag(const std::string& tag) const {
-    return structTags.at(tag);
 }
 
 void AbstractSyntaxTreeBuilderContext::newInitializerList() {

--- a/src/ast/AbstractSyntaxTreeBuilderContext.h
+++ b/src/ast/AbstractSyntaxTreeBuilderContext.h
@@ -1,7 +1,6 @@
 #ifndef ABSTRACTSYNTAXTREEBUILDERCONTEXT_H_
 #define ABSTRACTSYNTAXTREEBUILDERCONTEXT_H_
 
-#include <map>
 #include <memory>
 #include <stack>
 #include <string>
@@ -12,6 +11,7 @@
 #include "DeclarationSpecifiers.h"
 #include "FormalArgument.h"
 #include "FunctionDeclarator.h"
+#include "ParseEnvironment.h"
 #include "Pointer.h"
 #include "StorageSpecifier.h"
 #include "TerminalSymbol.h"
@@ -20,13 +20,17 @@
 #include "InitializedDeclarator.h"
 #include "InitializerListExpression.h"
 #include "Declarator.h"
+#include "scanner/LexicalSession.h"
 
 namespace ast {
 
 class AbstractSyntaxTreeBuilderContext {
 public:
-    AbstractSyntaxTreeBuilderContext();
+    explicit AbstractSyntaxTreeBuilderContext(scanner::LexicalSession& session);
     virtual ~AbstractSyntaxTreeBuilderContext() = default;
+
+    ParseEnvironment& environment() { return environment_; }
+    const ParseEnvironment& environment() const { return environment_; }
 
     void pushTerminal(TerminalSymbol terminal);
     TerminalSymbol popTerminal();
@@ -110,10 +114,6 @@ public:
     std::vector<std::pair<std::string, type::Type>> popStructMemberList();
     void addStructDeclarator(std::unique_ptr<Declarator> declarator);
     std::vector<std::unique_ptr<Declarator>> popStructDeclarators();
-    type::Type ensureStructTag(const std::string& tag);
-    bool hasStructTag(const std::string& tag) const;
-    type::Type lookupStructTag(const std::string& tag) const;
-
     void newInitializerList();
     void addInitializerElement(InitializerElement element);
     std::vector<InitializerElement> popInitializerList();
@@ -156,10 +156,11 @@ private:
     std::stack<bool> isUnionStack;
     std::stack<std::vector<std::pair<std::string, type::Type>>> structMemberLists;
     std::stack<std::vector<std::unique_ptr<Declarator>>> structDeclaratorLists;
-    std::map<std::string, type::Type> structTags;
     std::stack<std::vector<InitializerElement>> initializerLists;
 
     std::stack<std::vector<DesignatorStep>> pendingDesignators;
+
+    ParseEnvironment environment_;
 };
 
 }

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ast
         AbstractSyntaxTree.cpp
         AbstractSyntaxTreeBuilder.cpp
         AbstractSyntaxTreeBuilderContext.cpp
+        ParseEnvironment.cpp
         ArithmeticExpression.cpp
         ArrayAccess.cpp
         ArrayDeclarator.cpp
@@ -65,6 +66,7 @@ add_library(ast
         AbstractSyntaxTree.h
         AbstractSyntaxTreeBuilder.h
         AbstractSyntaxTreeBuilderContext.h
+        ParseEnvironment.h
         AbstractSyntaxTreeNode.h
         AbstractSyntaxTreeVisitor.h
         ArithmeticExpression.h
@@ -129,4 +131,4 @@ add_library(ast
     )
 
 trans_target_defaults(ast)
-target_link_libraries(ast PUBLIC parser types symbols)
+target_link_libraries(ast PUBLIC parser types symbols scanner)

--- a/src/ast/ContextualSyntaxNodeBuilder.cpp
+++ b/src/ast/ContextualSyntaxNodeBuilder.cpp
@@ -429,13 +429,14 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
                 auto members = context.popStructMemberList();
                 bool isUnion = context.popIsUnion();
                 // Shared incomplete tag so self-referential members keep one layout identity.
-                type::Type tagType = context.ensureStructTag(tag.value);
+                type::Type tagType = context.environment().ensureStructTag(tag.value);
                 if (isUnion) {
                     type::completeUnion(tagType, std::move(members));
                 } else {
                     type::completeStructure(tagType, std::move(members));
                 }
-                context.pushTypeSpecifier(TypeSpecifier { context.lookupStructTag(tag.value), tag.value });
+                // Shared body: tagType already sees completion via structureBodyIdentity().
+                context.pushTypeSpecifier(TypeSpecifier { tagType, tag.value });
             };
     nodeCreatorRegistry[s_struct_or_union_spec][{ s_struct_or_union, s_open_brace, s_struct_decl_list, s_close_brace }] =
             [](AbstractSyntaxTreeBuilderContext& context) {
@@ -453,10 +454,8 @@ ContextualSyntaxNodeBuilder::ContextualSyntaxNodeBuilder(const parser::Grammar& 
                 auto tag = context.popTerminal();
                 context.popIsUnion(); // layout decided at definition
                 context.popStructMemberList(); // no body
-                if (!context.hasStructTag(tag.value)) {
-                    context.ensureStructTag(tag.value);
-                }
-                context.pushTypeSpecifier(TypeSpecifier { context.lookupStructTag(tag.value), tag.value });
+                context.pushTypeSpecifier(TypeSpecifier {
+                        context.environment().ensureStructTag(tag.value), tag.value });
             };
 
     nodeCreatorRegistry[s_struct_declarator][{ s_declarator }] = [](AbstractSyntaxTreeBuilderContext& context) {

--- a/src/ast/ParseEnvironment.cpp
+++ b/src/ast/ParseEnvironment.cpp
@@ -1,0 +1,63 @@
+#include "ParseEnvironment.h"
+
+#include "types/Type.h"
+
+namespace ast {
+
+ParseEnvironment::ParseEnvironment(scanner::LexicalSession& session) :
+        session_ { session } {
+}
+
+type::Type ParseEnvironment::ensureStructTag(const std::string& tag) {
+    auto it = structTags_.find(tag);
+    if (it != structTags_.end()) {
+        return it->second;
+    }
+    type::Type incomplete = type::incompleteStructure();
+    structTags_.emplace(tag, incomplete);
+    return incomplete;
+}
+
+void ParseEnvironment::defineTypedef(const std::string& name, type::Type type) {
+    // Sole channel for typedef registration (lexer + lookup).
+    session_.typedefs.add(name, type);
+}
+
+std::optional<type::Type> ParseEnvironment::lookupTypedef(const std::string& name) const {
+    return session_.typedefs.tryLookup(name);
+}
+
+void ParseEnvironment::beginEnumDefinition() {
+    enumDefinitionStack_.emplace_back(0L, std::vector<std::pair<std::string, long>> {});
+}
+
+void ParseEnvironment::addEnumerator(std::string name, std::optional<long> explicitValue) {
+    if (enumDefinitionStack_.empty()) {
+        beginEnumDefinition();
+    }
+    auto& frame = enumDefinitionStack_.back();
+    long value = explicitValue ? *explicitValue : frame.first;
+    // Register immediately so later enumerators can fold prior names.
+    session_.enums.add(name, value);
+    frame.second.emplace_back(std::move(name), value);
+    frame.first = value + 1;
+}
+
+bool ParseEnvironment::lookupEnumConstant(const std::string& name, long& value) const {
+    return session_.enums.lookup(name, value);
+}
+
+std::vector<std::pair<std::string, long>> ParseEnvironment::endEnumDefinition() {
+    if (enumDefinitionStack_.empty()) {
+        return {};
+    }
+    auto result = std::move(enumDefinitionStack_.back().second);
+    enumDefinitionStack_.pop_back();
+    return result;
+}
+
+std::map<std::string, long> ParseEnvironment::enumConstantsSnapshot() const {
+    return session_.enums.entries();
+}
+
+} // namespace ast

--- a/src/ast/ParseEnvironment.h
+++ b/src/ast/ParseEnvironment.h
@@ -1,0 +1,49 @@
+#ifndef AST_PARSEENVIRONMENT_H_
+#define AST_PARSEENVIRONMENT_H_
+
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "scanner/LexicalSession.h"
+#include "types/Type.h"
+
+namespace ast {
+
+// Parse-time symbol environment for one translation unit: struct/union tags
+// and typedef/enum names (via LexicalSession). Separate from the bottom-up
+// reduction stacks on AbstractSyntaxTreeBuilderContext.
+class ParseEnvironment {
+public:
+    // Caller owns session; it must outlive this environment.
+    explicit ParseEnvironment(scanner::LexicalSession& session);
+
+    // Returns existing tag type or creates an incomplete record placeholder for the tag
+    // (completed later as struct or union). Sole public tag API.
+    type::Type ensureStructTag(const std::string& tag);
+
+    void defineTypedef(const std::string& name, type::Type type);
+    std::optional<type::Type> lookupTypedef(const std::string& name) const;
+
+    void addEnumerator(std::string name, std::optional<long> explicitValue = std::nullopt);
+    bool lookupEnumConstant(const std::string& name, long& value) const;
+    std::vector<std::pair<std::string, long>> endEnumDefinition();
+    // Snapshot of all parse-time enumerators registered on the session (for SA import).
+    std::map<std::string, long> enumConstantsSnapshot() const;
+
+private:
+    void beginEnumDefinition();
+
+    scanner::LexicalSession& session_;
+    std::map<std::string, type::Type> structTags_;
+    // Enum definition frames: each entry is (next_value, enumerators_so_far).
+    // Nested enums inside an outer enumerator const_exp are not supported
+    // (begin only when the stack is empty; see addEnumerator).
+    std::vector<std::pair<long, std::vector<std::pair<std::string, long>>>> enumDefinitionStack_;
+};
+
+} // namespace ast
+
+#endif // AST_PARSEENVIRONMENT_H_

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -49,7 +49,7 @@ void Compiler::compile(std::string sourceFileName) const {
     scanner::LexicalSession session;
     std::unique_ptr<scanner::Scanner> scanner =
             compilerComponentsFactory.makeScannerForSourceFile(sourceFileName, session);
-    std::unique_ptr<parser::SyntaxTreeBuilder> syntaxTreeBuilder = compilerComponentsFactory.makeSyntaxTreeBuilder(sourceFileName, &grammar);
+    std::unique_ptr<parser::SyntaxTreeBuilder> syntaxTreeBuilder = compilerComponentsFactory.makeSyntaxTreeBuilder(sourceFileName, &grammar, session);
     std::unique_ptr<parser::SyntaxTree> syntaxTree = parser->parse(*scanner, *syntaxTreeBuilder);
 
     semantic_analyzer::SemanticAnalyzer semanticAnalyzer;

--- a/src/driver/CompilerComponentsFactory.cpp
+++ b/src/driver/CompilerComponentsFactory.cpp
@@ -71,15 +71,15 @@ std::unique_ptr<parser::ParsingTable> CompilerComponentsFactory::generateParsing
 }
 
 std::unique_ptr<parser::SyntaxTreeBuilder> CompilerComponentsFactory::makeSyntaxTreeBuilder(
-        std::string sourceFileName, const parser::Grammar* grammar) const
+        std::string sourceFileName, const parser::Grammar* grammar, scanner::LexicalSession& session) const
 {
     if (configuration.usingCustomGrammar()) {
         return std::make_unique<parser::ParseTreeBuilder>(sourceFileName, grammar);
     }
     if (configuration.isSyntaxTreeLoggingEnabled()) {
-        return std::make_unique<driver::VerboseSyntaxTreeBuilder>(sourceFileName, grammar);
+        return std::make_unique<driver::VerboseSyntaxTreeBuilder>(sourceFileName, grammar, session);
     }
-    return std::make_unique<ast::AbstractSyntaxTreeBuilder>(grammar);
+    return std::make_unique<ast::AbstractSyntaxTreeBuilder>(grammar, session);
 }
 
 std::unique_ptr<codegen::AssemblyGenerator> CompilerComponentsFactory::makeAssemblyGenerator(std::ostream* assemblyFile) const {

--- a/src/driver/CompilerComponentsFactory.h
+++ b/src/driver/CompilerComponentsFactory.h
@@ -23,7 +23,7 @@ public:
 
     parser::Grammar makeGrammar() const;
     std::unique_ptr<parser::Parser> makeParser(parser::Grammar* grammar) const;
-    std::unique_ptr<parser::SyntaxTreeBuilder> makeSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar) const;
+    std::unique_ptr<parser::SyntaxTreeBuilder> makeSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar, scanner::LexicalSession& session) const;
 
     std::unique_ptr<codegen::AssemblyGenerator> makeAssemblyGenerator(std::ostream* assemblyFile) const;
 

--- a/src/driver/VerboseSyntaxTreeBuilder.cpp
+++ b/src/driver/VerboseSyntaxTreeBuilder.cpp
@@ -6,8 +6,9 @@
 
 namespace driver {
 
-VerboseSyntaxTreeBuilder::VerboseSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar):
-    astBuilder {grammar},
+VerboseSyntaxTreeBuilder::VerboseSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar,
+        scanner::LexicalSession& session):
+    astBuilder {grammar, session},
     parseTreeBuilder {sourceFileName, grammar},
     sourceFileName {sourceFileName},
     loggingVisitor {sourceFileName}

--- a/src/driver/VerboseSyntaxTreeBuilder.h
+++ b/src/driver/VerboseSyntaxTreeBuilder.h
@@ -5,13 +5,14 @@
 #include <string>
 
 #include "ast/AbstractSyntaxTreeBuilder.h"
+#include "scanner/LexicalSession.h"
 #include "LoggingSyntaxTreeVisitor.h"
 
 namespace driver {
 
 class VerboseSyntaxTreeBuilder : public parser::SyntaxTreeBuilder {
 public:
-    VerboseSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar);
+    VerboseSyntaxTreeBuilder(std::string sourceFileName, const parser::Grammar* grammar, scanner::LexicalSession& session);
     virtual ~VerboseSyntaxTreeBuilder();
 
     void makeTerminalNode(std::string type, std::string value, const translation_unit::Context &context) override;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(astTest
         astTest/DeclarationSpecifiersTest.cpp
         astTest/DeclarationTest.cpp
     astTest/CSNBCreatorsStubTest.cpp
+    astTest/ParseEnvironmentTest.cpp
     astTest/ExpressionDualTypeTest.cpp
         )
 target_link_libraries(astTest PRIVATE semantic_analyzer GTest::gmock_main ast translation_unit)

--- a/test/src/astTest/CSNBCreatorsStubTest.cpp
+++ b/test/src/astTest/CSNBCreatorsStubTest.cpp
@@ -1,25 +1,29 @@
 #include "gtest/gtest.h"
 
 #include "ast/AbstractSyntaxTreeBuilderContext.h"
+#include "scanner/LexicalSession.h"
 #include "ast/CSNB_Internal.h"
 
 namespace {
 
 // Remaining type stubs still throw; integer type-specs are implemented (Phase 1).
 TEST(CSNBCreators, unimplementedTypeStubsThrow) {
-    ast::AbstractSyntaxTreeBuilderContext context;
+    scanner::LexicalSession session;
+    ast::AbstractSyntaxTreeBuilderContext context{session};
     EXPECT_THROW(ast::typedefName(context), std::runtime_error);
     EXPECT_THROW(ast::enumType(context), std::runtime_error);
 }
 
 TEST(CSNBCreators, notImplementedYetFactoryThrows) {
-    ast::AbstractSyntaxTreeBuilderContext context;
+    scanner::LexicalSession session;
+    ast::AbstractSyntaxTreeBuilderContext context{session};
     auto stub = ast::notImplementedYet("feature X");
     EXPECT_THROW(stub(context), std::runtime_error);
 }
 
 TEST(CSNBCreators, doNothingIsNoOp) {
-    ast::AbstractSyntaxTreeBuilderContext context;
+    scanner::LexicalSession session;
+    ast::AbstractSyntaxTreeBuilderContext context{session};
     EXPECT_NO_THROW(ast::doNothing(context));
 }
 

--- a/test/src/astTest/ParseEnvironmentTest.cpp
+++ b/test/src/astTest/ParseEnvironmentTest.cpp
@@ -1,0 +1,41 @@
+#include "gtest/gtest.h"
+
+#include "ast/ParseEnvironment.h"
+#include "scanner/LexicalSession.h"
+#include "types/Type.h"
+
+using namespace ast;
+using namespace scanner;
+
+TEST(ParseEnvironment, ensureStructTagSharesIdentity) {
+    LexicalSession session;
+    ParseEnvironment env{session};
+    type::Type a = env.ensureStructTag("Node");
+    type::Type b = env.ensureStructTag("Node");
+    EXPECT_EQ(a.structureBodyIdentity(), b.structureBodyIdentity());
+    type::Type c = env.ensureStructTag("Node");
+    EXPECT_EQ(c.structureBodyIdentity(), a.structureBodyIdentity());
+}
+
+TEST(ParseEnvironment, typedefAndEnumThroughSession) {
+    LexicalSession session;
+    ParseEnvironment env{session};
+    env.defineTypedef("myint", type::signedInteger());
+    auto t = env.lookupTypedef("myint");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_TRUE(session.typedefs.has("myint"));
+
+    env.addEnumerator("RED");
+    env.addEnumerator("GREEN", 10);
+    env.addEnumerator("BLUE");
+    long v = 0;
+    EXPECT_TRUE(env.lookupEnumConstant("RED", v));
+    EXPECT_EQ(v, 0);
+    EXPECT_TRUE(env.lookupEnumConstant("GREEN", v));
+    EXPECT_EQ(v, 10);
+    EXPECT_TRUE(env.lookupEnumConstant("BLUE", v));
+    EXPECT_EQ(v, 11);
+    auto ended = env.endEnumDefinition();
+    ASSERT_EQ(ended.size(), 3u);
+    EXPECT_EQ(session.enums.entries().at("GREEN"), 10);
+}

--- a/test/src/parserGeneratorTest/LR1ParserGeneratedTableTests.cpp
+++ b/test/src/parserGeneratorTest/LR1ParserGeneratedTableTests.cpp
@@ -35,8 +35,8 @@ void generateAndParseExample(AutomatonKind kind) {
     BNFFileReader reader;
     Grammar grammar = reader.readGrammar(getResourcePath(kProductGrammar));
     LR1Parser parser { std::make_unique<GeneratedParsingTable>(&grammar, kind) };
-    auto syntaxTreeBuilder = factory.makeSyntaxTreeBuilder("test", &grammar);
     scanner::LexicalSession session;
+    auto syntaxTreeBuilder = factory.makeSyntaxTreeBuilder("test", &grammar, session);
     ASSERT_NO_THROW(
             parser.parse(*factory.makeScannerForSourceFile(
                     getTestResourcePath("programs/example_prog.src"), session),

--- a/test/src/parserTest/LR1ParserTest.cpp
+++ b/test/src/parserTest/LR1ParserTest.cpp
@@ -34,8 +34,8 @@ TEST(LR1Parser, parsesTestProgram) {
     auto parsingTable = std::make_unique<FilePersistedParsingTable>(getResourcePath("configuration/parsing_table"), &grammar);
 
     LR1Parser parser { std::move(parsingTable) };
-    auto builder = compilerComponentsFactory.makeSyntaxTreeBuilder("test", &grammar);
     scanner::LexicalSession session;
+    auto builder = compilerComponentsFactory.makeSyntaxTreeBuilder("test", &grammar, session);
     ASSERT_NO_THROW(
             parser.parse(*compilerComponentsFactory.makeScannerForSourceFile(
                     getTestResourcePath("programs/example_prog.src"), session),


### PR DESCRIPTION
## Summary

- Extract `ParseEnvironment` for parse-time symbols: struct/union tags plus typedef/enum façade over `LexicalSession`.
- Peel tag state off `AbstractSyntaxTreeBuilderContext` reduction stacks; CSNB uses `context.environment()` only.
- Wire stack-owned session through Compiler → factory → syntax-tree builder; snapshot enum constants at `build()` for SA.

## Stack

Phase 2 PR **3 of 6** (base: `phase2/02-lex-id-context`).

Depends on #93.

Enum production writers land on PR 04 (#95); typedef declaration-event writers on PR 05 (#96).

## Test plan

- [x] ParseEnvironment unit tests (tag identity, typedef/enum through session)
- [x] Full `ctest` green on stack tip