### PR TITLE
phase2/06: filter attributes, string concat, and header stand-ins

### DIFF
--- a/src/scanner/CMakeLists.txt
+++ b/src/scanner/CMakeLists.txt
@@ -20,3 +20,4 @@ add_library(scanner
 
 trans_target_defaults(scanner)
 target_link_libraries(scanner PUBLIC translation_unit types)
+target_link_libraries(scanner PRIVATE util)

--- a/src/scanner/Scanner.cpp
+++ b/src/scanner/Scanner.cpp
@@ -1,8 +1,90 @@
 #include "Scanner.h"
 
 #include "Token.h"
+#include "util/StringLiteralDecode.h"
+
+#include <cstdio>
+#include <vector>
 
 namespace scanner {
+namespace {
+
+bool isDroppedMarker(const std::string& lexeme) {
+    return lexeme == "__extension__"
+            || lexeme == "__restrict"
+            || lexeme == "__restrict__"
+            || lexeme == "restrict"
+            || lexeme == "__inline__"
+            || lexeme == "__inline"
+            || lexeme == "inline";
+}
+
+// Tokens that may sit between asm/__asm__ and the balanced paren group:
+// classic qualifiers plus C/GNU statement prefixes (asm goto, asm inline).
+bool isAsmPrefix(const std::string& lexeme) {
+    return lexeme == "volatile"
+            || lexeme == "__volatile__"
+            || lexeme == "__volatile"
+            || lexeme == "const"
+            || lexeme == "__const"
+            || lexeme == "__const__"
+            || lexeme == "goto"
+            || lexeme == "inline"
+            || lexeme == "__inline__"
+            || lexeme == "__inline";
+}
+
+bool isAttribute(const std::string& lexeme) {
+    return lexeme == "__attribute__";
+}
+
+bool isAsmKeyword(const std::string& lexeme) {
+    return lexeme == "__asm__" || lexeme == "asm";
+}
+
+bool isAttributeOrAsm(const std::string& lexeme) {
+    return isAttribute(lexeme) || isAsmKeyword(lexeme);
+}
+
+bool isWideStringPrefix(const std::string& lexeme) {
+    return lexeme == "L" || lexeme == "u" || lexeme == "U" || lexeme == "u8";
+}
+
+bool isFuncNameIdent(const std::string& lexeme) {
+    return lexeme == "__func__"
+            || lexeme == "__FUNCTION__"
+            || lexeme == "__PRETTY_FUNCTION__";
+}
+
+std::string encodeStringBody(const std::vector<unsigned char>& bytes) {
+    std::string out;
+    out.reserve(bytes.size() * 4);
+    for (unsigned char b : bytes) {
+        switch (b) {
+        case '\n': out += "\\n"; break;
+        case '\t': out += "\\t"; break;
+        case '\r': out += "\\r"; break;
+        case '\a': out += "\\a"; break;
+        case '\b': out += "\\b"; break;
+        case '\f': out += "\\f"; break;
+        case '\v': out += "\\v"; break;
+        case '\\': out += "\\\\"; break;
+        case '"': out += "\\\""; break;
+        default:
+            if (b >= 0x20 && b <= 0x7e) {
+                out += static_cast<char>(b);
+            } else {
+                char buf[5];
+                std::snprintf(buf, sizeof(buf), "\\%03o", static_cast<unsigned>(b));
+                out += buf;
+            }
+            break;
+        }
+    }
+    return out;
+}
+
+} // namespace
 
 Scanner::Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine, LexicalSession& session) :
         translationUnit { fileName },
@@ -11,13 +93,209 @@ Scanner::Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMac
     automaton->setTypedefRegistry(&session_.typedefs);
 }
 
