### PR TITLE
feat(codegen): full AT&T backend with dual-dialect functional suite

### DIFF
--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -19,7 +19,6 @@ std::string registerAccess(const Register& reg) {
     return registerAccess(reg.getName());
 }
 
-// StackMachine passes signed frame offsets; render as gas displacement (e.g. 40(%rsp), 16(%rbp)).
 std::string memoryOffsetMnemonic(const Register& memoryBase, int memoryOffset) {
     if (memoryOffset == 0) {
         return "(%" + memoryBase.getName() + ")";
@@ -45,7 +44,6 @@ std::string immediate(const std::string& constant) {
     return "$" + constant;
 }
 
-// StackMachine may pass a register name (e.g. r10) for indirect calls.
 bool isRegisterName(const std::string& name) {
     if (name == "rax" || name == "rbx" || name == "rcx" || name == "rdx"
             || name == "rsi" || name == "rdi" || name == "rbp" || name == "rsp") {
@@ -291,7 +289,6 @@ std::string ATandTInstructionSet::shl(const Register& result) const {
 }
 
 std::string ATandTInstructionSet::shr(const Register& result) const {
-    // Signed integer >> must arithmetic-shift (sign-extend).
     return "sarq %cl, " + registerAccess(result);
 }
 

--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -3,7 +3,6 @@
 #include "Register.h"
 #include "RegisterSubreg.h"
 #include "MemoryOperand.h"
-#include "types/ObjectAbi.h"
 
 #include <sstream>
 
@@ -67,21 +66,13 @@ std::string ATandTInstructionSet::preamble(const std::map<std::string, std::stri
         preamble << constant.first << ":\n\t" << toGasStringDirective(constant.second) << "\n";
     }
     for (const auto& global : globalVariables) {
-        if (global.multiWordInitializer && !global.multiWordInitializer->empty()) {
-            preamble << global.name << ":\n\t.quad ";
-            for (std::size_t i = 0; i < global.multiWordInitializer->size(); ++i) {
-                if (i > 0) {
-                    preamble << ", ";
-                }
-                preamble << (*global.multiWordInitializer)[i];
+        const auto operands = global.qwordOperands();
+        preamble << global.name << ":\n\t.quad ";
+        for (std::size_t i = 0; i < operands.size(); ++i) {
+            if (i > 0) {
+                preamble << ", ";
             }
-            preamble << "\n";
-            continue;
-        }
-        const int words = type::object_abi::dataWords(global.sizeInBytes);
-        preamble << global.name << ":\n\t.quad " << global.initializerLiteral;
-        for (int i = 1; i < words; ++i) {
-            preamble << ", 0";
+            preamble << operands[i];
         }
         preamble << "\n";
     }

--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -1,10 +1,10 @@
 #include "ATandTInstructionSet.h"
 
 #include "Register.h"
+#include "RegisterSubreg.h"
 #include "MemoryOperand.h"
 #include "types/ObjectAbi.h"
 
-#include <cctype>
 #include <sstream>
 
 namespace {
@@ -42,49 +42,6 @@ std::string immediate(const std::string& constant) {
         return constant;
     }
     return "$" + constant;
-}
-
-bool isRegisterName(const std::string& name) {
-    if (name == "rax" || name == "rbx" || name == "rcx" || name == "rdx"
-            || name == "rsi" || name == "rdi" || name == "rbp" || name == "rsp") {
-        return true;
-    }
-    if (name.size() >= 2 && name[0] == 'r' && std::isdigit(static_cast<unsigned char>(name[1]))) {
-        return true;
-    }
-    return false;
-}
-
-std::string lowByteAccess(const Register& reg) {
-    const std::string n = reg.getName();
-    if (n == "rax") return "%al";
-    if (n == "rbx") return "%bl";
-    if (n == "rcx") return "%cl";
-    if (n == "rdx") return "%dl";
-    if (n == "rsi") return "%sil";
-    if (n == "rdi") return "%dil";
-    if (n == "rbp") return "%bpl";
-    if (n == "rsp") return "%spl";
-    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
-        return "%" + n + "b";
-    }
-    return "%" + n;
-}
-
-std::string lowDwordAccess(const Register& reg) {
-    const std::string n = reg.getName();
-    if (n == "rax") return "%eax";
-    if (n == "rbx") return "%ebx";
-    if (n == "rcx") return "%ecx";
-    if (n == "rdx") return "%edx";
-    if (n == "rsi") return "%esi";
-    if (n == "rdi") return "%edi";
-    if (n == "rbp") return "%ebp";
-    if (n == "rsp") return "%esp";
-    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
-        return "%" + n + "d";
-    }
-    return "%" + n;
 }
 
 std::string toGasStringDirective(const std::string& escapedConstant) {
@@ -135,14 +92,15 @@ std::string ATandTInstructionSet::preamble(const std::map<std::string, std::stri
 }
 
 std::string ATandTInstructionSet::call(std::string procedureName) const {
-    if (isRegisterName(procedureName)) {
-        return "call *" + registerAccess(procedureName);
-    }
     return "call " + procedureName;
 }
 
 std::string ATandTInstructionSet::callPlt(std::string procedureName) const {
     return "call " + procedureName + "@plt";
+}
+
+std::string ATandTInstructionSet::callIndirect(const Register& target) const {
+    return "call *" + registerAccess(target);
 }
 
 std::string ATandTInstructionSet::loadGot(std::string symbolName, const Register& target) const {
@@ -357,11 +315,11 @@ std::string ATandTInstructionSet::loadDwordSignExtend(const Register& address, c
 }
 
 std::string ATandTInstructionSet::storeByte(const Register& source, const Register& address) const {
-    return "movb " + lowByteAccess(source) + ", (%" + address.getName() + ")";
+    return "movb %" + lowByteName(source) + ", (%" + address.getName() + ")";
 }
 
 std::string ATandTInstructionSet::storeDword(const Register& source, const Register& address) const {
-    return "movl " + lowDwordAccess(source) + ", (%" + address.getName() + ")";
+    return "movl %" + lowDwordName(source) + ", (%" + address.getName() + ")";
 }
 
 } // namespace codegen

--- a/src/codegen/ATandTInstructionSet.cpp
+++ b/src/codegen/ATandTInstructionSet.cpp
@@ -2,33 +2,101 @@
 
 #include "Register.h"
 #include "MemoryOperand.h"
+#include "types/ObjectAbi.h"
 
-#include <stdexcept>
+#include <cctype>
+#include <sstream>
 
 namespace {
 
 using codegen::Register;
 
+std::string registerAccess(const std::string& name) {
+    return "%" + name;
+}
+
+std::string registerAccess(const Register& reg) {
+    return registerAccess(reg.getName());
+}
+
+// StackMachine passes signed frame offsets; render as gas displacement (e.g. 40(%rsp), 16(%rbp)).
 std::string memoryOffsetMnemonic(const Register& memoryBase, int memoryOffset) {
-    return (memoryOffset ? "-" + std::to_string(memoryOffset) : "") + "(%" + memoryBase.getName() + ")";
+    if (memoryOffset == 0) {
+        return "(%" + memoryBase.getName() + ")";
+    }
+    return std::to_string(memoryOffset) + "(%" + memoryBase.getName() + ")";
 }
 
 std::string memoryReference(const codegen::MemoryOperand& operand) {
     if (operand.isGlobal()) {
-        throw std::runtime_error { "not implemented ATandTInstructionSet: global variable operand" };
+        return operand.label() + "(%rip)";
     }
     return memoryOffsetMnemonic(operand.baseRegister(), operand.offset());
 }
 
-std::string registerAccess(const Register& reg) {
-    return "%" + reg.getName();
-}
-
 std::string constantReference(int constant) {
-   return "$" + std::to_string(constant);
+    return "$" + std::to_string(constant);
 }
 
+std::string immediate(const std::string& constant) {
+    if (!constant.empty() && constant[0] == '$') {
+        return constant;
+    }
+    return "$" + constant;
 }
+
+// StackMachine may pass a register name (e.g. r10) for indirect calls.
+bool isRegisterName(const std::string& name) {
+    if (name == "rax" || name == "rbx" || name == "rcx" || name == "rdx"
+            || name == "rsi" || name == "rdi" || name == "rbp" || name == "rsp") {
+        return true;
+    }
+    if (name.size() >= 2 && name[0] == 'r' && std::isdigit(static_cast<unsigned char>(name[1]))) {
+        return true;
+    }
+    return false;
+}
+
+std::string lowByteAccess(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "%al";
+    if (n == "rbx") return "%bl";
+    if (n == "rcx") return "%cl";
+    if (n == "rdx") return "%dl";
+    if (n == "rsi") return "%sil";
+    if (n == "rdi") return "%dil";
+    if (n == "rbp") return "%bpl";
+    if (n == "rsp") return "%spl";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return "%" + n + "b";
+    }
+    return "%" + n;
+}
+
+std::string lowDwordAccess(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "%eax";
+    if (n == "rbx") return "%ebx";
+    if (n == "rcx") return "%ecx";
+    if (n == "rdx") return "%edx";
+    if (n == "rsi") return "%esi";
+    if (n == "rdi") return "%edi";
+    if (n == "rbp") return "%ebp";
+    if (n == "rsp") return "%esp";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return "%" + n + "d";
+    }
+    return "%" + n;
+}
+
+std::string toGasStringDirective(const std::string& escapedConstant) {
+    if (escapedConstant.size() >= 2 && escapedConstant.front() == '"' && escapedConstant.back() == '"') {
+        return ".string " + escapedConstant;
+    }
+    return ".string \"" + escapedConstant + "\"";
+}
+
+} // namespace
 
 namespace codegen {
 
@@ -36,18 +104,42 @@ ATandTInstructionSet::~ATandTInstructionSet() = default;
 
 std::string ATandTInstructionSet::preamble(const std::map<std::string, std::string>& constants,
         const std::vector<GlobalVariable>& globalVariables) const {
-    (void)constants;
-    (void)globalVariables;
-    return ".extern scanf\n"
+    std::stringstream preamble;
+    preamble << ".extern scanf\n"
             ".extern printf\n\n"
-            ".data\n"
-            "sfmt: .string \"%d\"\n"
-            "fmt: .string \"%d\n\"\n\n"
-            ".text\n"
+            ".section .data\n";
+    for (const auto& constant : constants) {
+        preamble << constant.first << ":\n\t" << toGasStringDirective(constant.second) << "\n";
+    }
+    for (const auto& global : globalVariables) {
+        if (global.multiWordInitializer && !global.multiWordInitializer->empty()) {
+            preamble << global.name << ":\n\t.quad ";
+            for (std::size_t i = 0; i < global.multiWordInitializer->size(); ++i) {
+                if (i > 0) {
+                    preamble << ", ";
+                }
+                preamble << (*global.multiWordInitializer)[i];
+            }
+            preamble << "\n";
+            continue;
+        }
+        const int words = type::object_abi::dataWords(global.sizeInBytes);
+        preamble << global.name << ":\n\t.quad " << global.initializerLiteral;
+        for (int i = 1; i < words; ++i) {
+            preamble << ", 0";
+        }
+        preamble << "\n";
+    }
+    preamble << "\n"
+            ".section .text\n"
             ".globl main\n\n";
+    return preamble.str();
 }
 
 std::string ATandTInstructionSet::call(std::string procedureName) const {
+    if (isRegisterName(procedureName)) {
+        return "call *" + registerAccess(procedureName);
+    }
     return "call " + procedureName;
 }
 
@@ -56,9 +148,7 @@ std::string ATandTInstructionSet::callPlt(std::string procedureName) const {
 }
 
 std::string ATandTInstructionSet::loadGot(std::string symbolName, const Register& target) const {
-    (void)symbolName;
-    (void)target;
-    throw std::runtime_error { "not implemented ATandTInstructionSet::loadGot" };
+    return "movq " + symbolName + "@GOTPCREL(%rip), " + registerAccess(target);
 }
 
 std::string ATandTInstructionSet::push(const Register& reg) const {
@@ -78,11 +168,11 @@ std::string ATandTInstructionSet::sub(const Register& reg, int constant) const {
 }
 
 std::string ATandTInstructionSet::lea(const MemoryOperand& source, const Register& target) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::lea" };
+    return "leaq " + memoryReference(source) + ", " + registerAccess(target);
 }
 
 std::string ATandTInstructionSet::not_(const Register& reg) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::not_(const Register& reg)" };
+    return "notq " + registerAccess(reg);
 }
 
 std::string ATandTInstructionSet::mov(const Register& source, const MemoryOperand& destination) const {
@@ -101,31 +191,31 @@ std::string ATandTInstructionSet::mov(const MemoryOperand& source, const Registe
 }
 
 std::string ATandTInstructionSet::mov(std::string constant, const MemoryOperand& destination) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::mov(std::string constant, MemoryOperand)" };
+    return "movq " + immediate(constant) + ", " + memoryReference(destination);
 }
 
 std::string ATandTInstructionSet::mov(std::string constant, const Register& destination) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::mov(std::string constant, const Register& destination)" };
+    return "movq " + immediate(constant) + ", " + registerAccess(destination);
 }
 
 std::string ATandTInstructionSet::cmp(const Register& leftArgument, const MemoryOperand& rightArgument) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(Register, MemoryOperand)" };
+    return "cmpq " + memoryReference(rightArgument) + ", " + registerAccess(leftArgument);
 }
 
 std::string ATandTInstructionSet::cmp(const Register& leftArgument, const Register& rightArgument) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(const Register& leftArgument, const Register& rightArgument)" };
+    return "cmpq " + registerAccess(rightArgument) + ", " + registerAccess(leftArgument);
 }
 
 std::string ATandTInstructionSet::cmp(const MemoryOperand& leftArgument, const Register& rightArgument) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(MemoryOperand, Register)" };
