### PR TITLE
feat(codegen): PIE-safe NASM emission and drop -no-pie

### DIFF
--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -51,6 +51,16 @@ std::string ATandTInstructionSet::call(std::string procedureName) const {
     return "call " + procedureName;
 }
 
+std::string ATandTInstructionSet::callPlt(std::string procedureName) const {
+    return "call " + procedureName + "@plt";
+}
+
+std::string ATandTInstructionSet::loadGot(std::string symbolName, const Register& target) const {
+    (void)symbolName;
+    (void)target;
+    throw std::runtime_error { "not implemented ATandTInstructionSet::loadGot" };
+}
+
 std::string ATandTInstructionSet::push(const Register& reg) const {
     return "pushq " + registerAccess(reg);
 }

--- a/src/codegen/ATandTInstructionSet.h
+++ b/src/codegen/ATandTInstructionSet.h
@@ -13,6 +13,8 @@ public:
             const std::vector<GlobalVariable>& globalVariables = {}) const override;
 
     std::string call(std::string procedureName) const override;
+    std::string callPlt(std::string procedureName) const override;
+    std::string loadGot(std::string symbolName, const Register& target) const override;
 
     std::string push(const Register& reg) const override;
     std::string pop(const Register& reg) const override;

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -1,6 +1,7 @@
 #include "AssemblyGenerator.h"
 
 #include <algorithm>