-Token Scanner::nextToken() {
+void Scanner::pushFront(Token t) {
+    pending.emplace_front(t);
+}
+
+Token Scanner::nextTokenUnfiltered() {
+    if (!pending.empty()) {
+        Token t { pending.front() };
+        pending.pop_front();
+        return t;
+    }
     char currentCharacter;
     do {
         currentCharacter = translationUnit.getNextCharacter();
         automaton->updateState(currentCharacter);
     } while (!automaton->isAtFinalState() && currentCharacter != '\0');
-    return {automaton->getAccumulatedToken(), automaton->getAccumulatedLexeme(), translationUnit.getContext()};
+    return { automaton->getAccumulatedToken(), automaton->getAccumulatedLexeme(),
+            translationUnit.getContext() };
+}
+
+void Scanner::skipBalancedParenGroup() {
+    // Post-E noise path: unclosed parens drain to END rather than erroring.
+    int depth = 1;
+    while (depth > 0) {
+        Token t = nextTokenUnfiltered();
+        if (t.id == Token::END) {
+            break;
+        }
+        if (t.lexeme == "(") {
+            ++depth;
+        } else if (t.lexeme == ")") {
+            --depth;
+        }
+    }
+}
+
+bool Scanner::isStringToken(const Token& t) {
+    return t.id == "string";
+}
+
+Token Scanner::nextTokenBaseFiltered() {
+    for (;;) {
+        Token t = nextTokenUnfiltered();
+        if (t.id == Token::END) {
+            return t;
+        }
+
+        if (t.lexeme == "__const" || t.lexeme == "__const__") {
+            return Token { "const", "const", t.context };
+        }
+        if (t.lexeme == "__signed__" || t.lexeme == "__signed") {
+            return Token { "signed", "signed", t.context };
+        }
+        if (t.lexeme == "__volatile__" || t.lexeme == "__volatile") {
+            return Token { "volatile", "volatile", t.context };
+        }
+
+        // C99 _Bool is 1 byte: expand to "unsigned" "char" (exact-id only so
+        // XML_Bool is untouched).
+        if (t.lexeme == "_Bool") {
+            pushFront(Token { "char", "char", t.context });
+            return Token { "unsigned", "unsigned", t.context };
+        }
+
+        // Extended integer / binary-float spellings from system headers after
+        // gcc -E (linux/types.h __int128, glibc _FloatN). Approximate for parse
+        // and layout only - not full 128-bit / _FloatN ABI.
+        if (t.lexeme == "__int128") {
+            pushFront(Token { "long", "long", t.context });
+            return Token { "long", "long", t.context };
+        }
+        if (t.lexeme == "_Float32") {
+            return Token { "float", "float", t.context };
+        }
+        if (t.lexeme == "_Float64" || t.lexeme == "_Float128"
+                || t.lexeme == "_Float32x" || t.lexeme == "_Float64x") {
+            return Token { "double", "double", t.context };
+        }
+
+        if (isFuncNameIdent(t.lexeme)) {
+            return Token { "string", "\"\"", t.context };
+        }
+
+        if (isDroppedMarker(t.lexeme)) {
+            continue;
+        }
+
+        if (isAttribute(t.lexeme)) {
+            // Only skip a following balanced paren group; do not drop type
+            // qualifiers/keywords that happen to look like asm prefixes.
+            Token next = nextTokenUnfiltered();
+            if (next.id == Token::END) {
+                return next;
+            }
+            if (next.lexeme == "(") {
+                skipBalancedParenGroup();
+            } else {
+                pushFront(next);
+            }
+            continue;
+        }
+
+        if (isAsmKeyword(t.lexeme)) {
+            // Optional prefixes before the paren group (asm volatile (...),
+            // asm goto (...), asm inline (...)).
+            for (;;) {
+                Token next = nextTokenUnfiltered();
+                if (next.id == Token::END) {
+                    return next;
+                }
+                if (isAsmPrefix(next.lexeme)) {
+                    continue;
+                }
+                if (next.lexeme == "(") {
+                    skipBalancedParenGroup();
+                    break;
+                }
+                // No paren group: drop the asm keyword and any consumed prefixes
+                // (prefixes were skipped with continue above, not restored).
+                pushFront(next);
+                break;
+            }
+            continue;
+        }
+
+        return t;
+    }
+}
+
+Token Scanner::nextToken() {
+    Token t = nextTokenBaseFiltered();
+    if (t.id == Token::END) {
+        return t;
+    }
+
+    // Wide / UTF prefixes: L"..." u"..." U"..." u8"..." -> plain string token.
+    // Token members are const, so rebind via a fresh local rather than assign.
+    // Lexical prefixes are independent of typedef tables (id or typedef_name).
+    // Peek base-filtered so dropped markers between L and "..." are transparent
+    // (unlike finishStringToken adjacency, which peeks unfiltered).
+    if ((t.id == "id" || t.id == "typedef_name") && isWideStringPrefix(t.lexeme)) {
+        Token next = nextTokenBaseFiltered();
+        if (!isStringToken(next)) {
+            pushFront(next);
+            return t;
+        }
+        return finishStringToken(next);
+    }
+
+    if (isStringToken(t)) {
+        return finishStringToken(t);
+    }
+
+    return t;
+}
+
+// C adjacent string concatenation (phase 6 after decode). Token is not
+// assignable (const members), so accumulate bytes and build one result.
+// decodeStringLiteralBytes includes trailing NUL; drop it when concatenating
+// interiors so only the final token has one NUL when re-encoded as a source form.
+//
+// Adjacency peeks unfiltered tokens: dropped markers / attributes between
+// literals are NOT transparent (GCC keeps non-adjacent strings separate).
+// Push the separator back so nextTokenBaseFiltered can still drop it later.
+Token Scanner::finishStringToken(const Token& first) {
+    auto takeInterior = [](const Token& t) {
+        auto bytes = util::decodeStringLiteralBytes(t.lexeme);
+        if (!bytes.empty() && bytes.back() == '\0') {
+            bytes.pop_back();
+        }
+        return bytes;
+    };
+    auto bytes = takeInterior(first);
+    for (;;) {
+        Token next = nextTokenUnfiltered();
+        if (next.id == Token::END) {
+            break;
+        }
+        // Noise between strings ends adjacency (do not glue across it).
+        if (isDroppedMarker(next.lexeme) || isAttributeOrAsm(next.lexeme)) {
+            pushFront(next);
+            break;
+        }
+        if (isStringToken(next)) {
+            auto right = takeInterior(next);
+            bytes.insert(bytes.end(), right.begin(), right.end());
+            continue;
+        }
+        if ((next.id == "id" || next.id == "typedef_name") && isWideStringPrefix(next.lexeme)) {
+            Token after = nextTokenUnfiltered();
+            if (isStringToken(after)) {
+                auto right = takeInterior(after);
+                bytes.insert(bytes.end(), right.begin(), right.end());
+                continue;
+            }
+            pushFront(after);
+            pushFront(next);
+            break;
+        }
+        pushFront(next);
+        break;
+    }
+    const std::string lexeme = "\"" + encodeStringBody(bytes) + "\"";
+    return Token { "string", lexeme, first.context };
 }
 
 } // namespace scanner