+    return "cmpq " + registerAccess(rightArgument) + ", " + memoryReference(leftArgument);
 }
 
 std::string ATandTInstructionSet::cmp(const Register& argument, int constant) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(const Register& argument, int constant)" };
+    return "cmpq " + constantReference(constant) + ", " + registerAccess(argument);
 }
 
 std::string ATandTInstructionSet::cmp(const MemoryOperand& leftArgument, int constant) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::cmp(MemoryOperand, int constant)" };
+    return "cmpq " + constantReference(constant) + ", " + memoryReference(leftArgument);
 }
 
 std::string ATandTInstructionSet::label(std::string name) const {
@@ -133,35 +223,35 @@ std::string ATandTInstructionSet::label(std::string name) const {
 }
 
 std::string ATandTInstructionSet::jmp(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::jmp(std::string label)" };
+    return "jmp " + label;
 }
 
 std::string ATandTInstructionSet::je(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::je(std::string label)" };
+    return "je " + label;
 }
 
 std::string ATandTInstructionSet::jne(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::jne(std::string label)" };
+    return "jne " + label;
 }
 
 std::string ATandTInstructionSet::jg(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::jg(std::string label)" };
+    return "jg " + label;
 }
 
 std::string ATandTInstructionSet::jl(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::jl(std::string label)" };
+    return "jl " + label;
 }
 
 std::string ATandTInstructionSet::jge(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::jge(std::string label)" };
+    return "jge " + label;
 }
 
 std::string ATandTInstructionSet::jle(std::string label) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::jle(std::string label)" };
+    return "jle " + label;
 }
 
 std::string ATandTInstructionSet::syscall() const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::syscall()" };