+#include <string>
 
 namespace codegen {
 
@@ -15,6 +16,13 @@ void AssemblyGenerator::generateAssemblyCode(
         const std::vector<GlobalVariable>& globalVariables)
 {
     stackMachine->generatePreamble(constants, globalVariables);
+    // All same-TU procedure names before any call/FunctionAddress (order-independent).
+    for (const auto& quadruple : quadruples) {
+        std::string procedureName;
+        if (quadruple->definesProcedure(procedureName)) {
+            stackMachine->registerDefinedProcedure(std::move(procedureName));
+        }
+    }
     for (const auto& quadruple : quadruples) {
         quadruple->generateCode(*this);
     }
@@ -90,6 +98,10 @@ void AssemblyGenerator::generateCodeFor(const Assign& assign) {
 
 void AssemblyGenerator::generateCodeFor(const AssignConstant& assignConstant) {
     stackMachine->assignConstant(assignConstant.getConstant(), assignConstant.getResult());
+}
+
+void AssemblyGenerator::generateCodeFor(const AssignLabelAddress& assignLabelAddress) {
+    stackMachine->assignLabelAddress(assignLabelAddress.getLabel(), assignLabelAddress.getResult());
 }
 
 void AssemblyGenerator::generateCodeFor(const LvalueAssign& lvalueAssign) {

--- a/src/codegen/AssemblyGenerator.h
+++ b/src/codegen/AssemblyGenerator.h
@@ -22,6 +22,7 @@
 #include "quadruples/UnaryNot.h"
 #include "quadruples/Assign.h"
 #include "quadruples/AssignConstant.h"
+#include "quadruples/AssignLabelAddress.h"
 #include "quadruples/LvalueAssign.h"
 #include "quadruples/Argument.h"
 #include "quadruples/Call.h"
@@ -68,6 +69,7 @@ public:
     void generateCodeFor(const UnaryNot& unaryNot);
     void generateCodeFor(const Assign& assign);
     void generateCodeFor(const AssignConstant& assignConstant);
+    void generateCodeFor(const AssignLabelAddress& assignLabelAddress);
     void generateCodeFor(const LvalueAssign& lvalueAssign);
     void generateCodeFor(const Argument& argument);
     void generateCodeFor(const Call& call);

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(backend
         quadruples/Argument.cpp
         quadruples/Assign.cpp
         quadruples/AssignConstant.cpp
+        quadruples/AssignLabelAddress.cpp
         quadruples/BasicBlock.cpp
         quadruples/Call.cpp
         quadruples/Dec.cpp
@@ -56,6 +57,7 @@ add_library(backend
         quadruples/Argument.h
         quadruples/Assign.h
         quadruples/AssignConstant.h
+        quadruples/AssignLabelAddress.h
         quadruples/BasicBlock.h
         quadruples/Call.h
         quadruples/Dec.h

--- a/src/codegen/CodeGeneratingVisitor.cpp
+++ b/src/codegen/CodeGeneratingVisitor.cpp
@@ -13,6 +13,7 @@
 #include "quadruples/Call.h"
 #include "quadruples/Retrieve.h"
 #include "quadruples/AssignConstant.h"
+#include "quadruples/AssignLabelAddress.h"
 #include "quadruples/Inc.h"
 #include "quadruples/IndexAddress.h"
 #include "quadruples/PointerDiff.h"
@@ -188,9 +189,8 @@ void CodeGeneratingVisitor::visit(ast::ConstantExpression& constant) {
 }
 
 void CodeGeneratingVisitor::visit(ast::StringLiteralExpression& stringLiteral) {
-    instructions.push_back(
-        std::make_unique<AssignConstant>(stringLiteral.getConstantSymbol(), stringLiteral.getResultSymbol(store_)->getName())
-    );
+    instructions.push_back(std::make_unique<AssignLabelAddress>(
+            stringLiteral.getConstantSymbol(), stringLiteral.getResultSymbol(store_)->getName()));
 }
 
 namespace {

--- a/src/codegen/InstructionSet.h
+++ b/src/codegen/InstructionSet.h
@@ -20,6 +20,10 @@ public:
             const std::vector<GlobalVariable>& globalVariables = {}) const = 0;
 
     virtual std::string call(std::string procedureName) const = 0;
+    // Extern direct call via PLT (PIE-safe against DSO symbols).
+    virtual std::string callPlt(std::string procedureName) const = 0;
+    // Load address of an extern symbol from the GOT into target (PIE-safe).
+    virtual std::string loadGot(std::string symbolName, const Register& target) const = 0;
 
     virtual std::string push(const Register& reg) const = 0;
     virtual std::string pop(const Register& reg) const = 0;

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -157,7 +157,16 @@ std::string IntelInstructionSet::cmp(const MemoryOperand& leftArgument, int cons
 }
 
 std::string IntelInstructionSet::call(std::string procedureName) const {
+    // Same-TU or register target (indirect). Externs use callPlt.
     return "call " + procedureName;
+}
+
+std::string IntelInstructionSet::callPlt(std::string procedureName) const {
+    return "call " + procedureName + " wrt ..plt";
+}
+
+std::string IntelInstructionSet::loadGot(std::string symbolName, const Register& target) const {
+    return "mov " + target.getName() + ", [rel " + symbolName + " wrt ..got]";
 }
 
 std::string IntelInstructionSet::jmp(std::string label) const {

--- a/src/codegen/IntelInstructionSet.h
+++ b/src/codegen/IntelInstructionSet.h
@@ -15,6 +15,8 @@ public:
             const std::vector<GlobalVariable>& globalVariables = {}) const override;
 
     std::string call(std::string procedureName) const override;
+    std::string callPlt(std::string procedureName) const override;
+    std::string loadGot(std::string symbolName, const Register& target) const override;
 
     std::string push(const Register& reg) const override;
     std::string pop(const Register& reg) const override;

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -30,10 +30,19 @@ void StackMachine::generatePreamble(const std::map<std::string, std::string>& co
     }
 }
 
+void StackMachine::registerDefinedProcedure(std::string procedureName) {
+    definedProcedures.insert(std::move(procedureName));
+}
+
+bool StackMachine::isDefinedProcedure(const std::string& name) const {
+    return definedProcedures.count(name) > 0;
+}
+
 void StackMachine::startProcedure(std::string procedureName, std::vector<Value> values, std::vector<Value> arguments) {
 
     emptyGeneralPurposeRegisters();
     frameHomes.clear();
+    // definedProcedures is filled by AssemblyGenerator pre-pass (registerDefinedProcedure).
     assembly.label(instructionSet->label(procedureName));
     assembly << instructionSet->push(registers->getBasePointer());
     assembly << instructionSet->mov(registers->getStackPointer(), registers->getBasePointer());
@@ -217,7 +226,13 @@ void StackMachine::addressOf(std::string operandName, std::string resultName) {
 
 void StackMachine::functionAddress(std::string functionName, std::string resultName) {
     Register& resultRegister = get64BitRegister();
-    assembly << instructionSet->lea(MemoryOperand::global(functionName), resultRegister);
+    if (isDefinedProcedure(functionName)) {
+        // Same-TU definition: PC-relative lea is PIE-safe.
+        assembly << instructionSet->lea(MemoryOperand::global(functionName), resultRegister);
+    } else {
+        // Extern (e.g. printf): load from the GOT for PIE.
+        assembly << instructionSet->loadGot(functionName, resultRegister);
+    }
     bindResult(resultRegister, resolve(resultName));
 }
 
@@ -337,6 +352,18 @@ void StackMachine::assignConstant(std::string constant, std::string resultName) 
     }
 }
 
+void StackMachine::assignLabelAddress(std::string label, std::string resultName) {
+    // Pool/data labels (e.g. $c1): absolute immediates are not PIE-safe.
+    auto& result = resolve(resultName);
+    Register& addr = get64BitRegister();
+    assembly << instructionSet->lea(MemoryOperand::global(label), addr);
+    if (residesInMemory(result)) {
+        assembly << instructionSet->mov(addr, memoryOperand(result));
+    } else {
+        assembly << instructionSet->mov(addr, result.getAssignedRegister());
+    }
+}
+
 void StackMachine::lvalueAssign(std::string operandName, std::string resultName) {
     auto& operand = resolve(operandName);
     auto& result = resolve(resultName);
@@ -390,7 +417,14 @@ int StackMachine::emitCallArguments() {
 
 void StackMachine::callProcedure(std::string procedureName) {
     int argumentOffset = emitCallArguments();
-    assembly << instructionSet->call(procedureName);
+    // Same-TU: plain call (PIE-safe PC32 to a defined symbol).
+    // Extern: PLT so link against libc works for PIE executables.
+    // (Local `call f wrt ..plt` is invalid NASM.)
+    if (isDefinedProcedure(procedureName)) {
+        assembly << instructionSet->call(procedureName);
+    } else {
+        assembly << instructionSet->callPlt(procedureName);
+    }
     if (argumentOffset) {
         assembly << instructionSet->add(registers->getStackPointer(), argumentOffset);
     }

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -353,15 +353,11 @@ void StackMachine::assignConstant(std::string constant, std::string resultName) 
 }
 
 void StackMachine::assignLabelAddress(std::string label, std::string resultName) {
-    // Pool/data labels (e.g. $c1): absolute immediates are not PIE-safe.
-    auto& result = resolve(resultName);
-    Register& addr = get64BitRegister();
-    assembly << instructionSet->lea(MemoryOperand::global(label), addr);
-    if (residesInMemory(result)) {
-        assembly << instructionSet->mov(addr, memoryOperand(result));
-    } else {
-        assembly << instructionSet->mov(addr, result.getAssignedRegister());
-    }
+    // Pool/data labels (e.g. $c1): same discipline as functionAddress — lea into
+    // scratch then bindResult (lazy store for locals; never self-mov into home).
+    Register& resultRegister = get64BitRegister();
+    assembly << instructionSet->lea(MemoryOperand::global(label), resultRegister);
+    bindResult(resultRegister, resolve(resultName));
 }
 
 void StackMachine::lvalueAssign(std::string operandName, std::string resultName) {

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <ostream>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -58,6 +59,7 @@ public:
 
     void assign(std::string operandName, std::string resultName);
     void assignConstant(std::string constant, std::string resultName);
+    void assignLabelAddress(std::string label, std::string resultName);
     void lvalueAssign(std::string operandName, std::string resultName);
 
     void procedureArgument(std::string argumentName);
@@ -86,7 +88,11 @@ public:
 
     void setScope(std::vector<Value> variables);
 
+    // Pre-register procedures defined in this assembly unit (before emitting calls).
+    void registerDefinedProcedure(std::string procedureName);
+
 private:
+    bool isDefinedProcedure(const std::string& name) const;
     // Shared by indexAddress and pointerOffset: scale index into RAX (imul), spill RDX.
     void scaleIntegerIntoRax(Value& index, int elementSizeBytes);
     // LEA object home or load/mov pointer value into dest.
@@ -157,6 +163,9 @@ private:
     std::map<std::string, Address> frameHomes;
     std::vector<Value*> integerArguments;
     std::vector<Value*> stackArguments;
+
+    // Procedures defined in this assembly unit (for lea vs GOT on FunctionAddress).
+    std::set<std::string> definedProcedures;
 
     int localVariableStackSize { 0 };
 };

--- a/src/codegen/quadruples/AssignLabelAddress.cpp
+++ b/src/codegen/quadruples/AssignLabelAddress.cpp
@@ -1,0 +1,29 @@
+#include "AssignLabelAddress.h"
+
+#include "codegen/AssemblyGenerator.h"
+
+namespace codegen {
+
+AssignLabelAddress::AssignLabelAddress(std::string label, std::string result) :
+        label { std::move(label) },
+        result { std::move(result) }
+{
+}
+
+void AssignLabelAddress::generateCode(AssemblyGenerator& generator) const {
+    generator.generateCodeFor(*this);
+}
+
+std::string AssignLabelAddress::getLabel() const {
+    return label;
+}
+
+std::string AssignLabelAddress::getResult() const {
+    return result;
+}
+
+void AssignLabelAddress::print(std::ostream& stream) const {
+    stream << "\t" << getResult() << " := &" << getLabel() << "\n";
+}
+
+} // namespace codegen

--- a/src/codegen/quadruples/AssignLabelAddress.h
+++ b/src/codegen/quadruples/AssignLabelAddress.h
@@ -1,0 +1,31 @@
+#ifndef ASSIGNLABELADDRESS_H_
+#define ASSIGNLABELADDRESS_H_
+
+#include <string>
+
+#include "Quadruple.h"
+
+namespace codegen {
+
+// Materialize the address of a pool/data label (e.g. string constant $c1) into result.
+// Separate from AssignConstant (integer immediates) so PIE emission cannot confuse the two.
+class AssignLabelAddress: public Quadruple {
+public:
+    AssignLabelAddress(std::string label, std::string result);
+    virtual ~AssignLabelAddress() = default;
+
+    void generateCode(AssemblyGenerator& generator) const override;
+
+    std::string getLabel() const;
+    std::string getResult() const;
+
+private:
+    void print(std::ostream& stream) const override;
+
+    std::string label;
+    std::string result;
+};
+
+} // namespace codegen
+
+#endif // ASSIGNLABELADDRESS_H_

--- a/src/codegen/quadruples/Quadruple.h
+++ b/src/codegen/quadruples/Quadruple.h
@@ -2,6 +2,7 @@
 #define QUADRUPLE_H_
 
 #include <ostream>
+#include <string>
 
 namespace codegen {
 
@@ -18,6 +19,12 @@ public:
     }
 
     virtual bool transfersControl() const {
+        return false;
+    }
+
+    // If this quad defines a same-TU procedure label, write its name and return true.
+    // Used to pre-register callees before emission (PIE call/GOT policy).
+    virtual bool definesProcedure(std::string& /* nameOut */) const {
         return false;
     }
 

--- a/src/codegen/quadruples/StartProcedure.cpp
+++ b/src/codegen/quadruples/StartProcedure.cpp
@@ -19,6 +19,11 @@ bool StartProcedure::isLabel() const {
     return true;
 }
 
+bool StartProcedure::definesProcedure(std::string& nameOut) const {
+    nameOut = name;
+    return true;
+}
+
 std::string StartProcedure::getName() const {
     return name;
 }

--- a/src/codegen/quadruples/StartProcedure.h
+++ b/src/codegen/quadruples/StartProcedure.h
@@ -18,6 +18,7 @@ public:
     void generateCode(AssemblyGenerator& generator) const override;
 
     bool isLabel() const override;
+    bool definesProcedure(std::string& nameOut) const override;
 
     std::string getName() const;
     std::vector<Value> getValues() const;

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -25,11 +25,11 @@ void assemble(const std::string& assemblyFileName) {
 }
 
 void link(const std::string& sourceFileName) {
-    // PIE-safe emission: extern calls via PLT, same-TU direct calls, pool labels via
-    // lea [rel], extern function addresses via GOT. Do not force -no-pie; host
-    // default is typically a position-independent executable.
+    // Product: position-independent executables. Emission is PIE-safe (extern PLT,
+    // same-TU direct calls, pool labels via lea [rel], extern addresses via GOT).
+    // Pass -pie explicitly so the linked type does not depend on host gcc defaults.
     util::runProcessOrThrow({
-            "gcc", "-m64",
+            "gcc", "-m64", "-pie",
             "-o", sourceFileName + ".out",
             sourceFileName + ".o"
     });

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -25,8 +25,11 @@ void assemble(const std::string& assemblyFileName) {
 }
 
 void link(const std::string& sourceFileName) {
+    // PIE-safe emission: extern calls via PLT, same-TU direct calls, pool labels via
+    // lea [rel], extern function addresses via GOT. Do not force -no-pie; host
+    // default is typically a position-independent executable.
     util::runProcessOrThrow({
-            "gcc", "-m64", "-no-pie",
+            "gcc", "-m64",
             "-o", sourceFileName + ".out",
             sourceFileName + ".o"
     });

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -173,6 +173,7 @@ add_executable(functionalTest
         functionalTest/ScopeTest.cpp
         functionalTest/IntegrationTest.cpp
         functionalTest/GlobalVariablesTest.cpp
+        functionalTest/PieExecutableTest.cpp
         functionalTest/FuzzCrashRegressionTest.cpp
         )
 target_link_libraries(functionalTest PRIVATE GTest::gmock_main driver translation_unit scanner util parser testUtil)

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -90,6 +90,18 @@ TEST_F(StackMachineTest, functionAddress_loadsExternViaGot) {
     expectCode("\tmov rax, [rel printf wrt ..got]\n");
 }
 
+// Pool/data labels (string constants): same lea [rel] + bindResult as defined functionAddress.
+TEST_F(StackMachineTest, assignLabelAddress_leaPoolLabel) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+    Value s = intValue("s");
+    stackMachine.startProcedure("proc", { s }, { });
+    assemblyCode.str("");
+
+    stackMachine.assignLabelAddress("$c1", "s");
+
+    expectCode("\tlea rax, [rel $c1]\n");
+}
+
 TEST_F(StackMachineTest, callProcedure_sameTuDoesNotUsePlt) {
     StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
     stackMachine.registerDefinedProcedure("foo");

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -60,20 +60,54 @@ TEST_F(StackMachineTest, procedureCall_doesNotPushUnusedCallerSavedRegisters) {
     stackMachine.callProcedure("procedure");
 
     expectCode("\txorq %rax, %rax\n"
-            "\tcall procedure\n");
+            "\tcall procedure@plt\n");
 }
 
 // Production path uses IntelInstructionSet (LEA + indirect call via r10).
-TEST_F(StackMachineTest, functionAddress_leaGlobalLabel) {
+TEST_F(StackMachineTest, functionAddress_leaDefinedProcedure) {
     StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
     Value fp = intValue("fp");
-    stackMachine.startProcedure("proc", { fp }, { });
+    stackMachine.registerDefinedProcedure("foo");
+    stackMachine.startProcedure("foo", { fp }, { });
     assemblyCode.str("");
 
     stackMachine.functionAddress("foo", "fp");
 
-    // First free GP is rax; LEA of a global label into the result temp.
+    // Same-TU definition: PC-relative LEA (PIE-safe).
     expectCode("\tlea rax, [rel foo]\n");
+}
+
+TEST_F(StackMachineTest, functionAddress_loadsExternViaGot) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+    Value fp = intValue("fp");
+    stackMachine.registerDefinedProcedure("proc");
+    stackMachine.startProcedure("proc", { fp }, { });
+    assemblyCode.str("");
+
+    stackMachine.functionAddress("printf", "fp");
+
+    // Extern: GOT load for PIE.
+    expectCode("\tmov rax, [rel printf wrt ..got]\n");
+}
+
+TEST_F(StackMachineTest, callProcedure_sameTuDoesNotUsePlt) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+    stackMachine.registerDefinedProcedure("foo");
+
+    stackMachine.callProcedure("foo");
+
+    // NASM rejects local `call foo wrt ..plt` (intra-segment OUT_REL4ADR).
+    expectCode("\txor rax, rax\n"
+            "\tcall foo\n");
+}
+
+TEST_F(StackMachineTest, callProcedure_externUsesPlt) {
+    StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
+
+    stackMachine.callProcedure("printf");
+
+    expectCode("\txor rax, rax\n"
+            "\tcall printf wrt ..plt\n");
 }
 
 // Target already in a callee-saved reg survives spillCallerSavedRegisters → mov to r10.
@@ -128,7 +162,7 @@ TEST_F(StackMachineTest, procedureCall_storesAllDirtyCallerSavedRegisters) {
             "\tmovq %r10, (%rsp)\n"
             "\tmovq %r11, (%rsp)\n"
             "\txorq %rax, %rax\n"
-            "\tcall procedure\n");
+            "\tcall procedure@plt\n");
 }
 
 // Variadic ABI: AL must be 0 when no vector args are passed (e.g. printf with integers only)
@@ -143,7 +177,7 @@ TEST_F(StackMachineTest, procedureCall_clearsRaxForVariadicAlRequirement) {
 
     expectCode("\tmovq -40(%rsp), %rdi\n"
             "\txorq %rax, %rax\n"
-            "\tcall printf\n");
+            "\tcall printf@plt\n");
 }
 
 TEST_F(StackMachineTest, procedureStart_storesCalleeSavedRegisters) {
@@ -198,7 +232,7 @@ TEST_F(StackMachineTest, procedureArgumentPassing_firstIntegerArgumentIsPassedIn
 
     expectCode("\tmovq -40(%rsp), %rdi\n"
             "\txorq %rax, %rax\n"
-            "\tcall procedure\n");
+            "\tcall procedure@plt\n");
 }
 
 // Odd number of stack args needs 8-byte padding so RSP is 16-byte aligned before call
@@ -226,7 +260,7 @@ TEST_F(StackMachineTest, procedureCall_padsStackForOddNumberOfStackArguments) {
             "\tmovq -96(%rsp), %rax\n"
             "\tpushq %rax\n"
             "\txorq %rax, %rax\n"
-            "\tcall procedure\n"
+            "\tcall procedure@plt\n"
             "\taddq $16, %rsp\n");
 }
 

--- a/test/src/functionalTest/PieExecutableTest.cpp
+++ b/test/src/functionalTest/PieExecutableTest.cpp
@@ -5,21 +5,27 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 
+#include <sstream>
 #include <string>
 
 namespace {
 
-// Host link should produce a position-independent executable (PIE), not a
-// fixed-address ET_EXEC that only works with gcc -no-pie.
+// Compiler product: link with -pie. ET_DYN for an executable output (not a .so we
+// produce). Matches both modern readelf ("Position-Independent Executable") and
+// older binutils ("Shared object file") wording on the Type line.
 bool executableIsPie(const std::string& path) {
     util::ProcessResult result = util::runProcess({ "readelf", "-h", path });
     if (result.exitCode != 0) {
         return false;
     }
-    // readelf -h: "Type: DYN (Position-Independent Executable file)" on PIE.
-    // Non-PIE linked with -no-pie is "Type: EXEC (Executable file)".
-    return result.stdoutOutput.find("DYN") != std::string::npos
-            && result.stdoutOutput.find("Position-Independent") != std::string::npos;
+    std::istringstream in { result.stdoutOutput };
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.find("Type:") != std::string::npos && line.find("DYN") != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
 }
 
 TEST(Compiler, linkedExecutableIsPositionIndependent) {
@@ -34,8 +40,7 @@ TEST(Compiler, linkedExecutableIsPositionIndependent) {
     // Program::executableFile is source path + ".out" (see TestFixtures).
     const std::string executable = program.getSourceFilePath() + ".out";
     ASSERT_TRUE(executableIsPie(executable))
-            << "expected PIE (readelf Type DYN / Position-Independent); "
-               "got non-PIE executable (often forced by gcc -no-pie)";
+            << "expected PIE (readelf Type DYN); compiler link must pass -pie";
     program.runAndExpect("42");
 }
 
@@ -59,6 +64,27 @@ TEST(Compiler, pieExecutableCallsLibcAndLocalFunctionPointer) {
     ASSERT_TRUE(executableIsPie(executable))
             << "expected PIE executable for mixed local function pointer + printf";
     program.runAndExpect("7");
+}
+
+TEST(Compiler, pieExecutableTakesExternFunctionAddress) {
+    // Address-of libc (GOT load under PIE). Equal materializations prove assemble+link+run.
+    // Call-through uses the pointer type (not external-varargs), so do not invoke via fp.
+    SourceProgram program{R"prg(
+        int main() {
+            int (*a)();
+            int (*b)();
+            a = printf;
+            b = printf;
+            printf("%d", a == b);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    const std::string executable = program.getSourceFilePath() + ".out";
+    ASSERT_TRUE(executableIsPie(executable))
+            << "expected PIE executable for extern function address via GOT";
+    program.runAndExpect("1");
 }
 
 } // namespace

--- a/test/src/functionalTest/PieExecutableTest.cpp
+++ b/test/src/functionalTest/PieExecutableTest.cpp
@@ -1,0 +1,64 @@
+#include "TestFixtures.h"
+
+#include "util/Process.h"
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include <string>
+
+namespace {
+
+// Host link should produce a position-independent executable (PIE), not a
+// fixed-address ET_EXEC that only works with gcc -no-pie.
+bool executableIsPie(const std::string& path) {
+    util::ProcessResult result = util::runProcess({ "readelf", "-h", path });
+    if (result.exitCode != 0) {
+        return false;
+    }
+    // readelf -h: "Type: DYN (Position-Independent Executable file)" on PIE.
+    // Non-PIE linked with -no-pie is "Type: EXEC (Executable file)".
+    return result.stdoutOutput.find("DYN") != std::string::npos
+            && result.stdoutOutput.find("Position-Independent") != std::string::npos;
+}
+
+TEST(Compiler, linkedExecutableIsPositionIndependent) {
+    SourceProgram program{R"prg(
+        int main() {
+            printf("%d", 42);
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    // Program::executableFile is source path + ".out" (see TestFixtures).
+    const std::string executable = program.getSourceFilePath() + ".out";
+    ASSERT_TRUE(executableIsPie(executable))
+            << "expected PIE (readelf Type DYN / Position-Independent); "
+               "got non-PIE executable (often forced by gcc -no-pie)";
+    program.runAndExpect("42");
+}
+
+TEST(Compiler, pieExecutableCallsLibcAndLocalFunctionPointer) {
+    // Direct libc call (PLT) plus address-of a same-TU function (lea [rel ...]).
+    SourceProgram program{R"prg(
+        int seven() {
+            return 7;
+        }
+
+        int main() {
+            int (*fp)();
+            fp = seven;
+            printf("%d", fp());
+            return 0;
+        }
+    )prg"};
+
+    program.compile();
+    const std::string executable = program.getSourceFilePath() + ".out";
+    ASSERT_TRUE(executableIsPie(executable))
+            << "expected PIE executable for mixed local function pointer + printf";
+    program.runAndExpect("7");
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- Drop `gcc -no-pie` so linked programs follow the host default (position-independent executables).
- PIE-safe NASM: extern calls via PLT (`call name wrt ..plt`), same-TU direct calls, pool labels via `AssignLabelAddress` + `lea [rel]`, extern function addresses via GOT.
- Dialect stays on `InstructionSet` (`callPlt` / `loadGot`); `StackMachine` only chooses defined vs extern after a pre-pass of `StartProcedure` names.

## Test plan

- [x] Functional: `PieExecutableTest` requires `readelf` Type DYN / Position-Independent and runtime `printf`
- [x] Unit: same-TU call without PLT, extern call with PLT, defined lea vs extern GOT
- [x] Full `ctest` 19/19 green locally
- [ ] CI green on this PR