--- a/src/scanner/Scanner.h
+++ b/src/scanner/Scanner.h
@@ -6,10 +6,16 @@
 #include "scanner/Token.h"
 #include "translation_unit/TranslationUnit.h"
 
+#include <deque>
 #include <memory>
 
 namespace scanner {
 
+// Finite-automaton lexer with a thin token filter so post-gcc -E noise and
+// C lexical conveniences never require a whole-file string rewrite layer:
+// attributes/asm, GNU markers, # lines (TranslationUnit), wide string
+// prefixes, adjacent string concatenation, _Bool, __int128 / _FloatN
+// stand-ins, __func__.
 class Scanner {
 public:
     Scanner(std::string fileName, std::unique_ptr<FiniteAutomaton> stateMachine, LexicalSession& session);
@@ -21,9 +27,17 @@ public:
     TypedefRegistry& typedefs() { return session_.typedefs; }
 
 private:
+    Token nextTokenUnfiltered();
+    Token nextTokenBaseFiltered();
+    Token finishStringToken(const Token& first);
+    void skipBalancedParenGroup();
+    void pushFront(Token t);
+    static bool isStringToken(const Token& t);
+
     TranslationUnit translationUnit;
     std::unique_ptr<FiniteAutomaton> automaton;
     LexicalSession& session_;
+    std::deque<Token> pending;
 };
 
 } // namespace scanner