+    return "syscall";
 }
 
 std::string ATandTInstructionSet::leave() const {
@@ -177,45 +267,36 @@ std::string ATandTInstructionSet::xor_(const Register& operand, const Register& 
 }
 
 std::string ATandTInstructionSet::xor_(const MemoryOperand& operand, const Register& result) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::xor_(MemoryOperand, Register)" };
+    return "xorq " + memoryReference(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::or_(const Register& operand, const Register& result) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::or_(const Register& operand, const Register& result)" };
+    return "orq " + registerAccess(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::or_(const MemoryOperand& operand, const Register& result) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::or_(MemoryOperand, Register)" };
+    return "orq " + memoryReference(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::and_(const Register& operand, const Register& result) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::and_(const Register& operand, const Register& result)" };
+    return "andq " + registerAccess(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::and_(const MemoryOperand& operand, const Register& result) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::and_(MemoryOperand, Register)" };
+    return "andq " + memoryReference(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::shl(const Register& result) const {
-    throw std::runtime_error {
-        "not implemented ATandTInstructionSet::shl(const Register& operand, const Register& result)"
-    };
+    return "shlq %cl, " + registerAccess(result);
 }
-
-//std::string ATandTInstructionSet::shl(std::string constant, const Register& result) const {
-//}
 
 std::string ATandTInstructionSet::shr(const Register& result) const {
-    throw std::runtime_error {
-        "not implemented ATandTInstructionSet::shr(const Register& operand, const Register& result)"
-    };
+    // Signed integer >> must arithmetic-shift (sign-extend).
+    return "sarq %cl, " + registerAccess(result);
 }
 
-//std::string ATandTInstructionSet::shr(std::string constant, const Register& result) const {
-//}
-
 std::string ATandTInstructionSet::add(const Register& operand, const Register& result) const {
-    return "addq " + registerAccess(operand) + ", " + registerAccess(result); // result = result + operand
+    return "addq " + registerAccess(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::add(const MemoryOperand& operand, const Register& result) const {
@@ -223,7 +304,7 @@ std::string ATandTInstructionSet::add(const MemoryOperand& operand, const Regist
 }
 
 std::string ATandTInstructionSet::sub(const Register& operand, const Register& result) const {
-    return "subq " + registerAccess(operand) + ", " + registerAccess(result); // result = result - operand
+    return "subq " + registerAccess(operand) + ", " + registerAccess(result);
 }
 
 std::string ATandTInstructionSet::sub(const MemoryOperand& operand, const Register& result) const {
@@ -231,44 +312,59 @@ std::string ATandTInstructionSet::sub(const MemoryOperand& operand, const Regist
 }
 
 std::string ATandTInstructionSet::imul(const Register& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::imul(const Register& operand)" };
+    return "imulq " + registerAccess(operand);
 }
 
 std::string ATandTInstructionSet::imul(const MemoryOperand& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::imul(MemoryOperand)" };
+    return "imulq " + memoryReference(operand);
 }
 
 std::string ATandTInstructionSet::idiv(const Register& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::idiv(const Register& operand)" };
+    return "idivq " + registerAccess(operand);
 }
 
 std::string ATandTInstructionSet::idiv(const MemoryOperand& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::idiv(MemoryOperand)" };
+    return "idivq " + memoryReference(operand);
 }
 
 std::string ATandTInstructionSet::cqo() const {
-    return "cqo";
+    return "cqto";
 }
 
 std::string ATandTInstructionSet::inc(const Register& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::inc(const Register& operand)" };
+    return "incq " + registerAccess(operand);
 }
 
 std::string ATandTInstructionSet::inc(const MemoryOperand& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::inc(MemoryOperand)" };
+    return "incq " + memoryReference(operand);
 }
 
 std::string ATandTInstructionSet::dec(const Register& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::dec(const Register& operand)" };
+    return "decq " + registerAccess(operand);
 }
 
 std::string ATandTInstructionSet::dec(const MemoryOperand& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::dec(MemoryOperand)" };
+    return "decq " + memoryReference(operand);
 }
 
 std::string ATandTInstructionSet::neg(const Register& operand) const {
-    throw std::runtime_error { "not implemented ATandTInstructionSet::neg(const Register& operand)" };
+    return "negq " + registerAccess(operand);
+}
+
+std::string ATandTInstructionSet::loadByteSignExtend(const Register& address, const Register& dest) const {
+    return "movsbq (%" + address.getName() + "), " + registerAccess(dest);
+}
+
+std::string ATandTInstructionSet::loadDwordSignExtend(const Register& address, const Register& dest) const {
+    return "movslq (%" + address.getName() + "), " + registerAccess(dest);
+}
+
+std::string ATandTInstructionSet::storeByte(const Register& source, const Register& address) const {
+    return "movb " + lowByteAccess(source) + ", (%" + address.getName() + ")";
+}
+
+std::string ATandTInstructionSet::storeDword(const Register& source, const Register& address) const {
+    return "movl " + lowDwordAccess(source) + ", (%" + address.getName() + ")";
 }
 
 } // namespace codegen
-

--- a/src/codegen/ATandTInstructionSet.h
+++ b/src/codegen/ATandTInstructionSet.h
@@ -85,6 +85,11 @@ public:
     std::string dec(const MemoryOperand& operand) const override;
 
     std::string neg(const Register& operand) const override;
+
+    std::string loadByteSignExtend(const Register& address, const Register& dest) const override;
+    std::string loadDwordSignExtend(const Register& address, const Register& dest) const override;
+    std::string storeByte(const Register& source, const Register& address) const override;
+    std::string storeDword(const Register& source, const Register& address) const override;
 };
 
 } // namespace codegen

--- a/src/codegen/ATandTInstructionSet.h
+++ b/src/codegen/ATandTInstructionSet.h
@@ -14,6 +14,7 @@ public:
 
     std::string call(std::string procedureName) const override;
     std::string callPlt(std::string procedureName) const override;
+    std::string callIndirect(const Register& target) const override;
     std::string loadGot(std::string symbolName, const Register& target) const override;
 
     std::string push(const Register& reg) const override;

--- a/src/codegen/AssemblyGenerator.cpp
+++ b/src/codegen/AssemblyGenerator.cpp
@@ -16,7 +16,6 @@ void AssemblyGenerator::generateAssemblyCode(
         const std::vector<GlobalVariable>& globalVariables)
 {
     stackMachine->generatePreamble(constants, globalVariables);
-    // All same-TU procedure names before any call/FunctionAddress (order-independent).
     for (const auto& quadruple : quadruples) {
         std::string procedureName;
         if (quadruple->definesProcedure(procedureName)) {

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(backend
         IntelInstructionSet.cpp
         QuadrupleGenerator.cpp
         Register.cpp
+        RegisterSubreg.cpp
         StackMachine.cpp
         StackMachine_Addressing.cpp
         Value.cpp
@@ -102,6 +103,7 @@ add_library(backend
         MemoryOperand.h
         QuadrupleGenerator.h
         Register.h
+        RegisterSubreg.h
         StackMachine.h
         Value.h
         Assembly.h)

--- a/src/codegen/GlobalVariable.h
+++ b/src/codegen/GlobalVariable.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Value.h"
+#include "types/ObjectAbi.h"
 
 namespace codegen {
 
@@ -20,6 +21,21 @@ struct GlobalVariable {
 
     Value toValue() const {
         return Value { name, 0, Type::INTEGRAL, sizeInBytes };
+    }
+
+    // Qword operands for .data emission (shared by Intel dq / gas .quad).
+    std::vector<std::string> qwordOperands() const {
+        if (multiWordInitializer && !multiWordInitializer->empty()) {
+            return *multiWordInitializer;
+        }
+        const int words = type::object_abi::dataWords(sizeInBytes);
+        std::vector<std::string> operands;
+        operands.reserve(static_cast<std::size_t>(words > 0 ? words : 1));
+        operands.push_back(initializerLiteral);
+        for (int i = 1; i < words; ++i) {
+            operands.push_back("0");
+        }
+        return operands;
     }
 };
 

--- a/src/codegen/InstructionSet.h
+++ b/src/codegen/InstructionSet.h
@@ -96,6 +96,12 @@ public:
     virtual std::string dec(const MemoryOperand& operand) const = 0;
 
     virtual std::string neg(const Register& operand) const = 0;
+
+    // Narrow memory ops used for char/int loads and stores (dialect owns mnemonics).
+    virtual std::string loadByteSignExtend(const Register& address, const Register& dest) const = 0;
+    virtual std::string loadDwordSignExtend(const Register& address, const Register& dest) const = 0;
+    virtual std::string storeByte(const Register& source, const Register& address) const = 0;
+    virtual std::string storeDword(const Register& source, const Register& address) const = 0;
 };
 
 } // namespace codegen

--- a/src/codegen/InstructionSet.h
+++ b/src/codegen/InstructionSet.h
@@ -21,6 +21,7 @@ public:
 
     virtual std::string call(std::string procedureName) const = 0;
     virtual std::string callPlt(std::string procedureName) const = 0;
+    virtual std::string callIndirect(const Register& target) const = 0;
     virtual std::string loadGot(std::string symbolName, const Register& target) const = 0;
 
     virtual std::string push(const Register& reg) const = 0;

--- a/src/codegen/InstructionSet.h
+++ b/src/codegen/InstructionSet.h
@@ -20,9 +20,7 @@ public:
             const std::vector<GlobalVariable>& globalVariables = {}) const = 0;
 
     virtual std::string call(std::string procedureName) const = 0;
-    // Extern direct call via PLT (PIE-safe against DSO symbols).
     virtual std::string callPlt(std::string procedureName) const = 0;
-    // Load address of an extern symbol from the GOT into target (PIE-safe).
     virtual std::string loadGot(std::string symbolName, const Register& target) const = 0;
 
     virtual std::string push(const Register& reg) const = 0;
@@ -97,7 +95,6 @@ public:
 
     virtual std::string neg(const Register& operand) const = 0;
 
-    // Narrow memory ops used for char/int loads and stores (dialect owns mnemonics).
     virtual std::string loadByteSignExtend(const Register& address, const Register& dest) const = 0;
     virtual std::string loadDwordSignExtend(const Register& address, const Register& dest) const = 0;
     virtual std::string storeByte(const Register& source, const Register& address) const = 0;

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -1,9 +1,9 @@
 #include "IntelInstructionSet.h"
 
 #include "Register.h"
+#include "RegisterSubreg.h"
 #include "types/ObjectAbi.h"
 
-#include <cctype>
 #include <iostream>
 #include <sstream>
 
@@ -165,6 +165,10 @@ std::string IntelInstructionSet::callPlt(std::string procedureName) const {
     return "call " + procedureName + " wrt ..plt";
 }
 
+std::string IntelInstructionSet::callIndirect(const Register& target) const {
+    return "call " + target.getName();
+}
+
 std::string IntelInstructionSet::loadGot(std::string symbolName, const Register& target) const {
     return "mov " + target.getName() + ", [rel " + symbolName + " wrt ..got]";
 }
@@ -305,42 +309,6 @@ std::string IntelInstructionSet::neg(const Register& operand) const {
     return "neg " + operand.getName();
 }
 
-namespace {
-
-std::string intelLowByte(const Register& reg) {
-    const std::string n = reg.getName();
-    if (n == "rax") return "al";
-    if (n == "rbx") return "bl";
-    if (n == "rcx") return "cl";
-    if (n == "rdx") return "dl";
-    if (n == "rsi") return "sil";
-    if (n == "rdi") return "dil";
-    if (n == "rbp") return "bpl";
-    if (n == "rsp") return "spl";
-    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
-        return n + "b";
-    }
-    return n;
-}
-
-std::string intelLowDword(const Register& reg) {
-    const std::string n = reg.getName();
-    if (n == "rax") return "eax";
-    if (n == "rbx") return "ebx";
-    if (n == "rcx") return "ecx";
-    if (n == "rdx") return "edx";
-    if (n == "rsi") return "esi";
-    if (n == "rdi") return "edi";
-    if (n == "rbp") return "ebp";
-    if (n == "rsp") return "esp";
-    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
-        return n + "d";
-    }
-    return n;
-}
-
-} // namespace
-
 std::string IntelInstructionSet::loadByteSignExtend(const Register& address, const Register& dest) const {
     return "movsx " + dest.getName() + ", byte [" + address.getName() + "]";
 }
@@ -350,11 +318,11 @@ std::string IntelInstructionSet::loadDwordSignExtend(const Register& address, co
 }
 
 std::string IntelInstructionSet::storeByte(const Register& source, const Register& address) const {
-    return "mov byte [" + address.getName() + "], " + intelLowByte(source);
+    return "mov byte [" + address.getName() + "], " + lowByteName(source);
 }
 
 std::string IntelInstructionSet::storeDword(const Register& source, const Register& address) const {
-    return "mov dword [" + address.getName() + "], " + intelLowDword(source);
+    return "mov dword [" + address.getName() + "], " + lowDwordName(source);
 }
 
 } // namespace codegen

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -2,7 +2,6 @@
 
 #include "Register.h"
 #include "RegisterSubreg.h"
-#include "types/ObjectAbi.h"
 
 #include <iostream>
 #include <sstream>
@@ -56,29 +55,16 @@ std::string IntelInstructionSet::preamble(const std::map<std::string, std::strin
     for (const auto& constant : constants) {
         preamble << "\t" << constant.first << " " << toConstantDeclaration(constant.second) << "\n";
     }
-    // Scalar globals are one qword; multi-word aggregates emit sizeInBytes-worth of words.
     for (const auto& global : globalVariables) {
-        if (global.multiWordInitializer && !global.multiWordInitializer->empty()) {
-            preamble << "\t" << global.name << " dq ";
-            for (std::size_t i = 0; i < global.multiWordInitializer->size(); ++i) {
-                if (i > 0) {
-                    preamble << ", ";
-                }
-                preamble << (*global.multiWordInitializer)[i];
+        const auto operands = global.qwordOperands();
+        preamble << "\t" << global.name << " dq ";
+        for (std::size_t i = 0; i < operands.size(); ++i) {
+            if (i > 0) {
+                preamble << ", ";
             }
-            preamble << "\n";
-            continue;
+            preamble << operands[i];
         }
-        const int words = type::object_abi::dataWords(global.sizeInBytes);
-        if (words <= 1) {
-            preamble << "\t" << global.name << " dq " << global.initializerLiteral << "\n";
-        } else {
-            preamble << "\t" << global.name << " dq " << global.initializerLiteral;
-            for (int i = 1; i < words; ++i) {
-                preamble << ", 0";
-            }
-            preamble << "\n";
-        }
+        preamble << "\n";
     }
     preamble << "\n"
             "section .text\n"

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -158,7 +158,6 @@ std::string IntelInstructionSet::cmp(const MemoryOperand& leftArgument, int cons
 }
 
 std::string IntelInstructionSet::call(std::string procedureName) const {
-    // Same-TU or register target (indirect). Externs use callPlt.
     return "call " + procedureName;
 }
 

--- a/src/codegen/IntelInstructionSet.cpp
+++ b/src/codegen/IntelInstructionSet.cpp
@@ -3,6 +3,7 @@
 #include "Register.h"
 #include "types/ObjectAbi.h"
 
+#include <cctype>
 #include <iostream>
 #include <sstream>
 
@@ -303,6 +304,58 @@ std::string IntelInstructionSet::dec(const MemoryOperand& operand) const {
 
 std::string IntelInstructionSet::neg(const Register& operand) const {
     return "neg " + operand.getName();
+}
+
+namespace {
+
+std::string intelLowByte(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "al";
+    if (n == "rbx") return "bl";
+    if (n == "rcx") return "cl";
+    if (n == "rdx") return "dl";
+    if (n == "rsi") return "sil";
+    if (n == "rdi") return "dil";
+    if (n == "rbp") return "bpl";
+    if (n == "rsp") return "spl";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return n + "b";
+    }
+    return n;
+}
+
+std::string intelLowDword(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "eax";
+    if (n == "rbx") return "ebx";
+    if (n == "rcx") return "ecx";
+    if (n == "rdx") return "edx";
+    if (n == "rsi") return "esi";
+    if (n == "rdi") return "edi";
+    if (n == "rbp") return "ebp";
+    if (n == "rsp") return "esp";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return n + "d";
+    }
+    return n;
+}
+
+} // namespace
+
+std::string IntelInstructionSet::loadByteSignExtend(const Register& address, const Register& dest) const {
+    return "movsx " + dest.getName() + ", byte [" + address.getName() + "]";
+}
+
+std::string IntelInstructionSet::loadDwordSignExtend(const Register& address, const Register& dest) const {
+    return "movsxd " + dest.getName() + ", dword [" + address.getName() + "]";
+}
+
+std::string IntelInstructionSet::storeByte(const Register& source, const Register& address) const {
+    return "mov byte [" + address.getName() + "], " + intelLowByte(source);
+}
+
+std::string IntelInstructionSet::storeDword(const Register& source, const Register& address) const {
+    return "mov dword [" + address.getName() + "], " + intelLowDword(source);
 }
 
 } // namespace codegen

--- a/src/codegen/IntelInstructionSet.h
+++ b/src/codegen/IntelInstructionSet.h
@@ -16,6 +16,7 @@ public:
 
     std::string call(std::string procedureName) const override;
     std::string callPlt(std::string procedureName) const override;
+    std::string callIndirect(const Register& target) const override;
     std::string loadGot(std::string symbolName, const Register& target) const override;
 
     std::string push(const Register& reg) const override;

--- a/src/codegen/IntelInstructionSet.h
+++ b/src/codegen/IntelInstructionSet.h
@@ -87,6 +87,11 @@ public:
     std::string dec(const MemoryOperand& operand) const override;
 
     std::string neg(const Register& operand) const override;
+
+    std::string loadByteSignExtend(const Register& address, const Register& dest) const override;
+    std::string loadDwordSignExtend(const Register& address, const Register& dest) const override;
+    std::string storeByte(const Register& source, const Register& address) const override;
+    std::string storeDword(const Register& source, const Register& address) const override;
 };
 
 } // namespace codegen

--- a/src/codegen/RegisterSubreg.cpp
+++ b/src/codegen/RegisterSubreg.cpp
@@ -1,0 +1,41 @@
+#include "RegisterSubreg.h"
+
+#include "Register.h"
+
+#include <cctype>
+
+namespace codegen {
+
+std::string lowByteName(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "al";
+    if (n == "rbx") return "bl";
+    if (n == "rcx") return "cl";
+    if (n == "rdx") return "dl";
+    if (n == "rsi") return "sil";
+    if (n == "rdi") return "dil";
+    if (n == "rbp") return "bpl";
+    if (n == "rsp") return "spl";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return n + "b";
+    }
+    return n;
+}
+
+std::string lowDwordName(const Register& reg) {
+    const std::string n = reg.getName();
+    if (n == "rax") return "eax";
+    if (n == "rbx") return "ebx";
+    if (n == "rcx") return "ecx";
+    if (n == "rdx") return "edx";
+    if (n == "rsi") return "esi";
+    if (n == "rdi") return "edi";
+    if (n == "rbp") return "ebp";
+    if (n == "rsp") return "esp";
+    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
+        return n + "d";
+    }
+    return n;
+}
+
+} // namespace codegen

--- a/src/codegen/RegisterSubreg.h
+++ b/src/codegen/RegisterSubreg.h
@@ -1,0 +1,16 @@
+#ifndef REGISTER_SUBREG_H_
+#define REGISTER_SUBREG_H_
+
+#include <string>
+
+namespace codegen {
+
+class Register;
+
+// Partial register spellings without dialect prefixes (al, r8b, eax, r8d).
+std::string lowByteName(const Register& reg);
+std::string lowDwordName(const Register& reg);
+
+} // namespace codegen
+
+#endif // REGISTER_SUBREG_H_

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -317,7 +317,7 @@ void StackMachine::assignConstant(std::string constant, std::string resultName) 
 }
 
 void StackMachine::assignLabelAddress(std::string label, std::string resultName) {
-    // Pool/data labels (e.g. __trans_c1): same discipline as functionAddress — lea into
+    // Pool/data labels (e.g. L$str1): same discipline as functionAddress — lea into
     // scratch then bindResult (lazy store for locals; never self-mov into home).
     Register& resultRegister = get64BitRegister();
     assembly << instructionSet->lea(MemoryOperand::global(label), resultRegister);

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -41,7 +41,6 @@ void StackMachine::startProcedure(std::string procedureName, std::vector<Value> 
 
     emptyGeneralPurposeRegisters();
     frameHomes.clear();
-    // definedProcedures is filled by AssemblyGenerator pre-pass (registerDefinedProcedure).
     assembly.label(instructionSet->label(procedureName));
     assembly << instructionSet->push(registers->getBasePointer());
     assembly << instructionSet->mov(registers->getStackPointer(), registers->getBasePointer());
@@ -226,10 +225,8 @@ void StackMachine::addressOf(std::string operandName, std::string resultName) {
 void StackMachine::functionAddress(std::string functionName, std::string resultName) {
     Register& resultRegister = get64BitRegister();
     if (isDefinedProcedure(functionName)) {
-        // Same-TU definition: PC-relative lea is PIE-safe.
         assembly << instructionSet->lea(MemoryOperand::global(functionName), resultRegister);
     } else {
-        // Extern (e.g. printf): load from the GOT for PIE.
         assembly << instructionSet->loadGot(functionName, resultRegister);
     }
     bindResult(resultRegister, resolve(resultName));
@@ -317,8 +314,6 @@ void StackMachine::assignConstant(std::string constant, std::string resultName) 
 }
 
 void StackMachine::assignLabelAddress(std::string label, std::string resultName) {
-    // Pool/data labels (e.g. L$str1): same discipline as functionAddress — lea into
-    // scratch then bindResult (lazy store for locals; never self-mov into home).
     Register& resultRegister = get64BitRegister();
     assembly << instructionSet->lea(MemoryOperand::global(label), resultRegister);
     bindResult(resultRegister, resolve(resultName));
@@ -377,9 +372,6 @@ int StackMachine::emitCallArguments() {
 
 void StackMachine::callProcedure(std::string procedureName) {
     int argumentOffset = emitCallArguments();
-    // Same-TU: plain call (PIE-safe PC32 to a defined symbol).
-    // Extern: PLT so link against libc works for PIE executables.
-    // (Local `call f wrt ..plt` is invalid NASM.)
     if (isDefinedProcedure(procedureName)) {
         assembly << instructionSet->call(procedureName);
     } else {

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -3,7 +3,6 @@
 #include "types/ObjectAbi.h"
 
 #include <cassert>
-#include <cctype>
 #include <stdexcept>
 
 #include "InstructionSet.h"
@@ -236,41 +235,6 @@ void StackMachine::functionAddress(std::string functionName, std::string resultN
     bindResult(resultRegister, resolve(resultName));
 }
 
-namespace {
-// Low-byte name for NASM size-qualified stores (rax→al, r8→r8b, …).
-std::string lowByteName(const Register& reg) {
-    const std::string n = reg.getName();
-    if (n == "rax") return "al";
-    if (n == "rbx") return "bl";
-    if (n == "rcx") return "cl";
-    if (n == "rdx") return "dl";
-    if (n == "rsi") return "sil";
-    if (n == "rdi") return "dil";
-    if (n == "rbp") return "bpl";
-    if (n == "rsp") return "spl";
-    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
-        return n + "b";
-    }
-    return n;
-}
-std::string lowDwordName(const Register& reg) {
-    const std::string n = reg.getName();
-    if (n == "rax") return "eax";
-    if (n == "rbx") return "ebx";
-    if (n == "rcx") return "ecx";
-    if (n == "rdx") return "edx";
-    if (n == "rsi") return "esi";
-    if (n == "rdi") return "edi";
-    if (n == "rbp") return "ebp";
-    if (n == "rsp") return "esp";
-    // r8–r15: dword form is r8d…r15d (not e8).
-    if (n.size() >= 2 && n[0] == 'r' && std::isdigit(static_cast<unsigned char>(n[1]))) {
-        return n + "d";
-    }
-    return n;
-}
-} // namespace
-
 void StackMachine::dereference(std::string operandName, std::string lvalueName, std::string resultName) {
     auto& operand = resolve(operandName);
     auto& result = resolve(resultName);
@@ -281,9 +245,9 @@ void StackMachine::dereference(std::string operandName, std::string lvalueName, 
     // Sign-extend into the full 64-bit register: the rest of the ALU uses 64-bit ops/cmp.
     // (Types are signed-default for char/int on this frontend.)
     if (loadSize == 1) {
-        assembly << ("movsx " + resultRegister.getName() + ", byte [" + pointerRegister.getName() + "]");
+        assembly << instructionSet->loadByteSignExtend(pointerRegister, resultRegister);
     } else if (loadSize == 4) {
-        assembly << ("movsxd " + resultRegister.getName() + ", dword [" + pointerRegister.getName() + "]");
+        assembly << instructionSet->loadDwordSignExtend(pointerRegister, resultRegister);
     } else {
         assembly << instructionSet->mov(MemoryOperand::at(pointerRegister, 0), resultRegister);
     }
@@ -353,7 +317,7 @@ void StackMachine::assignConstant(std::string constant, std::string resultName) 
 }
 
 void StackMachine::assignLabelAddress(std::string label, std::string resultName) {
-    // Pool/data labels (e.g. $c1): same discipline as functionAddress — lea into
+    // Pool/data labels (e.g. __trans_c1): same discipline as functionAddress — lea into
     // scratch then bindResult (lazy store for locals; never self-mov into home).
     Register& resultRegister = get64BitRegister();
     assembly << instructionSet->lea(MemoryOperand::global(label), resultRegister);
@@ -369,9 +333,9 @@ void StackMachine::lvalueAssign(std::string operandName, std::string resultName)
     // Store width follows the rvalue size so packed char/int array elements do not clobber neighbors.
     const int storeSize = operand.getSizeInBytes();
     if (storeSize == 1) {
-        assembly << ("mov byte [" + resultRegister.getName() + "], " + lowByteName(operandRegister));
+        assembly << instructionSet->storeByte(operandRegister, resultRegister);
     } else if (storeSize == 4) {
-        assembly << ("mov dword [" + resultRegister.getName() + "], " + lowDwordName(operandRegister));
+        assembly << instructionSet->storeDword(operandRegister, resultRegister);
     } else {
         assembly << instructionSet->mov(operandRegister, MemoryOperand::at(resultRegister, 0));
     }

--- a/src/codegen/StackMachine.cpp
+++ b/src/codegen/StackMachine.cpp
@@ -405,7 +405,7 @@ void StackMachine::callProcedureIndirect(std::string targetSymbolName) {
         }
     }
 
-    assembly << instructionSet->call(targetReg.getName());
+    assembly << instructionSet->callIndirect(targetReg);
     if (argumentOffset) {
         assembly << instructionSet->add(registers->getStackPointer(), argumentOffset);
     }

--- a/src/codegen/StackMachine.h
+++ b/src/codegen/StackMachine.h
@@ -88,7 +88,6 @@ public:
 
     void setScope(std::vector<Value> variables);
 
-    // Pre-register procedures defined in this assembly unit (before emitting calls).
     void registerDefinedProcedure(std::string procedureName);
 
 private:
@@ -164,7 +163,6 @@ private:
     std::vector<Value*> integerArguments;
     std::vector<Value*> stackArguments;
 
-    // Procedures defined in this assembly unit (for lea vs GOT on FunctionAddress).
     std::set<std::string> definedProcedures;
 
     int localVariableStackSize { 0 };

--- a/src/codegen/quadruples/AssignLabelAddress.h
+++ b/src/codegen/quadruples/AssignLabelAddress.h
@@ -7,7 +7,7 @@
 
 namespace codegen {
 
-// Materialize the address of a pool/data label (e.g. string constant __trans_c1) into result.
+// Materialize the address of a pool/data label (e.g. string constant L$str1) into result.
 // Separate from AssignConstant (integer immediates) so PIE emission cannot confuse the two.
 class AssignLabelAddress: public Quadruple {
 public:

--- a/src/codegen/quadruples/AssignLabelAddress.h
+++ b/src/codegen/quadruples/AssignLabelAddress.h
@@ -7,7 +7,7 @@
 
 namespace codegen {
 
-// Materialize the address of a pool/data label (e.g. string constant $c1) into result.
+// Materialize the address of a pool/data label (e.g. string constant __trans_c1) into result.
 // Separate from AssignConstant (integer immediates) so PIE emission cannot confuse the two.
 class AssignLabelAddress: public Quadruple {
 public:

--- a/src/codegen/quadruples/AssignLabelAddress.h
+++ b/src/codegen/quadruples/AssignLabelAddress.h
@@ -7,8 +7,7 @@
 
 namespace codegen {
 
-// Materialize the address of a pool/data label (e.g. string constant L$str1) into result.
-// Separate from AssignConstant (integer immediates) so PIE emission cannot confuse the two.
+// Address of a pool/data label (not an integer immediate).
 class AssignLabelAddress: public Quadruple {
 public:
     AssignLabelAddress(std::string label, std::string result);

--- a/src/codegen/quadruples/Quadruple.h
+++ b/src/codegen/quadruples/Quadruple.h
@@ -22,8 +22,6 @@ public:
         return false;
     }
 
-    // If this quad defines a same-TU procedure label, write its name and return true.
-    // Used to pre-register callees before emission (PIE call/GOT policy).
     virtual bool definesProcedure(std::string& /* nameOut */) const {
         return false;
     }

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -20,8 +20,6 @@ static Logger& out = LogManager::getOutputLogger();
 
 namespace {
 
-// Intermediate assembly/object are dialect-suffixed so intel and att of the same
-// source can coexist for inspection. The linked product is always source.out.
 std::string dialectStem(const std::string& sourceFileName, const Configuration& configuration) {
     return sourceFileName + "." + configuration.assemblyDialectTag();
 }
@@ -30,7 +28,6 @@ void assemble(const std::string& assemblyFileName, const std::string& objectFile
         AssemblyDialect dialect) {
     switch (dialect) {
     case AssemblyDialect::Intel:
-        // NASM Intel syntax -> ELF64 object.
         util::runProcessOrThrow({
                 "nasm", "-O1", "-f", "elf64",
                 "-o", objectFileName,
@@ -38,7 +35,6 @@ void assemble(const std::string& assemblyFileName, const std::string& objectFile
         });
         return;
     case AssemblyDialect::AtAndT:
-        // GNU as AT&T syntax -> ELF64 object.
         util::runProcessOrThrow({
                 "as", "--64",
                 "-o", objectFileName,
@@ -50,9 +46,6 @@ void assemble(const std::string& assemblyFileName, const std::string& objectFile
 }
 
 void link(const std::string& objectFileName, const std::string& executableFileName) {
-    // Product: position-independent executables. Emission is PIE-safe (extern PLT,
-    // same-TU direct calls, pool labels via lea [rel], extern addresses via GOT).
-    // Pass -pie explicitly so the linked type does not depend on host gcc defaults.
     util::runProcessOrThrow({
             "gcc", "-m64", "-pie",
             "-o", executableFileName,

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -20,18 +20,42 @@ static Logger& out = LogManager::getOutputLogger();
 
 namespace {
 
-void assemble(const std::string& assemblyFileName) {
-    util::runProcessOrThrow({ "nasm", "-O1", "-f", "elf64", assemblyFileName });
+// Dialect-suffixed artifacts so intel and att builds of the same source coexist.
+std::string dialectStem(const std::string& sourceFileName, const Configuration& configuration) {
+    return sourceFileName + "." + configuration.assemblyDialectTag();
 }
 
-void link(const std::string& sourceFileName) {
+void assemble(const std::string& assemblyFileName, const std::string& objectFileName,
+        AssemblyDialect dialect) {
+    switch (dialect) {
+    case AssemblyDialect::Intel:
+        // NASM Intel syntax -> ELF64 object.
+        util::runProcessOrThrow({
+                "nasm", "-O1", "-f", "elf64",
+                "-o", objectFileName,
+                assemblyFileName
+        });
+        return;
+    case AssemblyDialect::AtAndT:
+        // GNU as AT&T syntax -> ELF64 object.
+        util::runProcessOrThrow({
+                "as", "--64",
+                "-o", objectFileName,
+                assemblyFileName
+        });
+        return;
+    }
+    throw std::logic_error { "unknown AssemblyDialect" };
+}
+
+void link(const std::string& objectFileName, const std::string& executableFileName) {
     // Product: position-independent executables. Emission is PIE-safe (extern PLT,
     // same-TU direct calls, pool labels via lea [rel], extern addresses via GOT).
     // Pass -pie explicitly so the linked type does not depend on host gcc defaults.
     util::runProcessOrThrow({
             "gcc", "-m64", "-pie",
-            "-o", sourceFileName + ".out",
-            sourceFileName + ".o"
+            "-o", executableFileName,
+            objectFileName
     });
 }
 
@@ -46,7 +70,7 @@ Compiler::Compiler(Configuration configuration) :
 }
 
 void Compiler::compile(std::string sourceFileName) const {
-    out << "Compiling " << sourceFileName << "...\n";
+    out << "Compiling " << sourceFileName << " [" << configuration.assemblyDialectTag() << "]...\n";
 
     // Per-TU lexical state (typedefs, enums). Not process-static.
     scanner::LexicalSession session;
@@ -85,7 +109,11 @@ void Compiler::compile(std::string sourceFileName) const {
         out << "quadruples end\n\n";
     }
 
-    std::string assemblyFileName { sourceFileName + ".S" };
+    const std::string stem = dialectStem(sourceFileName, configuration);
+    const std::string assemblyFileName = stem + ".S";
+    const std::string objectFileName = stem + ".o";
+    const std::string executableFileName = stem + ".out";
+
     std::ofstream assemblyFile { assemblyFileName };
     if (!assemblyFile) {
         throw std::runtime_error { "Unable to open assembly output file " + assemblyFileName };
@@ -94,7 +122,7 @@ void Compiler::compile(std::string sourceFileName) const {
     assemblyGenerator->generateAssemblyCode(std::move(quadruples), semanticAnalyzer.getConstants(), globalVariables);
     assemblyFile.close();
 
-    assemble(assemblyFileName);
-    link(sourceFileName);
+    assemble(assemblyFileName, objectFileName, configuration.getAssemblyDialect());
+    link(objectFileName, executableFileName);
     out << "Successfully compiled and linked\n";
 }

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -20,7 +20,8 @@ static Logger& out = LogManager::getOutputLogger();
 
 namespace {
 
-// Dialect-suffixed artifacts so intel and att builds of the same source coexist.
+// Intermediate assembly/object are dialect-suffixed so intel and att of the same
+// source can coexist for inspection. The linked product is always source.out.
 std::string dialectStem(const std::string& sourceFileName, const Configuration& configuration) {
     return sourceFileName + "." + configuration.assemblyDialectTag();
 }
@@ -112,7 +113,7 @@ void Compiler::compile(std::string sourceFileName) const {
     const std::string stem = dialectStem(sourceFileName, configuration);
     const std::string assemblyFileName = stem + ".S";
     const std::string objectFileName = stem + ".o";
-    const std::string executableFileName = stem + ".out";
+    const std::string executableFileName = sourceFileName + ".out";
 
     std::ofstream assemblyFile { assemblyFileName };
     if (!assemblyFile) {

--- a/src/driver/Compiler.cpp
+++ b/src/driver/Compiler.cpp
@@ -20,10 +20,6 @@ static Logger& out = LogManager::getOutputLogger();
 
 namespace {
 
-std::string dialectStem(const std::string& sourceFileName, const Configuration& configuration) {
-    return sourceFileName + "." + configuration.assemblyDialectTag();
-}
-
 void assemble(const std::string& assemblyFileName, const std::string& objectFileName,
         AssemblyDialect dialect) {
     switch (dialect) {
@@ -103,9 +99,8 @@ void Compiler::compile(std::string sourceFileName) const {
         out << "quadruples end\n\n";
     }
 
-    const std::string stem = dialectStem(sourceFileName, configuration);
-    const std::string assemblyFileName = stem + ".S";
-    const std::string objectFileName = stem + ".o";
+    const std::string assemblyFileName = sourceFileName + ".S";
+    const std::string objectFileName = sourceFileName + ".o";
     const std::string executableFileName = sourceFileName + ".out";
 
     std::ofstream assemblyFile { assemblyFileName };

--- a/src/driver/CompilerComponentsFactory.cpp
+++ b/src/driver/CompilerComponentsFactory.cpp
@@ -13,9 +13,11 @@
 #include "Configuration.h"
 
 #include "codegen/AssemblyGenerator.h"
+#include "codegen/ATandTInstructionSet.h"
 #include "codegen/IntelInstructionSet.h"
 
 #include <chrono>
+#include <stdexcept>
 
 CompilerComponentsFactory::CompilerComponentsFactory(Configuration configuration) :
         configuration { configuration }
@@ -83,9 +85,20 @@ std::unique_ptr<parser::SyntaxTreeBuilder> CompilerComponentsFactory::makeSyntax
 }
 
 std::unique_ptr<codegen::AssemblyGenerator> CompilerComponentsFactory::makeAssemblyGenerator(std::ostream* assemblyFile) const {
+    std::unique_ptr<codegen::InstructionSet> instructionSet;
+    switch (configuration.getAssemblyDialect()) {
+    case AssemblyDialect::Intel:
+        instructionSet = std::make_unique<codegen::IntelInstructionSet>();
+        break;
+    case AssemblyDialect::AtAndT:
+        instructionSet = std::make_unique<codegen::ATandTInstructionSet>();
+        break;
+    default:
+        throw std::logic_error { "unknown AssemblyDialect" };
+    }
     return std::make_unique<codegen::AssemblyGenerator>(
             std::make_unique<codegen::StackMachine>(
                     assemblyFile,
-                    std::make_unique<codegen::IntelInstructionSet>(),
+                    std::move(instructionSet),
                     std::make_unique<codegen::Amd64Registers>()));
 }

--- a/src/driver/Configuration.cpp
+++ b/src/driver/Configuration.cpp
@@ -55,14 +55,18 @@ AssemblyDialect Configuration::getAssemblyDialect() const {
     return assemblyDialect;
 }
 
-std::string Configuration::assemblyDialectTag() const {
-    switch (assemblyDialect) {
+std::string assemblyDialectTag(AssemblyDialect dialect) {
+    switch (dialect) {
     case AssemblyDialect::Intel:
         return "intel";
     case AssemblyDialect::AtAndT:
         return "att";
     }
     throw std::logic_error { "unknown AssemblyDialect" };
+}
+
+std::string Configuration::assemblyDialectTag() const {
+    return ::assemblyDialectTag(assemblyDialect);
 }
 
 bool Configuration::usingCustomGrammar() const {

--- a/src/driver/Configuration.cpp
+++ b/src/driver/Configuration.cpp
@@ -1,5 +1,7 @@
 #include "Configuration.h"
 
+#include <stdexcept>
+
 void Configuration::setSourceFiles(std::vector<std::string> sourceFiles) {
     this->sourceFiles = sourceFiles;
 }
@@ -11,6 +13,10 @@ void Configuration::setResourcesBasePath(std::string resourcesBasePath) {
 void Configuration::setGrammarPath(std::string grammarPath) {
     this->grammarPath = grammarPath;
     this->customGrammar = true;
+}
+
+void Configuration::setAssemblyDialect(AssemblyDialect dialect) {
+    this->assemblyDialect = dialect;
 }
 
 void Configuration::enableScannerLogging() {
@@ -43,6 +49,20 @@ std::string Configuration::getGrammarPath() const {
 
 std::string Configuration::getParsingTablePath() const {
     return resourcesBasePath + parsingTablePath;
+}
+
+AssemblyDialect Configuration::getAssemblyDialect() const {
+    return assemblyDialect;
+}
+
+std::string Configuration::assemblyDialectTag() const {
+    switch (assemblyDialect) {
+    case AssemblyDialect::Intel:
+        return "intel";
+    case AssemblyDialect::AtAndT:
+        return "att";
+    }
+    throw std::logic_error { "unknown AssemblyDialect" };
 }
 
 bool Configuration::usingCustomGrammar() const {

--- a/src/driver/Configuration.h
+++ b/src/driver/Configuration.h
@@ -4,6 +4,12 @@
 #include <string>
 #include <vector>
 
+// Assembly syntax / backend dialect (InstructionSet + assembler).
+enum class AssemblyDialect {
+    Intel,  // NASM Intel syntax (default)
+    AtAndT  // GNU as AT&T syntax
+};
+
 class Configuration {
   public:
     Configuration() = default;
@@ -12,6 +18,7 @@ class Configuration {
     void setSourceFiles(std::vector<std::string> sourceFiles);
     void setResourcesBasePath(std::string resourcesBasePath);
     void setGrammarPath(std::string grammarPath);
+    void setAssemblyDialect(AssemblyDialect dialect);
     void enableScannerLogging();
     void enableParserLogging();
     void enableSyntaxTreeLogging();
@@ -21,6 +28,9 @@ class Configuration {
     std::string getLexPath() const;
     std::string getGrammarPath() const;
     std::string getParsingTablePath() const;
+    AssemblyDialect getAssemblyDialect() const;
+    // Short tag for artifact suffixes and CLI: "intel" | "att".
+    std::string assemblyDialectTag() const;
     bool usingCustomGrammar() const;
     bool isScannerLoggingEnabled() const;
     bool isParserLoggingEnabled() const;
@@ -33,6 +43,7 @@ class Configuration {
     std::string lexPath {"resources/configuration/scanner.lex"};
     std::string grammarPath {"resources/configuration/grammar.bnf"};
     std::string parsingTablePath {"resources/configuration/parsing_table"};
+    AssemblyDialect assemblyDialect { AssemblyDialect::Intel };
     bool customGrammar {false};
     bool scannerLogging {false};
     bool parserLogging {false};

--- a/src/driver/Configuration.h
+++ b/src/driver/Configuration.h
@@ -4,10 +4,9 @@
 #include <string>
 #include <vector>
 
-// Assembly syntax / backend dialect (InstructionSet + assembler).
 enum class AssemblyDialect {
-    Intel,  // NASM Intel syntax (default)
-    AtAndT  // GNU as AT&T syntax
+    Intel,
+    AtAndT
 };
 
 class Configuration {
@@ -29,7 +28,6 @@ class Configuration {
     std::string getGrammarPath() const;
     std::string getParsingTablePath() const;
     AssemblyDialect getAssemblyDialect() const;
-    // Short tag for artifact suffixes and CLI: "intel" | "att".
     std::string assemblyDialectTag() const;
     bool usingCustomGrammar() const;
     bool isScannerLoggingEnabled() const;

--- a/src/driver/Configuration.h
+++ b/src/driver/Configuration.h
@@ -9,6 +9,9 @@ enum class AssemblyDialect {
     AtAndT
 };
 
+// Canonical short name for CLI and artifacts: "intel" | "att".
+std::string assemblyDialectTag(AssemblyDialect dialect);
+
 class Configuration {
   public:
     Configuration() = default;

--- a/src/driver/ConfigurationParser.cpp
+++ b/src/driver/ConfigurationParser.cpp
@@ -4,11 +4,12 @@
 #include <iostream>
 #include <iterator>
 
-static const char* const COMMAND_LINE_OPTIONS = "hl:g:r:";
+static const char* const COMMAND_LINE_OPTIONS = "hl:g:r:a:";
 static const char HELP_OPTION = 'h';
 static const char LOGGING_OPTION = 'l';
 static const char GRAMMAR_OPTION = 'g';
 static const char RESOURCES_BASEDIR_OPTION = 'r';
+static const char ASSEMBLY_DIALECT_OPTION = 'a';
 static const char SCANNER_LOGGING_FLAG = 's';
 static const char PARSER_LOGGING_FLAG = 'p';
 static const char SYNTAX_TREE_LOGGING_FLAG = 't';
@@ -46,6 +47,9 @@ int ConfigurationParser::parseOptions(int argc, char **argv) {
                 break;
             case RESOURCES_BASEDIR_OPTION:
                 configuration.setResourcesBasePath(optarg);
+                break;
+            case ASSEMBLY_DIALECT_OPTION:
+                setAssemblyDialect(optarg);
                 break;
             case HELP_OPTION:
             default:
@@ -100,6 +104,18 @@ void ConfigurationParser::setLogging(std::string loggingArguments) {
 	}
 }
 
+void ConfigurationParser::setAssemblyDialect(std::string dialect) {
+	if (dialect == "intel") {
+		configuration.setAssemblyDialect(AssemblyDialect::Intel);
+		return;
+	}
+	if (dialect == "att") {
+		configuration.setAssemblyDialect(AssemblyDialect::AtAndT);
+		return;
+	}
+	outputErrorAndTerminate("Invalid assembly dialect: " + dialect + " (expected intel or att)");
+}
+
 void ConfigurationParser::outputErrorAndTerminate(std::string errorMessage) const {
 	std::cerr << errorMessage << std::endl;
 	std::cerr << std::endl;
@@ -115,5 +131,6 @@ void ConfigurationParser::printUsage() const {
 	std::cerr << " -" << LOGGING_OPTION << "<s|p|t|i>\tEnable scanner|parser|syntax tree|intermediate code logging" << std::endl;
 	std::cerr << " -" << GRAMMAR_OPTION << "<file_name>\tSpecify custom grammar file" << std::endl;
 	std::cerr << " -" << RESOURCES_BASEDIR_OPTION << "<directory_path>\tSpecify custom resources base directory" << std::endl;
+	std::cerr << " -" << ASSEMBLY_DIALECT_OPTION << "<intel|att>\tAssembly dialect (default: intel)" << std::endl;
 }
 

--- a/src/driver/ConfigurationParser.h
+++ b/src/driver/ConfigurationParser.h
@@ -21,6 +21,7 @@ class ConfigurationParser {
     void parseSourceFileNames(int argc, char **argv);
 
     void setLogging(std::string loggingArguments);
+    void setAssemblyDialect(std::string dialect);
 
     void outputErrorAndTerminate(std::string errorMessage) const;
     void printUsage() const;

--- a/src/semantic_analyzer/SymbolTable.cpp
+++ b/src/semantic_analyzer/SymbolTable.cpp
@@ -9,7 +9,10 @@ static Logger& out = LogManager::getOutputLogger();
 const std::string LABEL_PREFIX = "__L";
 unsigned nextLabel { 0 };
 
-const std::string CONSTANT_PREFIX = "$c";
+// Compiler-internal pool labels. Must be valid NASM and gas symbols and must not
+// be expressible as a normal C identifier clash target for typical user code
+// ($ was gas-hostile; bare user ids cannot start with "__trans_" by convention).
+const std::string CONSTANT_PREFIX = "__trans_c";
 unsigned nextConstant { 0 };
 
 std::string generateLabelName() {

--- a/src/semantic_analyzer/SymbolTable.cpp
+++ b/src/semantic_analyzer/SymbolTable.cpp
@@ -9,11 +9,7 @@ static Logger& out = LogManager::getOutputLogger();
 const std::string LABEL_PREFIX = "__L";
 unsigned nextLabel { 0 };
 
-// String pool labels in the assembly output. Constraints:
-// - Not a valid C identifier (C does not allow '$' in identifiers).
-// - Legal as a non-local symbol in both NASM and gas.
-//   Leading '.' is local in NASM (becomes main.LstrN); leading '$' is immediate in gas.
-//   "L$str" is non-local in NASM and a plain symbol in gas.
+// Not a C identifier; legal non-local label in NASM and gas.
 const std::string CONSTANT_PREFIX = "L$str";
 unsigned nextConstant { 0 };
 

--- a/src/semantic_analyzer/SymbolTable.cpp
+++ b/src/semantic_analyzer/SymbolTable.cpp
@@ -9,10 +9,12 @@ static Logger& out = LogManager::getOutputLogger();
 const std::string LABEL_PREFIX = "__L";
 unsigned nextLabel { 0 };
 
-// Compiler-internal pool labels. Must be valid NASM and gas symbols and must not
-// be expressible as a normal C identifier clash target for typical user code
-// ($ was gas-hostile; bare user ids cannot start with "__trans_" by convention).
-const std::string CONSTANT_PREFIX = "__trans_c";
+// String pool labels in the assembly output. Constraints:
+// - Not a valid C identifier (C does not allow '$' in identifiers).
+// - Legal as a non-local symbol in both NASM and gas.
+//   Leading '.' is local in NASM (becomes main.LstrN); leading '$' is immediate in gas.
+//   "L$str" is non-local in NASM and a plain symbol in gas.
+const std::string CONSTANT_PREFIX = "L$str";
 unsigned nextConstant { 0 };
 
 std::string generateLabelName() {

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -177,15 +177,9 @@ add_executable(functionalTest
         functionalTest/PieExecutableTest.cpp
         functionalTest/FuzzCrashRegressionTest.cpp
         )
-# Custom main names the assembly backend; do not link gmock_main.
 target_link_libraries(functionalTest PRIVATE GTest::gmock driver translation_unit scanner util parser testUtil)
 
-# One ctest entry per (dialect x shard) so failures name the backend:
-#   functionalTest_intel_shard0, functionalTest_att_shard3, ...
-# TRANS_ASM_DIALECT selects InstructionSet + assembler for that process.
-# Adding new TEST() cases needs no CMake changes — gtest shards by case name.
-# Override at configure time: cmake -DFUNCTIONAL_TEST_SHARDS=16 ...
-# Note: make coverage runs ctest -j1 so shards do not race on gcov .gcda files.
+# Dialect x gtest shard matrix (TRANS_ASM_DIALECT). Override: -DFUNCTIONAL_TEST_SHARDS=16
 set(FUNCTIONAL_TEST_SHARDS 8 CACHE STRING "Number of gtest shards for functionalTest (ctest -j runs them in parallel)")
 if(NOT FUNCTIONAL_TEST_SHARDS MATCHES "^[1-9][0-9]*$")
   message(FATAL_ERROR "FUNCTIONAL_TEST_SHARDS must be a positive integer (got: ${FUNCTIONAL_TEST_SHARDS})")

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -128,6 +128,7 @@ add_test(NAME utilTest COMMAND utilTest)
 add_executable(functionalTest
         functionalTest/TestFixtures.h
         functionalTest/TestFixtures.cpp
+        functionalTest/FunctionalTestMain.cpp
         functionalTest/CompilerInitTest.cpp
         functionalTest/ConditionalTest.cpp
         functionalTest/TernaryTest.cpp
@@ -176,10 +177,13 @@ add_executable(functionalTest
         functionalTest/PieExecutableTest.cpp
         functionalTest/FuzzCrashRegressionTest.cpp
         )
-target_link_libraries(functionalTest PRIVATE GTest::gmock_main driver translation_unit scanner util parser testUtil)
+# Custom main names the assembly backend; do not link gmock_main.
+target_link_libraries(functionalTest PRIVATE GTest::gmock driver translation_unit scanner util parser testUtil)
 
-# Split functionalTest across N gtest processes so ctest -j can run them in parallel.
-# Adding new TEST() cases needs no CMake changes — gtest assigns each case to a shard by name.
+# One ctest entry per (dialect x shard) so failures name the backend:
+#   functionalTest_intel_shard0, functionalTest_att_shard3, ...
+# TRANS_ASM_DIALECT selects InstructionSet + assembler for that process.
+# Adding new TEST() cases needs no CMake changes — gtest shards by case name.
 # Override at configure time: cmake -DFUNCTIONAL_TEST_SHARDS=16 ...
 # Note: make coverage runs ctest -j1 so shards do not race on gcov .gcda files.
 set(FUNCTIONAL_TEST_SHARDS 8 CACHE STRING "Number of gtest shards for functionalTest (ctest -j runs them in parallel)")
@@ -187,10 +191,13 @@ if(NOT FUNCTIONAL_TEST_SHARDS MATCHES "^[1-9][0-9]*$")
   message(FATAL_ERROR "FUNCTIONAL_TEST_SHARDS must be a positive integer (got: ${FUNCTIONAL_TEST_SHARDS})")
 endif()
 math(EXPR functional_last_shard "${FUNCTIONAL_TEST_SHARDS} - 1")
-foreach(shard RANGE 0 ${functional_last_shard})
-  add_test(NAME functionalTest_shard${shard} COMMAND functionalTest)
-  set_tests_properties(functionalTest_shard${shard} PROPERTIES
-    LABELS "functional"
-    ENVIRONMENT "GTEST_TOTAL_SHARDS=${FUNCTIONAL_TEST_SHARDS};GTEST_SHARD_INDEX=${shard}"
-  )
+foreach(dialect intel att)
+  foreach(shard RANGE 0 ${functional_last_shard})
+    set(test_name functionalTest_${dialect}_shard${shard})
+    add_test(NAME ${test_name} COMMAND functionalTest)
+    set_tests_properties(${test_name} PROPERTIES
+      LABELS "functional;${dialect}"
+      ENVIRONMENT "TRANS_ASM_DIALECT=${dialect};GTEST_TOTAL_SHARDS=${FUNCTIONAL_TEST_SHARDS};GTEST_SHARD_INDEX=${shard}"
+    )
+  endforeach()
 endforeach()

--- a/test/src/codegenTest/ATandTInstructionSetTests.cpp
+++ b/test/src/codegenTest/ATandTInstructionSetTests.cpp
@@ -54,8 +54,13 @@ TEST(ATandTInstructionSet, emitsCallPlt) {
     EXPECT_THAT(instructions.callPlt("printf"), Eq("call printf@plt"));
 }
 
-TEST(ATandTInstructionSet, emitsIndirectCall) {
-    EXPECT_THAT(instructions.call("r10"), Eq("call *%r10"));
+TEST(ATandTInstructionSet, callNamedRegisterLikeLabelIsDirect) {
+    EXPECT_THAT(instructions.call("r10"), Eq("call r10"));
+}
+
+TEST(ATandTInstructionSet, emitsCallIndirect) {
+    Register target { "r10" };
+    EXPECT_THAT(instructions.callIndirect(target), Eq("call *%r10"));
 }
 
 }

--- a/test/src/codegenTest/ATandTInstructionSetTests.cpp
+++ b/test/src/codegenTest/ATandTInstructionSetTests.cpp
@@ -26,7 +26,6 @@ TEST(ATandTInstructionSet, emitsPreamble) {
 TEST(ATandTInstructionSet, emitsMovToMemoryWithOffset) {
     Register source { "src" };
     Register memoryBase { "memBase" };
-    // Signed offset as-is (positive = higher address, matching Intel [base + N]).
     EXPECT_THAT(instructions.mov(source, MemoryOperand::at(memoryBase, 42)), Eq("movq %src, 42(%memBase)"));
 }
 
@@ -42,7 +41,6 @@ TEST(ATandTInstructionSet, emitsQuadSubtract) {
 }
 
 TEST(ATandTInstructionSet, emitsCqo) {
-    // Gas AT&T mnemonic for cqo is cqto.
     EXPECT_THAT(instructions.cqo(), Eq("cqto"));
 }
 

--- a/test/src/codegenTest/ATandTInstructionSetTests.cpp
+++ b/test/src/codegenTest/ATandTInstructionSetTests.cpp
@@ -17,17 +17,17 @@ ATandTInstructionSet instructions;
 TEST(ATandTInstructionSet, emitsPreamble) {
     EXPECT_THAT(instructions.preamble({}), Eq(".extern scanf\n"
             ".extern printf\n\n"
-            ".data\n"
-            "sfmt: .string \"%d\"\n"
-            "fmt: .string \"%d\n\"\n\n"
-            ".text\n"
+            ".section .data\n"
+            "\n"
+            ".section .text\n"
             ".globl main\n\n"));
 }
 
 TEST(ATandTInstructionSet, emitsMovToMemoryWithOffset) {
     Register source { "src" };
     Register memoryBase { "memBase" };
-    EXPECT_THAT(instructions.mov(source, MemoryOperand::at(memoryBase, 42)), Eq("movq %src, -42(%memBase)"));
+    // Signed offset as-is (positive = higher address, matching Intel [base + N]).
+    EXPECT_THAT(instructions.mov(source, MemoryOperand::at(memoryBase, 42)), Eq("movq %src, 42(%memBase)"));
 }
 
 TEST(ATandTInstructionSet, emitsMovToMemoryWithoutOffset) {
@@ -42,7 +42,22 @@ TEST(ATandTInstructionSet, emitsQuadSubtract) {
 }
 
 TEST(ATandTInstructionSet, emitsCqo) {
-    EXPECT_THAT(instructions.cqo(), Eq("cqo"));
+    // Gas AT&T mnemonic for cqo is cqto.
+    EXPECT_THAT(instructions.cqo(), Eq("cqto"));
+}
+
+TEST(ATandTInstructionSet, emitsLoadGot) {
+    Register target { "rax" };
+    EXPECT_THAT(instructions.loadGot("printf", target),
+            Eq("movq printf@GOTPCREL(%rip), %rax"));
+}
+
+TEST(ATandTInstructionSet, emitsCallPlt) {
+    EXPECT_THAT(instructions.callPlt("printf"), Eq("call printf@plt"));
+}
+
+TEST(ATandTInstructionSet, emitsIndirectCall) {
+    EXPECT_THAT(instructions.call("r10"), Eq("call *%r10"));
 }
 
 }

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -97,9 +97,9 @@ TEST_F(StackMachineTest, assignLabelAddress_leaPoolLabel) {
     stackMachine.startProcedure("proc", { s }, { });
     assemblyCode.str("");
 
-    stackMachine.assignLabelAddress("$c1", "s");
+    stackMachine.assignLabelAddress("__trans_c1", "s");
 
-    expectCode("\tlea rax, [rel $c1]\n");
+    expectCode("\tlea rax, [rel __trans_c1]\n");
 }
 
 TEST_F(StackMachineTest, callProcedure_sameTuDoesNotUsePlt) {
@@ -187,7 +187,7 @@ TEST_F(StackMachineTest, procedureCall_clearsRaxForVariadicAlRequirement) {
     stackMachine.procedureArgument(value.getName());
     stackMachine.callProcedure("printf");
 
-    expectCode("\tmovq -40(%rsp), %rdi\n"
+    expectCode("\tmovq 40(%rsp), %rdi\n"
             "\txorq %rax, %rax\n"
             "\tcall printf@plt\n");
 }
@@ -242,7 +242,7 @@ TEST_F(StackMachineTest, procedureArgumentPassing_firstIntegerArgumentIsPassedIn
     stackMachine.procedureArgument(value.getName());
     stackMachine.callProcedure("procedure");
 
-    expectCode("\tmovq -40(%rsp), %rdi\n"
+    expectCode("\tmovq 40(%rsp), %rdi\n"
             "\txorq %rax, %rax\n"
             "\tcall procedure@plt\n");
 }
@@ -262,14 +262,14 @@ TEST_F(StackMachineTest, procedureCall_padsStackForOddNumberOfStackArguments) {
     }
     stackMachine.callProcedure("procedure");
 
-    expectCode("\tmovq -40(%rsp), %rdi\n"
-            "\tmovq -48(%rsp), %rsi\n"
-            "\tmovq -56(%rsp), %rdx\n"
-            "\tmovq -64(%rsp), %rcx\n"
-            "\tmovq -72(%rsp), %r8\n"
-            "\tmovq -80(%rsp), %r9\n"
+    expectCode("\tmovq 40(%rsp), %rdi\n"
+            "\tmovq 48(%rsp), %rsi\n"
+            "\tmovq 56(%rsp), %rdx\n"
+            "\tmovq 64(%rsp), %rcx\n"
+            "\tmovq 72(%rsp), %r8\n"
+            "\tmovq 80(%rsp), %r9\n"
             "\tsubq $8, %rsp\n"
-            "\tmovq -96(%rsp), %rax\n"
+            "\tmovq 96(%rsp), %rax\n"
             "\tpushq %rax\n"
             "\txorq %rax, %rax\n"
             "\tcall procedure@plt\n"
@@ -308,7 +308,7 @@ TEST_F(StackMachineTest, sub_reg_mem) {
 
     // then
     expectCode("\tmovq %rax, %rbx\n"
-            "\tsubq -8(%rsp), %rbx\n");
+            "\tsubq 8(%rsp), %rbx\n");
 
     expectRegisterContains(rax, v1);
     expectRegisterContains(rbx, v3);
@@ -342,7 +342,7 @@ TEST_F(StackMachineTest, sub_mem_mem) {
 
     // then
     expectCode("\tmovq (%rsp), %rax\n"
-            "\tsubq -8(%rsp), %rax\n");
+            "\tsubq 8(%rsp), %rax\n");
 
     expectRegisterContains(rax, v3);
 }
@@ -379,7 +379,7 @@ TEST_F(StackMachineTest, add_reg_mem) {
 
     // then
     expectCode("\tmovq %rax, %rbx\n"
-            "\taddq -8(%rsp), %rbx\n");
+            "\taddq 8(%rsp), %rbx\n");
 
     expectRegisterContains(rax, v1);
     expectRegisterContains(rbx, v3);
@@ -413,7 +413,7 @@ TEST_F(StackMachineTest, add_mem_mem) {
 
     // then
     expectCode("\tmovq (%rsp), %rax\n"
-            "\taddq -8(%rsp), %rax\n");
+            "\taddq 8(%rsp), %rax\n");
 
     expectRegisterContains(rax, v3);
 }

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -63,7 +63,6 @@ TEST_F(StackMachineTest, procedureCall_doesNotPushUnusedCallerSavedRegisters) {
             "\tcall procedure@plt\n");
 }
 
-// Production path uses IntelInstructionSet (LEA + indirect call via r10).
 TEST_F(StackMachineTest, functionAddress_leaDefinedProcedure) {
     StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
     Value fp = intValue("fp");
@@ -73,7 +72,6 @@ TEST_F(StackMachineTest, functionAddress_leaDefinedProcedure) {
 
     stackMachine.functionAddress("foo", "fp");
 
-    // Same-TU definition: PC-relative LEA (PIE-safe).
     expectCode("\tlea rax, [rel foo]\n");
 }
 
@@ -86,11 +84,9 @@ TEST_F(StackMachineTest, functionAddress_loadsExternViaGot) {
 
     stackMachine.functionAddress("printf", "fp");
 
-    // Extern: GOT load for PIE.
     expectCode("\tmov rax, [rel printf wrt ..got]\n");
 }
 
-// Pool/data labels (string constants): same lea [rel] + bindResult as defined functionAddress.
 TEST_F(StackMachineTest, assignLabelAddress_leaPoolLabel) {
     StackMachine stackMachine { &assemblyCode, std::make_unique<IntelInstructionSet>(), std::make_unique<Amd64Registers>() };
     Value s = intValue("s");
@@ -108,7 +104,6 @@ TEST_F(StackMachineTest, callProcedure_sameTuDoesNotUsePlt) {
 
     stackMachine.callProcedure("foo");
 
-    // NASM rejects local `call foo wrt ..plt` (intra-segment OUT_REL4ADR).
     expectCode("\txor rax, rax\n"
             "\tcall foo\n");
 }

--- a/test/src/codegenTest/StackMachineTests.cpp
+++ b/test/src/codegenTest/StackMachineTests.cpp
@@ -97,9 +97,9 @@ TEST_F(StackMachineTest, assignLabelAddress_leaPoolLabel) {
     stackMachine.startProcedure("proc", { s }, { });
     assemblyCode.str("");
 
-    stackMachine.assignLabelAddress("__trans_c1", "s");
+    stackMachine.assignLabelAddress("L$str1", "s");
 
-    expectCode("\tlea rax, [rel __trans_c1]\n");
+    expectCode("\tlea rax, [rel L$str1]\n");
 }
 
 TEST_F(StackMachineTest, callProcedure_sameTuDoesNotUsePlt) {

--- a/test/src/driverTest/ConfigurationParserTest.cpp
+++ b/test/src/driverTest/ConfigurationParserTest.cpp
@@ -18,6 +18,43 @@ TEST(ConfigurationParser, createsDefaultTransConfiguration) {
 	ASSERT_THAT(configuration.getGrammarPath(), StrEq("resources/configuration/grammar.bnf"));
 	ASSERT_THAT(configuration.isScannerLoggingEnabled(), Eq(false));
 	ASSERT_THAT(configuration.isParserLoggingEnabled(), Eq(false));
+	ASSERT_THAT(configuration.getAssemblyDialect(), Eq(AssemblyDialect::Intel));
+	ASSERT_THAT(configuration.assemblyDialectTag(), StrEq("intel"));
+}
+
+TEST(ConfigurationParser, setsIntelAssemblyDialect) {
+	char executable[] = "trans";
+	char dialectArg[] = "-aintel";
+	char sourceFileName[] = "test.src";
+	char *argv[] = { executable, dialectArg, sourceFileName };
+
+	ConfigurationParser parser(3, argv);
+	Configuration configuration = parser.getConfiguration();
+
+	ASSERT_THAT(configuration.getAssemblyDialect(), Eq(AssemblyDialect::Intel));
+	ASSERT_THAT(configuration.assemblyDialectTag(), StrEq("intel"));
+}
+
+TEST(ConfigurationParser, setsAtAndTAssemblyDialect) {
+	char executable[] = "trans";
+	char dialectArg[] = "-aatt";
+	char sourceFileName[] = "test.src";
+	char *argv[] = { executable, dialectArg, sourceFileName };
+
+	ConfigurationParser parser(3, argv);
+	Configuration configuration = parser.getConfiguration();
+
+	ASSERT_THAT(configuration.getAssemblyDialect(), Eq(AssemblyDialect::AtAndT));
+	ASSERT_THAT(configuration.assemblyDialectTag(), StrEq("att"));
+}
+
+TEST(ConfigurationParser, terminatesGivenUnknownAssemblyDialect) {
+	char executable[] = "trans";
+	char dialectArg[] = "-agas";
+	char sourceFileName[] = "test.src";
+	char *argv[] = { executable, dialectArg, sourceFileName };
+
+	ASSERT_EXIT(ConfigurationParser configuration(3, argv);, ExitedWithCode(EXIT_FAILURE), "");
 }
 
 TEST(ConfigurationParser, handlesMultipleSourceFiles) {

--- a/test/src/driverTest/DriverExitCodeTest.cpp
+++ b/test/src/driverTest/DriverExitCodeTest.cpp
@@ -33,17 +33,17 @@ std::filesystem::path writeTempSource(const std::string& name, const std::string
 
 void removeCompileArtifacts(const std::filesystem::path& sourcePath) {
     std::filesystem::remove(sourcePath);
-    // Dialect-suffixed artifacts (default compile is intel).
+    // Linked product is always source.out (not dialect-suffixed).
+    std::filesystem::remove(sourcePath.string() + ".out");
+    // Intermediate assembly/object may be dialect-suffixed.
     for (const char* tag : { "intel", "att" }) {
         const std::string stem = sourcePath.string() + "." + tag;
         std::filesystem::remove(stem + ".S");
         std::filesystem::remove(stem + ".o");
-        std::filesystem::remove(stem + ".out");
     }
-    // Legacy unsuffixed names (pre-dialect-suffix).
+    // Legacy unsuffixed intermediates.
     std::filesystem::remove(sourcePath.string() + ".S");
     std::filesystem::remove(sourcePath.string() + ".o");
-    std::filesystem::remove(sourcePath.string() + ".out");
 }
 
 // Prepends pathPrefix to PATH for this object's lifetime, then restores it.

--- a/test/src/driverTest/DriverExitCodeTest.cpp
+++ b/test/src/driverTest/DriverExitCodeTest.cpp
@@ -33,14 +33,9 @@ std::filesystem::path writeTempSource(const std::string& name, const std::string
 
 void removeCompileArtifacts(const std::filesystem::path& sourcePath) {
     std::filesystem::remove(sourcePath);
-    std::filesystem::remove(sourcePath.string() + ".out");
-    for (const char* tag : { "intel", "att" }) {
-        const std::string stem = sourcePath.string() + "." + tag;
-        std::filesystem::remove(stem + ".S");
-        std::filesystem::remove(stem + ".o");
-    }
     std::filesystem::remove(sourcePath.string() + ".S");
     std::filesystem::remove(sourcePath.string() + ".o");
+    std::filesystem::remove(sourcePath.string() + ".out");
 }
 
 // Prepends pathPrefix to PATH for this object's lifetime, then restores it.

--- a/test/src/driverTest/DriverExitCodeTest.cpp
+++ b/test/src/driverTest/DriverExitCodeTest.cpp
@@ -33,6 +33,14 @@ std::filesystem::path writeTempSource(const std::string& name, const std::string
 
 void removeCompileArtifacts(const std::filesystem::path& sourcePath) {
     std::filesystem::remove(sourcePath);
+    // Dialect-suffixed artifacts (default compile is intel).
+    for (const char* tag : { "intel", "att" }) {
+        const std::string stem = sourcePath.string() + "." + tag;
+        std::filesystem::remove(stem + ".S");
+        std::filesystem::remove(stem + ".o");
+        std::filesystem::remove(stem + ".out");
+    }
+    // Legacy unsuffixed names (pre-dialect-suffix).
     std::filesystem::remove(sourcePath.string() + ".S");
     std::filesystem::remove(sourcePath.string() + ".o");
     std::filesystem::remove(sourcePath.string() + ".out");

--- a/test/src/driverTest/DriverExitCodeTest.cpp
+++ b/test/src/driverTest/DriverExitCodeTest.cpp
@@ -33,15 +33,12 @@ std::filesystem::path writeTempSource(const std::string& name, const std::string
 
 void removeCompileArtifacts(const std::filesystem::path& sourcePath) {
     std::filesystem::remove(sourcePath);
-    // Linked product is always source.out (not dialect-suffixed).
     std::filesystem::remove(sourcePath.string() + ".out");
-    // Intermediate assembly/object may be dialect-suffixed.
     for (const char* tag : { "intel", "att" }) {
         const std::string stem = sourcePath.string() + "." + tag;
         std::filesystem::remove(stem + ".S");
         std::filesystem::remove(stem + ".o");
     }
-    // Legacy unsuffixed intermediates.
     std::filesystem::remove(sourcePath.string() + ".S");
     std::filesystem::remove(sourcePath.string() + ".o");
 }

--- a/test/src/functionalTest/FunctionalTestMain.cpp
+++ b/test/src/functionalTest/FunctionalTestMain.cpp
@@ -7,8 +7,6 @@
 
 namespace {
 
-// Prints the active assembly backend on every test start/end so gtest logs
-// name the dialect even when the TEST() body does not.
 class AssemblyBackendListener : public ::testing::EmptyTestEventListener {
 public:
     void OnTestProgramStart(const ::testing::UnitTest& /*unit_test*/) override {

--- a/test/src/functionalTest/FunctionalTestMain.cpp
+++ b/test/src/functionalTest/FunctionalTestMain.cpp
@@ -1,0 +1,44 @@
+#include "TestFixtures.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <iostream>
+
+namespace {
+
+// Prints the active assembly backend on every test start/end so gtest logs
+// name the dialect even when the TEST() body does not.
+class AssemblyBackendListener : public ::testing::EmptyTestEventListener {
+public:
+    void OnTestProgramStart(const ::testing::UnitTest& /*unit_test*/) override {
+        std::cout << "[==========] Assembly backend: " << functionalTestDialectTag() << "\n";
+    }
+
+    void OnTestStart(const ::testing::TestInfo& test_info) override {
+        std::cout << "[ BACKEND  ] " << functionalTestDialectTag()
+                  << "  " << test_info.test_suite_name() << "." << test_info.name() << "\n";
+    }
+
+    void OnTestEnd(const ::testing::TestInfo& test_info) override {
+        if (test_info.result()->Failed()) {
+            std::cout << "[  FAILED  ] backend=" << functionalTestDialectTag()
+                      << "  " << test_info.test_suite_name() << "." << test_info.name() << "\n";
+        }
+    }
+
+    void OnTestProgramEnd(const ::testing::UnitTest& unit_test) override {
+        if (unit_test.failed_test_count() > 0) {
+            std::cout << "[==========] Failures above are for assembly backend: "
+                      << functionalTestDialectTag() << "\n";
+        }
+    }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleMock(&argc, argv);
+    ::testing::UnitTest::GetInstance()->listeners().Append(new AssemblyBackendListener);
+    return RUN_ALL_TESTS();
+}

--- a/test/src/functionalTest/PieExecutableTest.cpp
+++ b/test/src/functionalTest/PieExecutableTest.cpp
@@ -10,9 +10,6 @@
 
 namespace {
 
-// Compiler product: link with -pie. ET_DYN for an executable output (not a .so we
-// produce). Matches both modern readelf ("Position-Independent Executable") and
-// older binutils ("Shared object file") wording on the Type line.
 bool executableIsPie(const std::string& path) {
     util::ProcessResult result = util::runProcess({ "readelf", "-h", path });
     if (result.exitCode != 0) {
@@ -44,7 +41,6 @@ TEST(Compiler, linkedExecutableIsPositionIndependent) {
 }
 
 TEST(Compiler, pieExecutableCallsLibcAndLocalFunctionPointer) {
-    // Direct libc call (PLT) plus address-of a same-TU function (lea [rel ...]).
     SourceProgram program{R"prg(
         int seven() {
             return 7;
@@ -66,8 +62,6 @@ TEST(Compiler, pieExecutableCallsLibcAndLocalFunctionPointer) {
 }
 
 TEST(Compiler, pieExecutableTakesExternFunctionAddress) {
-    // Address-of libc (GOT load under PIE). Equal materializations prove assemble+link+run.
-    // Call-through uses the pointer type (not external-varargs), so do not invoke via fp.
     SourceProgram program{R"prg(
         int main() {
             int (*a)();

--- a/test/src/functionalTest/PieExecutableTest.cpp
+++ b/test/src/functionalTest/PieExecutableTest.cpp
@@ -37,10 +37,9 @@ TEST(Compiler, linkedExecutableIsPositionIndependent) {
     )prg"};
 
     program.compile();
-    // Program::executableFile is source path + ".out" (see TestFixtures).
-    const std::string executable = program.getSourceFilePath() + ".out";
-    ASSERT_TRUE(executableIsPie(executable))
-            << "expected PIE (readelf Type DYN); compiler link must pass -pie";
+    ASSERT_TRUE(executableIsPie(program.getExecutableFilePath()))
+            << "expected PIE (readelf Type DYN) for backend=" << functionalTestDialectTag()
+            << "; compiler link must pass -pie";
     program.runAndExpect("42");
 }
 
@@ -60,9 +59,9 @@ TEST(Compiler, pieExecutableCallsLibcAndLocalFunctionPointer) {
     )prg"};
 
     program.compile();
-    const std::string executable = program.getSourceFilePath() + ".out";
-    ASSERT_TRUE(executableIsPie(executable))
-            << "expected PIE executable for mixed local function pointer + printf";
+    ASSERT_TRUE(executableIsPie(program.getExecutableFilePath()))
+            << "expected PIE executable for backend=" << functionalTestDialectTag()
+            << " (mixed local function pointer + printf)";
     program.runAndExpect("7");
 }
 
@@ -81,9 +80,9 @@ TEST(Compiler, pieExecutableTakesExternFunctionAddress) {
     )prg"};
 
     program.compile();
-    const std::string executable = program.getSourceFilePath() + ".out";
-    ASSERT_TRUE(executableIsPie(executable))
-            << "expected PIE executable for extern function address via GOT";
+    ASSERT_TRUE(executableIsPie(program.getExecutableFilePath()))
+            << "expected PIE executable for backend=" << functionalTestDialectTag()
+            << " (extern function address via GOT)";
     program.runAndExpect("1");
 }
 

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -63,14 +63,16 @@ AssemblyDialect dialectFromEnvironment() {
             std::string("TRANS_ASM_DIALECT must be 'intel' or 'att' (got '") + raw + "')" };
 }
 
+const AssemblyDialect kFunctionalTestDialect = dialectFromEnvironment();
+
 } // namespace
 
 AssemblyDialect functionalTestDialect() {
-    return dialectFromEnvironment();
+    return kFunctionalTestDialect;
 }
 
 const char* functionalTestDialectTag() {
-    switch (functionalTestDialect()) {
+    switch (kFunctionalTestDialect) {
     case AssemblyDialect::Intel:
         return "intel";
     case AssemblyDialect::AtAndT:
@@ -84,7 +86,7 @@ std::string Program::executablePathFor(const std::string& sourcePath) {
 }
 
 std::string Program::outputPathFor(const std::string& sourcePath) {
-    return sourcePath + "." + functionalTestDialectTag() + ".execution.output";
+    return sourcePath + ".execution.output";
 }
 
 Program::Program(std::string programName) :

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -51,8 +51,6 @@ std::string dialectFlag(AssemblyDialect dialect) {
     throw std::logic_error { "unknown AssemblyDialect" };
 }
 
-// TRANS_ASM_DIALECT=intel|att selects the backend for this process.
-// Unset defaults to intel (local ad-hoc runs). ctest always sets the env.
 AssemblyDialect dialectFromEnvironment() {
     const char* raw = std::getenv("TRANS_ASM_DIALECT");
     if (raw == nullptr || raw[0] == '\0' || std::string(raw) == "intel") {
@@ -82,8 +80,6 @@ const char* functionalTestDialectTag() {
 }
 
 std::string Program::executablePathFor(const std::string& sourcePath) {
-    // Product path is source.out (not dialect-suffixed). Parallel dialect jobs
-    // still isolate via unique source basenames (*_intel / *_att).
     return sourcePath + ".out";
 }
 
@@ -204,10 +200,6 @@ void Program::assertExecuted() const {
 
 namespace {
 
-// Unique basename under programs/tmp/ so concurrent processes (ctest -j / gtest
-// shards / intel vs att) do not clobber each other's artifacts.
-// Replace path separators: parameterized suites use names like
-// "Suite/Case.Name/param" which must stay a single path segment.
 std::string uniqueProgramNameForCurrentTest() {
     const auto *info = ::testing::UnitTest::GetInstance()->current_test_info();
     if (info == nullptr) {

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -12,6 +12,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
@@ -38,18 +39,67 @@ std::string readFileContents(std::string filename) {
     return content;
 }
 
-Program::Program(std::string programName) :
-        programName{programName},
-        sourceFilePath{getTestResourcePath("programs/" + programName + ".src")},
-        executableFile{sourceFilePath + ".out"},
-        outputFile{sourceFilePath + ".execution.output"} {
+namespace {
 
-    remove(executableFile.c_str());
-    remove(outputFile.c_str());
+std::string dialectFlag(AssemblyDialect dialect) {
+    switch (dialect) {
+    case AssemblyDialect::Intel:
+        return "-aintel";
+    case AssemblyDialect::AtAndT:
+        return "-aatt";
+    }
+    throw std::logic_error { "unknown AssemblyDialect" };
 }
 
-void Program::compile(bool verbose) {
+// TRANS_ASM_DIALECT=intel|att selects the backend for this process.
+// Unset defaults to intel (local ad-hoc runs). ctest always sets the env.
+AssemblyDialect dialectFromEnvironment() {
+    const char* raw = std::getenv("TRANS_ASM_DIALECT");
+    if (raw == nullptr || raw[0] == '\0' || std::string(raw) == "intel") {
+        return AssemblyDialect::Intel;
+    }
+    if (std::string(raw) == "att") {
+        return AssemblyDialect::AtAndT;
+    }
+    throw std::runtime_error {
+            std::string("TRANS_ASM_DIALECT must be 'intel' or 'att' (got '") + raw + "')" };
+}
+
+} // namespace
+
+AssemblyDialect functionalTestDialect() {
+    return dialectFromEnvironment();
+}
+
+const char* functionalTestDialectTag() {
+    switch (functionalTestDialect()) {
+    case AssemblyDialect::Intel:
+        return "intel";
+    case AssemblyDialect::AtAndT:
+        return "att";
+    }
+    return "unknown";
+}
+
+std::string Program::executablePathFor(const std::string& sourcePath) {
+    return sourcePath + "." + functionalTestDialectTag() + ".out";
+}
+
+std::string Program::outputPathFor(const std::string& sourcePath) {
+    return sourcePath + "." + functionalTestDialectTag() + ".execution.output";
+}
+
+Program::Program(std::string programName) :
+        programName{programName},
+        sourceFilePath{getTestResourcePath("programs/" + programName + ".src")} {
+    remove(executablePathFor(sourceFilePath).c_str());
+    remove(outputPathFor(sourceFilePath).c_str());
+}
+
+int Program::compileOnce(bool verbose) {
+    const AssemblyDialect dialect = functionalTestDialect();
     std::vector<std::string> arguments{"trans", "-r../../../"};
+    arguments.push_back(dialectFlag(dialect));
     arguments.push_back("-lti"); // log (l) syntax tree (t) and intermediate form (i)
     arguments.push_back(sourceFilePath);
     std::vector<char *> argv;
@@ -67,33 +117,35 @@ void Program::compile(bool verbose) {
         exitCode = transDriver.run(ConfigurationParser{(int)argv.size() - 1, argv.data()});
     });
     if (verbose) {
-        std::cout << outputStream.str();
+        std::cout << "[backend=" << functionalTestDialectTag() << "]\n" << outputStream.str();
     }
 
     compilationErrors = errorStream.str();
-    // Driver already writes failures to the error logger; exit code is the contract.
-    if (exitCode == 0) {
-        compiled = true;
-    } else {
-        if (!compilationErrors.empty()) {
-            std::cerr << compilationErrors;
-        }
-        compiled = false;
+    if (exitCode != 0 && !compilationErrors.empty()) {
+        std::cerr << "[backend=" << functionalTestDialectTag() << "]\n" << compilationErrors;
     }
+    return exitCode;
+}
+
+void Program::compile(bool verbose) {
+    compilationErrors.clear();
+    compiled = (compileOnce(verbose) == 0);
 }
 
 void Program::run() {
     assertCompiled();
-    remove(outputFile.c_str());
-    util::runProcessOrThrow({executableFile}, {}, outputFile);
+    const std::string outFile = outputPathFor(sourceFilePath);
+    remove(outFile.c_str());
+    util::runProcessOrThrow({executablePathFor(sourceFilePath)}, {}, outFile);
     executed = true;
 }
 
 void Program::run(std::string input) {
     assertCompiled();
-    remove(outputFile.c_str());
+    const std::string outFile = outputPathFor(sourceFilePath);
+    remove(outFile.c_str());
     // Match prior `echo '...' | prog` behavior: stdin text ends with a newline.
-    util::runProcessOrThrow({executableFile}, input + "\n", outputFile);
+    util::runProcessOrThrow({executablePathFor(sourceFilePath)}, input + "\n", outFile);
     executed = true;
 }
 
@@ -109,19 +161,25 @@ void Program::runAndExpect(std::string input, std::string expectedOutput) {
 
 void Program::assertOutputEquals(std::string expectedOutput) const {
     assertExecuted();
-    EXPECT_THAT(readFileContents(outputFile), Eq(expectedOutput));
+    SCOPED_TRACE(std::string("backend=") + functionalTestDialectTag());
+    EXPECT_THAT(readFileContents(outputPathFor(sourceFilePath)), Eq(expectedOutput));
 }
 
 void Program::assertCompilationErrors(std::string expectedErrorFragment) const {
     if (compiled) {
         throw std::runtime_error{"Program is compiled without errors."};
     }
+    SCOPED_TRACE(std::string("backend=") + functionalTestDialectTag());
     EXPECT_THAT(compilationErrors, HasSubstr(expectedErrorFragment));
 }
 
 std::string Program::getOutputFilePath() const {
     assertExecuted();
-    return outputFile;
+    return outputPathFor(sourceFilePath);
+}
+
+std::string Program::getExecutableFilePath() const {
+    return executablePathFor(sourceFilePath);
 }
 
 std::string Program::getName() const { return programName; }
@@ -130,20 +188,22 @@ std::string Program::getSourceFilePath() const { return sourceFilePath; }
 
 void Program::assertCompiled() const {
     if (!compiled) {
-        throw std::runtime_error{"Program is not compiled."};
+        throw std::runtime_error{
+                std::string("Program is not compiled [backend=") + functionalTestDialectTag() + "]."};
     }
 }
 
 void Program::assertExecuted() const {
     if (!executed) {
-        throw std::runtime_error{"Program has not executed."};
+        throw std::runtime_error{
+                std::string("Program has not executed [backend=") + functionalTestDialectTag() + "]."};
     }
 }
 
 namespace {
 
 // Unique basename under programs/tmp/ so concurrent processes (ctest -j / gtest
-// shards) do not clobber each other's .src / .S / .o / .out artifacts.
+// shards / intel vs att) do not clobber each other's artifacts.
 // Replace path separators: parameterized suites use names like
 // "Suite/Case.Name/param" which must stay a single path segment.
 std::string uniqueProgramNameForCurrentTest() {
@@ -151,7 +211,8 @@ std::string uniqueProgramNameForCurrentTest() {
     if (info == nullptr) {
         throw std::logic_error("SourceProgram requires an active gtest (current_test_info is null)");
     }
-    std::string name = std::string(info->test_suite_name()) + "_" + info->name();
+    std::string name = std::string(info->test_suite_name()) + "_" + info->name()
+            + "_" + functionalTestDialectTag();
     for (char &c : name) {
         if (c == '/' || c == '\\') {
             c = '_';

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -82,7 +82,9 @@ const char* functionalTestDialectTag() {
 }
 
 std::string Program::executablePathFor(const std::string& sourcePath) {
-    return sourcePath + "." + functionalTestDialectTag() + ".out";
+    // Product path is source.out (not dialect-suffixed). Parallel dialect jobs
+    // still isolate via unique source basenames (*_intel / *_att).
+    return sourcePath + ".out";
 }
 
 std::string Program::outputPathFor(const std::string& sourcePath) {

--- a/test/src/functionalTest/TestFixtures.cpp
+++ b/test/src/functionalTest/TestFixtures.cpp
@@ -41,16 +41,6 @@ std::string readFileContents(std::string filename) {
 
 namespace {
 
-std::string dialectFlag(AssemblyDialect dialect) {
-    switch (dialect) {
-    case AssemblyDialect::Intel:
-        return "-aintel";
-    case AssemblyDialect::AtAndT:
-        return "-aatt";
-    }
-    throw std::logic_error { "unknown AssemblyDialect" };
-}
-
 AssemblyDialect dialectFromEnvironment() {
     const char* raw = std::getenv("TRANS_ASM_DIALECT");
     if (raw == nullptr || raw[0] == '\0' || std::string(raw) == "intel") {
@@ -71,14 +61,8 @@ AssemblyDialect functionalTestDialect() {
     return kFunctionalTestDialect;
 }
 
-const char* functionalTestDialectTag() {
-    switch (kFunctionalTestDialect) {
-    case AssemblyDialect::Intel:
-        return "intel";
-    case AssemblyDialect::AtAndT:
-        return "att";
-    }
-    return "unknown";
+std::string functionalTestDialectTag() {
+    return assemblyDialectTag(kFunctionalTestDialect);
 }
 
 std::string Program::executablePathFor(const std::string& sourcePath) {
@@ -97,9 +81,8 @@ Program::Program(std::string programName) :
 }
 
 int Program::compileOnce(bool verbose) {
-    const AssemblyDialect dialect = functionalTestDialect();
     std::vector<std::string> arguments{"trans", "-r../../../"};
-    arguments.push_back(dialectFlag(dialect));
+    arguments.push_back("-a" + functionalTestDialectTag());
     arguments.push_back("-lti"); // log (l) syntax tree (t) and intermediate form (i)
     arguments.push_back(sourceFilePath);
     std::vector<char *> argv;

--- a/test/src/functionalTest/TestFixtures.h
+++ b/test/src/functionalTest/TestFixtures.h
@@ -11,12 +11,9 @@
 
 using namespace testing;
 
-// Active backend for this process: set by TRANS_ASM_DIALECT (intel|att).
-// ctest registers separate dialect suites so failures name the backend.
 AssemblyDialect functionalTestDialect();
 const char* functionalTestDialectTag();
 
-// Functional tests compile/run the process-active assembly backend only.
 class Program {
   public:
     Program(std::string programName);
@@ -52,8 +49,6 @@ class Program {
 
 class SourceProgram : public Program {
   public:
-    // Writes under programs/tmp/<Suite>_<Name>_<dialect>.* so parallel dialect
-    // ctest jobs and gtest shards cannot collide.
     explicit SourceProgram(std::string sourceCode);
 
   private:

--- a/test/src/functionalTest/TestFixtures.h
+++ b/test/src/functionalTest/TestFixtures.h
@@ -11,12 +11,19 @@
 
 using namespace testing;
 
+// Active backend for this process: set by TRANS_ASM_DIALECT (intel|att).
+// ctest registers separate dialect suites so failures name the backend.
+AssemblyDialect functionalTestDialect();
+const char* functionalTestDialectTag();
+
+// Functional tests compile/run the process-active assembly backend only.
 class Program {
   public:
     Program(std::string programName);
     virtual ~Program() = default;
 
     void compile(bool verbose = false);
+
     void run();
     void run(std::string input);
     void runAndExpect(std::string expectedOutput);
@@ -27,15 +34,17 @@ class Program {
     std::string getOutputFilePath() const;
     std::string getName() const;
     std::string getSourceFilePath() const;
+    std::string getExecutableFilePath() const;
 
   private:
     void assertCompiled() const;
     void assertExecuted() const;
+    int compileOnce(bool verbose);
+    static std::string executablePathFor(const std::string& sourcePath);
+    static std::string outputPathFor(const std::string& sourcePath);
 
     const std::string programName;
     const std::string sourceFilePath;
-    const std::string executableFile;
-    const std::string outputFile;
     std::string compilationErrors;
     bool compiled = false;
     bool executed = false;
@@ -43,7 +52,8 @@ class Program {
 
 class SourceProgram : public Program {
   public:
-    // Writes under programs/tmp/<Suite>_<Name>.* so parallel shards cannot collide.
+    // Writes under programs/tmp/<Suite>_<Name>_<dialect>.* so parallel dialect
+    // ctest jobs and gtest shards cannot collide.
     explicit SourceProgram(std::string sourceCode);
 
   private:

--- a/test/src/functionalTest/TestFixtures.h
+++ b/test/src/functionalTest/TestFixtures.h
@@ -12,7 +12,7 @@
 using namespace testing;
 
 AssemblyDialect functionalTestDialect();
-const char* functionalTestDialectTag();
+std::string functionalTestDialectTag();
 
 class Program {
   public:


### PR DESCRIPTION
## Summary

Selectable x86-64 assembly backend (`-a intel|att`, default intel) with a complete AT&T (GNU as) path alongside the existing NASM Intel path, dual functional coverage, and PIE-safe emission on both.

### Product
- **CLI:** `-a intel` | `-a att` (see `assemblyDialectTag`)
- **Codegen:** factory selects `IntelInstructionSet` or `ATandTInstructionSet`
- **Assemble:** `nasm -f elf64` vs `as --64`; link remains `gcc -m64 -pie` → `source.out`
- **Artifacts:** always `source.S`, `source.o`, `source.out` (no dialect suffix)
- **Pool labels:** `L$strN` (not a C identifier; non-local in NASM and gas)
- **Calls:** direct `call` / `callPlt`; typed `callIndirect(Register)` (no string register guessing)
- **Narrow mem ops:** `loadByteSignExtend` / `storeDword` / … on `InstructionSet`; shared `RegisterSubreg` for partial register names
- **Globals preamble:** `GlobalVariable::qwordOperands()` shared; dialects only format (`dq` / `.quad`)

### Functional tests
- One dialect per process via `TRANS_ASM_DIALECT`
- ctest: `functionalTest_{intel,att}_shardN` (labels `functional` + dialect)
- Isolation: unique tmp sources (`…_intel` / `…_att`), not dialect-tagged product names
- Process-cached dialect; plain `source.execution.output`

### Layering
```
-a intel|att     → Configuration
Factory          → Intel | ATandT InstructionSet
StackMachine     → call / callPlt / callIndirect · lea / loadGot · sized mem
assemble         → nasm | as
```

## Test plan

- [x] `ctest -L intel` — all shards green
- [x] `ctest -L att` — all shards green
- [x] Unit: `codegenTest`, `driverTest` (incl. `-a` parse / unknown dialect)
- [x] Full `ctest` (unit + both dialect matrices)
- [ ] CI green on this PR