--- a/src/translation_unit/TranslationUnit.cpp
+++ b/src/translation_unit/TranslationUnit.cpp
@@ -24,12 +24,25 @@ char TranslationUnit::getNextCharacter() {
 }
 
 bool TranslationUnit::advanceLine() {
-    if (std::getline(sourceFile, currentLine)) {
+    // Skip preprocessor directive lines that can survive host gcc -E -P
+    // (e.g. #pragma). Real preprocessing is host gcc; this only keeps the
+    // grammar from seeing leftover # lines.
+    while (std::getline(sourceFile, currentLine)) {
         ++currentLineNumber;
         lineOffset = 0;
+        std::size_t i = 0;
+        while (i < currentLine.size()
+                && (currentLine[i] == ' ' || currentLine[i] == '\t')) {
+            ++i;
+        }
+        if (i < currentLine.size() && currentLine[i] == '#') {
+            continue;
+        }
         return true;
-    } else {
-        return false;
     }
+    // EOF (including after only # lines): do not leave a skipped line readable.
+    currentLine.clear();
+    lineOffset = 0;
+    return false;
 }
 

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(scannerTest
         scannerTest/FiniteAutomatonTest.cpp
         scannerTest/LexFileScannerReaderTest.cpp
         scannerTest/LexicalSessionTest.cpp
+        scannerTest/ScannerFilterTest.cpp
         scannerTest/StateTest.cpp
         scannerTest/TokenMatcher.h
         )

--- a/test/src/scannerTest/ScannerFilterTest.cpp
+++ b/test/src/scannerTest/ScannerFilterTest.cpp
@@ -1,0 +1,440 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "scanner/LexFileScannerReader.h"
+#include "scanner/Scanner.h"
+#include "scanner/LexicalSession.h"
+#include "scanner/Token.h"
+#include "types/Type.h"
+
+#include "ResourceHelpers.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace testing;
+using namespace scanner;
+
+namespace {
+
+std::vector<std::pair<std::string, std::string>> scanIds(const std::string& path) {
+    LexFileScannerReader reader;
+    scanner::LexicalSession session;
+    Scanner scanner { path,
+        reader.fromConfiguration(getResourcePath("configuration/scanner.lex")), session };
+    std::vector<std::pair<std::string, std::string>> out;
+    for (;;) {
+        Token t = scanner.nextToken();
+        if (t.id == Token::END) {
+            break;
+        }
+        out.push_back({ t.id, t.lexeme });
+    }
+    return out;
+}
+
+TEST(ScannerFilter, stripsAttributeAndKeepsDeclaration) {
+    auto path = writeTempSource("scan_attr",
+            "int x __attribute__((unused));\n");
+    auto toks = scanIds(path);
+    ASSERT_THAT(toks.size(), Ge(3u));
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "x");
+    EXPECT_EQ(toks[2].second, ";");
+    for (const auto& t : toks) {
+        EXPECT_THAT(t.second, Not(HasSubstr("__attribute__")));
+        EXPECT_NE(t.second, "unused");
+    }
+}
+
+TEST(ScannerFilter, preservesAttributeTextInsideStringLiteral) {
+    auto path = writeTempSource("scan_attr_str",
+            "const char *p = \"__attribute__((unused))\";\n");
+    auto toks = scanIds(path);
+    bool foundString = false;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            foundString = true;
+            EXPECT_THAT(t.second, HasSubstr("__attribute__"));
+        }
+        EXPECT_NE(t.second, "__attribute__");
+    }
+    EXPECT_TRUE(foundString);
+}
+
+TEST(ScannerFilter, dropsExtensionAndInlineMarkers) {
+    auto path = writeTempSource("scan_ext",
+            "__extension__ __inline__ int f(void) { return 1; }\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "__extension__");
+        EXPECT_NE(t.second, "__inline__");
+        EXPECT_NE(t.second, "inline");
+    }
+    ASSERT_FALSE(toks.empty());
+    EXPECT_EQ(toks[0].second, "int");
+}
+
+TEST(ScannerFilter, mapsGnuConstToConstKeyword) {
+    auto path = writeTempSource("scan_const",
+            "__const int k = 3;\n");
+    auto toks = scanIds(path);
+    ASSERT_GE(toks.size(), 2u);
+    EXPECT_EQ(toks[0].first, "const");
+    EXPECT_EQ(toks[0].second, "const");
+    EXPECT_EQ(toks[1].second, "int");
+}
+
+TEST(ScannerFilter, mapsGnuConstDunderToConstKeyword) {
+    auto path = writeTempSource("scan_const2",
+            "__const__ int k = 3;\n");
+    auto toks = scanIds(path);
+    ASSERT_GE(toks.size(), 2u);
+    EXPECT_EQ(toks[0].first, "const");
+    EXPECT_EQ(toks[0].second, "const");
+}
+
+TEST(ScannerFilter, dropsPragmaLines) {
+    auto path = writeTempSource("scan_pragma",
+            "#pragma once\nint x;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "pragma");
+        EXPECT_NE(t.second, "once");
+    }
+    ASSERT_GE(toks.size(), 3u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "x");
+}
+
+TEST(ScannerFilter, stripsAsmBalancedForm) {
+    auto path = writeTempSource("scan_asm",
+            "int y __asm__(\"x\");\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "__asm__");
+    }
+    ASSERT_GE(toks.size(), 3u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "y");
+    EXPECT_EQ(toks[2].second, ";");
+}
+
+TEST(ScannerFilter, dropsC99InlineKeyword) {
+    auto path = writeTempSource("scan_inline",
+            "static inline int f(void) { return 1; }\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "inline");
+    }
+    ASSERT_GE(toks.size(), 2u);
+    EXPECT_EQ(toks[0].second, "static");
+    EXPECT_EQ(toks[1].second, "int");
+}
+
+TEST(ScannerFilter, preservesInlineInsideStringLiteral) {
+    auto path = writeTempSource("scan_inline_str",
+            "const char *p = \"inline \";\n");
+    auto toks = scanIds(path);
+    bool found = false;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            found = true;
+            EXPECT_THAT(t.second, HasSubstr("inline"));
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+// --- Phase B: lexical features formerly implemented as source string rewrites ---
+
+TEST(ScannerFilter, stripsWideStringPrefixL) {
+    auto path = writeTempSource("scan_wide_l",
+            "const char *p = L\"NULL\";\n");
+    auto toks = scanIds(path);
+    bool found = false;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            found = true;
+            EXPECT_EQ(t.second, "\"NULL\"");
+        }
+        EXPECT_NE(t.second, "L");
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST(ScannerFilter, stripsU8StringPrefix) {
+    auto path = writeTempSource("scan_wide_u8",
+            "const char *p = u8\"hi\";\n");
+    auto toks = scanIds(path);
+    bool found = false;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            found = true;
+            EXPECT_EQ(t.second, "\"hi\"");
+        }
+        EXPECT_NE(t.second, "u8");
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST(ScannerFilter, concatenatesAdjacentStringLiterals) {
+    auto path = writeTempSource("scan_concat",
+            "const char *p = \"ab\" \"cd\";\n");
+    auto toks = scanIds(path);
+    int stringCount = 0;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            ++stringCount;
+            EXPECT_EQ(t.second, "\"abcd\"");
+        }
+    }
+    EXPECT_EQ(stringCount, 1);
+}
+
+TEST(ScannerFilter, hexStringConcatDoesNotMergeEscapes) {
+    // C phases: convert escapes then concatenate. "\\x09" "def" must not become
+    // one hex escape \\x09def.
+    auto path = writeTempSource("scan_hex_concat",
+            "const char *p = \"\\x09\" \"def\";\n");
+    auto toks = scanIds(path);
+    int stringCount = 0;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            ++stringCount;
+            EXPECT_THAT(t.second, Not(HasSubstr("\\x09def")));
+            // Decoded 0x09 + "def"; re-encode prefers named escape for tab.
+            EXPECT_EQ(t.second, "\"\\tdef\"");
+        }
+    }
+    EXPECT_EQ(stringCount, 1);
+}
+
+TEST(ScannerFilter, concatenatesWideAndPlainAdjacentStrings) {
+    auto path = writeTempSource("scan_wide_concat",
+            "const char *p = L\"hi\" \"there\";\n");
+    auto toks = scanIds(path);
+    int stringCount = 0;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            ++stringCount;
+            EXPECT_EQ(t.second, "\"hithere\"");
+        }
+        EXPECT_NE(t.second, "L");
+    }
+    EXPECT_EQ(stringCount, 1);
+}
+
+TEST(ScannerFilter, mapsBoolToUnsignedCharTokens) {
+    auto path = writeTempSource("scan_bool", "_Bool b;\n");
+    auto toks = scanIds(path);
+    ASSERT_GE(toks.size(), 3u);
+    EXPECT_EQ(toks[0].second, "unsigned");
+    EXPECT_EQ(toks[1].second, "char");
+    EXPECT_EQ(toks[2].second, "b");
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "_Bool");
+    }
+}
+
+// linux/types.h after gcc -E: typedef __signed__ __int128 __s128 ...
+// Approximate as long long so the typedef name is not eaten as a type.
+TEST(ScannerFilter, mapsInt128ToLongLongTokens) {
+    auto path = writeTempSource("scan_int128",
+            "typedef __signed__ __int128 __s128;\n"
+            "typedef unsigned __int128 __u128;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "__int128");
+    }
+    // signed long long __s128 ; unsigned long long __u128 ;
+    ASSERT_GE(toks.size(), 10u);
+    EXPECT_EQ(toks[0].second, "typedef");
+    EXPECT_EQ(toks[1].second, "signed");
+    EXPECT_EQ(toks[2].second, "long");
+    EXPECT_EQ(toks[3].second, "long");
+    EXPECT_EQ(toks[4].second, "__s128");
+    EXPECT_EQ(toks[5].second, ";");
+    EXPECT_EQ(toks[6].second, "typedef");
+    EXPECT_EQ(toks[7].second, "unsigned");
+    EXPECT_EQ(toks[8].second, "long");
+    EXPECT_EQ(toks[9].second, "long");
+    EXPECT_EQ(toks[10].second, "__u128");
+}
+
+// glibc floatN after gcc -E: map ISO/IEC TS 18661 spellings to float/double.
+TEST(ScannerFilter, mapsExtendedFloatTypes) {
+    auto path = writeTempSource("scan_floatn",
+            "_Float32 a; _Float64 b; _Float128 c; _Float32x d; _Float64x e;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_THAT(t.second, Not(HasSubstr("_Float")));
+    }
+    ASSERT_GE(toks.size(), 10u);
+    EXPECT_EQ(toks[0].second, "float");
+    EXPECT_EQ(toks[1].second, "a");
+    EXPECT_EQ(toks[3].second, "double");
+    EXPECT_EQ(toks[4].second, "b");
+    EXPECT_EQ(toks[6].second, "double");
+    EXPECT_EQ(toks[7].second, "c");
+    EXPECT_EQ(toks[9].second, "double");
+    EXPECT_EQ(toks[10].second, "d");
+    EXPECT_EQ(toks[12].second, "double");
+    EXPECT_EQ(toks[13].second, "e");
+}
+
+TEST(ScannerFilter, doesNotRewriteXmlBoolSuffix) {
+    auto path = writeTempSource("scan_xml_bool", "XML_Bool flag;\n");
+    auto toks = scanIds(path);
+    ASSERT_GE(toks.size(), 2u);
+    EXPECT_EQ(toks[0].second, "XML_Bool");
+    EXPECT_EQ(toks[1].second, "flag");
+    for (const auto& t : toks) {
+        EXPECT_THAT(t.second, Not(HasSubstr("XMLunsigned")));
+    }
+}
+
+TEST(ScannerFilter, mapsFuncIdentifiersToEmptyString) {
+    auto path = writeTempSource("scan_func",
+            "const char *a = __func__;\n"
+            "const char *b = __FUNCTION__;\n"
+            "const char *c = __PRETTY_FUNCTION__;\n");
+    auto toks = scanIds(path);
+    int emptyStrings = 0;
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "__func__");
+        EXPECT_NE(t.second, "__FUNCTION__");
+        EXPECT_NE(t.second, "__PRETTY_FUNCTION__");
+        if (t.first == "string" && t.second == "\"\"") {
+            ++emptyStrings;
+        }
+    }
+    EXPECT_EQ(emptyStrings, 3);
+}
+
+TEST(ScannerFilter, preservesFuncTextInsideStringLiteral) {
+    auto path = writeTempSource("scan_func_str",
+            "const char *msg = \"call __func__ here\";\n");
+    auto toks = scanIds(path);
+    bool found = false;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            found = true;
+            EXPECT_THAT(t.second, HasSubstr("__func__"));
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+
+TEST(ScannerFilter, stripsAsmVolatileForm) {
+    auto path = writeTempSource("scan_asm_vol", "int x; asm volatile (\"nop\"); int y;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "asm");
+        EXPECT_NE(t.second, "volatile");
+        EXPECT_NE(t.second, "nop");
+    }
+    ASSERT_GE(toks.size(), 6u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "x");
+}
+
+TEST(ScannerFilter, stripsAsmGotoForm) {
+    auto path = writeTempSource("scan_asm_goto",
+            "int x; asm goto (\"nop\" : : : : lab); int y;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "asm");
+        EXPECT_NE(t.second, "goto");
+        EXPECT_NE(t.second, "nop");
+        EXPECT_NE(t.second, "lab");
+    }
+    // Stripped form leaves the trailing statement ';' (int x ; ; int y ;).
+    ASSERT_EQ(toks.size(), 7u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "x");
+    EXPECT_EQ(toks[2].second, ";");
+    EXPECT_EQ(toks[3].second, ";");
+    EXPECT_EQ(toks[4].second, "int");
+    EXPECT_EQ(toks[5].second, "y");
+    EXPECT_EQ(toks[6].second, ";");
+}
+
+TEST(ScannerFilter, stripsAsmInlineForm) {
+    auto path = writeTempSource("scan_asm_inline",
+            "int x; asm inline (\"nop\"); int y;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "asm");
+        EXPECT_NE(t.second, "inline");
+        EXPECT_NE(t.second, "nop");
+    }
+    ASSERT_GE(toks.size(), 6u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "x");
+}
+
+TEST(ScannerFilter, stripsAsmVolatileGotoForm) {
+    // Multi-prefix pin: isAsmPrefix loop accepts volatile then goto before the group.
+    auto path = writeTempSource("scan_asm_vol_goto",
+            "int x; asm volatile goto (\"nop\" : : : : lab); int y;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "asm");
+        EXPECT_NE(t.second, "volatile");
+        EXPECT_NE(t.second, "goto");
+        EXPECT_NE(t.second, "nop");
+        EXPECT_NE(t.second, "lab");
+    }
+    ASSERT_EQ(toks.size(), 7u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "x");
+    EXPECT_EQ(toks[2].second, ";");
+    EXPECT_EQ(toks[3].second, ";");
+    EXPECT_EQ(toks[4].second, "int");
+    EXPECT_EQ(toks[5].second, "y");
+    EXPECT_EQ(toks[6].second, ";");
+}
+
+TEST(ScannerFilter, dropsRestrictKeyword) {
+    auto path = writeTempSource("scan_restrict", "int * restrict p;\n");
+    auto toks = scanIds(path);
+    for (const auto& t : toks) {
+        EXPECT_NE(t.second, "restrict");
+    }
+    ASSERT_GE(toks.size(), 4u);
+    EXPECT_EQ(toks[0].second, "int");
+    EXPECT_EQ(toks[1].second, "*");
+    EXPECT_EQ(toks[2].second, "p");
+}
+
+
+TEST(ScannerFilter, noiseBetweenStringsDoesNotConcat) {
+    auto path = writeTempSource("scan_noise_concat",
+            "const char *p = \"ab\" __extension__ \"cd\";\n");
+    auto toks = scanIds(path);
+    int stringCount = 0;
+    for (const auto& t : toks) {
+        if (t.first == "string") {
+            ++stringCount;
+            EXPECT_THAT(t.second, AnyOf(Eq("\"ab\""), Eq("\"cd\"")));
+        }
+    }
+    EXPECT_EQ(stringCount, 2);
+}
+
+TEST(ScannerFilter, widePrefixWorksWhenSpellingIsTypedefName) {
+    auto path = writeTempSource("scan_wide_typedef", "L\"hi\";\n");
+    LexFileScannerReader reader;
+    LexicalSession session;
+    session.typedefs.add("L", type::signedInteger());
+    Scanner scanner{path, reader.fromConfiguration(getResourcePath("configuration/scanner.lex")), session};
+    // FA emits typedef_name for L; filter must still strip prefix and yield "hi".
+    Token first = scanner.nextToken();
+    ASSERT_EQ(first.id, "string");
+    EXPECT_EQ(first.lexeme, "\"hi\"");
+}
+
+} // namespace

--- a/test/src/scannerTest/ScannerTokensTest.cpp
+++ b/test/src/scannerTest/ScannerTokensTest.cpp
@@ -9,11 +9,8 @@
 
 #include "ResourceHelpers.h"
 
-#include <cerrno>
-#include <fstream>
 #include <stdexcept>
 #include <string>
-#include <sys/stat.h>
 #include <utility>
 #include <vector>
 
@@ -21,21 +18,6 @@ using namespace testing;
 using namespace scanner;
 
 namespace {
-
-std::string writeTempSource(const std::string &name, const std::string &contents) {
-    // test/programs/tmp is gitignored; create if needed (same path layout as SourceProgram).
-    const std::string dir = getTestResourcePath("programs/tmp/");
-    if (mkdir(dir.c_str(), 0777) == -1 && errno != 17) {
-        throw std::runtime_error("Could not create " + dir);
-    }
-    const std::string path = dir + name + ".src";
-    std::ofstream out(path);
-    if (!out) {
-        throw std::runtime_error("Could not write " + path);
-    }
-    out << contents;
-    return path;
-}
 
 std::vector<Token> scanAll(const std::string &path) {
     LexFileScannerReader reader;

--- a/test/src/translation_unitTest/TranslationUnitTest.cpp
+++ b/test/src/translation_unitTest/TranslationUnitTest.cpp
@@ -6,6 +6,7 @@
 #include "ResourceHelpers.h"
 
 #include <stdexcept>
+#include <string>
 
 using namespace testing;
 
@@ -43,4 +44,46 @@ TEST(TranslationUnit, returnsCharactersFromInputFile) {
 	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('\0'));
 	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('\0'));
 	ASSERT_THAT(translationUnit.getContext().getOffset(), TypedEq<std::size_t>(4));
+}
+
+// Pin: leftover preprocessor lines (including indented #) are dropped in the
+// translation unit, not in the scanner filter stack.
+TEST(TranslationUnit, skipsPragmaAndIndentedHashLines) {
+	const std::string path = writeTempSource("tu_hash_skip",
+			"#pragma once\n"
+			"\t# indent-hash\n"
+			"int x;\n");
+	TranslationUnit translationUnit(path);
+
+	// Two skipped lines still advance the physical line counter.
+	ASSERT_THAT(translationUnit.getContext().getOffset(), TypedEq<std::size_t>(3));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('i'));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('n'));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('t'));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq(' '));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('x'));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq(';'));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('\0'));
+}
+
+// All-# files must not re-emit the last skipped line as content.
+TEST(TranslationUnit, allHashLinesYieldImmediateEof) {
+	const std::string path = writeTempSource("tu_all_hash",
+			"#pragma once\n"
+			"#define FOO 1\n");
+	TranslationUnit translationUnit(path);
+
+	ASSERT_THAT(translationUnit.getContext().getOffset(), TypedEq<std::size_t>(2));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('\0'));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('\0'));
+}
+
+TEST(TranslationUnit, allIndentedHashLinesYieldImmediateEof) {
+	const std::string path = writeTempSource("tu_all_indent_hash",
+			"\t# pragma\n"
+			"  # indent\n");
+	TranslationUnit translationUnit(path);
+
+	ASSERT_THAT(translationUnit.getContext().getOffset(), TypedEq<std::size_t>(2));
+	ASSERT_THAT(translationUnit.getNextCharacter(), Eq('\0'));
 }

--- a/test/src/util/ResourceHelpers.cpp
+++ b/test/src/util/ResourceHelpers.cpp
@@ -1,5 +1,10 @@
 #include "ResourceHelpers.h"
 
+#include <cerrno>
+#include <fstream>
+#include <stdexcept>
+#include <sys/stat.h>
+
 std::string getResourcesBaseDir() {
     return "../../../";
 }
@@ -10,4 +15,18 @@ std::string getResourcePath(std::string resource) {
 
 std::string getTestResourcePath(std::string resource) {
     return "../../../test/" + resource;
+}
+
+std::string writeTempSource(const std::string& name, const std::string& contents) {
+    const std::string dir = getTestResourcePath("programs/tmp/");
+    if (mkdir(dir.c_str(), 0777) == -1 && errno != EEXIST) {
+        throw std::runtime_error("Could not create " + dir);
+    }
+    const std::string path = dir + name + ".src";
+    std::ofstream out(path);
+    if (!out) {
+        throw std::runtime_error("Could not write temp source " + path);
+    }
+    out << contents;
+    return path;
 }

--- a/test/src/util/ResourceHelpers.h
+++ b/test/src/util/ResourceHelpers.h
@@ -7,4 +7,7 @@ std::string getResourcesBaseDir();
 std::string getResourcePath(std::string resource);
 std::string getTestResourcePath(std::string resource);
 
+// Write contents under test/programs/tmp/<name>.src (gitignored). Returns the path.
+std::string writeTempSource(const std::string& name, const std::string& contents);
+
 #endif


### PR DESCRIPTION
## Summary

- Post-`gcc -E` token filters on `Scanner`: attributes/asm, dropped markers, wide prefixes, adjacent-string concat, type stand-ins (`_Bool`, `__int128`, `_FloatN`, `__func__`).
- Line-oriented `#` skip in `TranslationUnit` (including all-`#` EOF clear so skipped lines are not re-emitted).
- Three-tier path: unfiltered → base-filtered → wide/concat. Shared test `writeTempSource` helper.

## Stack

Phase 2 PR **6 of 6** (base: `phase2/05-typedef`). Tip of the stack.

Depends on #96.

## Test plan

- [x] `ScannerFilterTest` behavioral suite (attrs, asm multi-prefix, concat, stand-ins, noise between strings)
- [x] TU `#` skip + all-hash EOF pins
- [x] Full `ctest` 19/19 green on tip